### PR TITLE
Exceptions cannot be thrown in magic __toString

### DIFF
--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -104,7 +104,7 @@ abstract class DatabaseExporter
 					break;
 			}
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			// Do nothing
 		}

--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -94,7 +94,7 @@ abstract class DatabaseExporter
 		{
 			// Check everything is ok to run first.
 			$this->check();
-	
+
 			// Get the format.
 			switch ($this->asFormat)
 			{

--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -85,20 +85,28 @@ abstract class DatabaseExporter
 	 * @return  string
 	 *
 	 * @since   1.0
-	 * @throws  \Exception if an error is encountered.
 	 */
 	public function __toString()
 	{
-		// Check everything is ok to run first.
-		$this->check();
+		$buffer = '';
 
-		// Get the format.
-		switch ($this->asFormat)
+		try
 		{
-			case 'xml':
-			default:
-				$buffer = $this->buildXml();
-				break;
+			// Check everything is ok to run first.
+			$this->check();
+	
+			// Get the format.
+			switch ($this->asFormat)
+			{
+				case 'xml':
+				default:
+					$buffer = $this->buildXml();
+					break;
+			}
+		}
+		catch (Exception $e)
+		{
+			// Do nothing
 		}
 
 		return $buffer;


### PR DESCRIPTION
This is a PHP requirement. If an exception goes uncaught in a ```__toString()``` magic method then a PHP Fatal Error is generated