### PR TITLE
Fixed PHP warning "Warning: mysqli_close(): Couldn't fetch mysqli"

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -84,7 +84,7 @@ class MysqliDriver extends DatabaseDriver
 	 */
 	public function __destruct()
 	{
-		if (is_callable(array($this->connection, 'close')))
+		if (is_resource($this->connection))
 		{
 			mysqli_close($this->connection);
 		}


### PR DESCRIPTION
This line causes warning:

```
Warning: mysqli_close(): Couldn't fetch mysqli in path/vendor/joomla/framework/src/Joomla/Database/Mysqli/MysqliDriver.php on line 87
```

The same condition is used at SqlsrvDriver.php and PostgresqlDriver.php.

Discussed here:
https://github.com/joomla-framework/database/commit/98861e2c941bf171db5d2b1ed7aea9988b2c6a10#commitcomment-7657897
