### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/DatabaseMysqlCase.php
+++ b/Tests/DatabaseMysqlCase.php
@@ -100,7 +100,7 @@ abstract class DatabaseMysqlCase extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/database.xml');
 	}
 
 	/**
@@ -118,6 +118,6 @@ abstract class DatabaseMysqlCase extends TestDatabase
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
 
-		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+		return $this->createDefaultDbConnection($pdo, self::$options['database']);
 	}
 }

--- a/Tests/DatabaseMysqliCase.php
+++ b/Tests/DatabaseMysqliCase.php
@@ -100,7 +100,7 @@ abstract class DatabaseMysqliCase extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/database.xml');
 	}
 
 	/**
@@ -118,6 +118,6 @@ abstract class DatabaseMysqliCase extends TestDatabase
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
 
-		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+		return $this->createDefaultDbConnection($pdo, self::$options['database']);
 	}
 }

--- a/Tests/DatabaseOracleCase.php
+++ b/Tests/DatabaseOracleCase.php
@@ -113,7 +113,7 @@ abstract class DatabaseOracleCase extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/database.xml');
 	}
 
 	/**
@@ -132,6 +132,6 @@ abstract class DatabaseOracleCase extends TestDatabase
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
 
-		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+		return $this->createDefaultDbConnection($pdo, self::$options['database']);
 	}
 }

--- a/Tests/DatabasePostgresqlCase.php
+++ b/Tests/DatabasePostgresqlCase.php
@@ -103,7 +103,7 @@ abstract class DatabasePostgresqlCase extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/database.xml');
 	}
 
 	/**
@@ -121,6 +121,6 @@ abstract class DatabasePostgresqlCase extends TestDatabase
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
 
-		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+		return $this->createDefaultDbConnection($pdo, self::$options['database']);
 	}
 }

--- a/Tests/DatabaseSqlsrvCase.php
+++ b/Tests/DatabaseSqlsrvCase.php
@@ -100,7 +100,7 @@ abstract class DatabaseSqlsrvCase extends TestDatabase
 	 */
 	protected function getDataSet()
 	{
-		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+		return $this->createXmlDataSet(__DIR__ . '/Stubs/database.xml');
 	}
 
 	/**
@@ -118,6 +118,6 @@ abstract class DatabaseSqlsrvCase extends TestDatabase
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
 
-		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+		return $this->createDefaultDbConnection($pdo, self::$options['database']);
 	}
 }

--- a/Tests/DriverMysqlTest.php
+++ b/Tests/DriverMysqlTest.php
@@ -608,13 +608,13 @@ class DriverMysqlTest extends DatabaseMysqlCase
 	}
 
 	/**
-	 * Test setUTF method.
+	 * Test setUtf method.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testSetUTF()
+	public function testSetUtf()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -607,13 +607,13 @@ class DriverMysqliTest extends DatabaseMysqliCase
 	}
 
 	/**
-	 * Test setUTF method.
+	 * Test setUtf method.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testSetUTF()
+	public function testSetUtf()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/DriverPostgresqlTest.php
+++ b/Tests/DriverPostgresqlTest.php
@@ -875,13 +875,13 @@ class DriverPostgresqlTest extends DatabasePostgresqlCase
 	}
 
 	/**
-	 * Test setUTF function
+	 * Test setUtf function
 	 *
 	 * @return   void
 	 */
-	public function testSetUTF()
+	public function testSetUtf()
 	{
-		$this->assertThat(self::$driver->setUTF(), $this->equalTo(0), __LINE__);
+		$this->assertThat(self::$driver->setUtf(), $this->equalTo(0), __LINE__);
 	}
 
 	/**

--- a/Tests/DriverSqliteTest.php
+++ b/Tests/DriverSqliteTest.php
@@ -602,13 +602,13 @@ class DriverSqliteTest extends TestDatabase
 	}
 
 	/**
-	 * Test setUTF method.
+	 * Test setUtf method.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testSetUTF()
+	public function testSetUtf()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}

--- a/Tests/DriverSqlsrvTest.php
+++ b/Tests/DriverSqlsrvTest.php
@@ -520,14 +520,14 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 	}
 
 	/**
-	 * Tests the setUTF method
+	 * Tests the setUtf method
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
-	 * @todo    Implement testSetUTF().
+	 * @todo    Implement testSetUtf().
 	 */
-	public function testSetUTF()
+	public function testSetUtf()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');

--- a/Tests/ImporterMySqlInspector.php
+++ b/Tests/ImporterMySqlInspector.php
@@ -49,9 +49,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getAddColumnSQL($table, \SimpleXMLElement $field)
+	public function getAddColumnSql($table, \SimpleXMLElement $field)
 	{
-		return parent::getAddColumnSQL($table, $field);
+		return parent::getAddColumnSql($table, $field);
 	}
 
 	/**
@@ -64,9 +64,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getAddKeySQL($table, $keys)
+	public function getAddKeySql($table, $keys)
 	{
-		return parent::getAddKeySQL($table, $keys);
+		return parent::getAddKeySql($table, $keys);
 	}
 
 	/**
@@ -78,9 +78,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getAlterTableSQL(\SimpleXMLElement $structure)
+	public function getAlterTableSql(\SimpleXMLElement $structure)
 	{
-		return parent::getAlterTableSQL($structure);
+		return parent::getAlterTableSql($structure);
 	}
 
 	/**
@@ -93,9 +93,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getChangeColumnSQL($table, \SimpleXMLElement $field)
+	public function getChangeColumnSql($table, \SimpleXMLElement $field)
 	{
-		return parent::getChangeColumnSQL($table, $field);
+		return parent::getChangeColumnSql($table, $field);
 	}
 
 	/**
@@ -107,9 +107,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getColumnSQL(\SimpleXMLElement $field)
+	public function getColumnSql(\SimpleXMLElement $field)
 	{
-		return parent::getColumnSQL($field);
+		return parent::getColumnSql($field);
 	}
 
 	/**
@@ -122,9 +122,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getDropColumnSQL($table, $name)
+	public function getDropColumnSql($table, $name)
 	{
-		return parent::getDropColumnSQL($table, $name);
+		return parent::getDropColumnSql($table, $name);
 	}
 
 	/**
@@ -139,9 +139,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getDropKeySQL($table, $name)
+	public function getDropKeySql($table, $name)
 	{
-		return parent::getDropKeySQL($table, $name);
+		return parent::getDropKeySql($table, $name);
 	}
 
 	/**
@@ -153,9 +153,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getDropPrimaryKeySQL($table)
+	public function getDropPrimaryKeySql($table)
 	{
-		return parent::getDropPrimaryKeySQL($table);
+		return parent::getDropPrimaryKeySql($table);
 	}
 
 	/**
@@ -182,9 +182,9 @@ class ImporterMySqlInspector extends \Joomla\Database\Mysql\MysqlImporter
 	 *
 	 * @since   1.0
 	 */
-	public function getKeySQL($columns)
+	public function getKeySql($columns)
 	{
-		return parent::getKeySQL($columns);
+		return parent::getKeySql($columns);
 	}
 
 	/**

--- a/Tests/ImporterMySqlTest.php
+++ b/Tests/ImporterMySqlTest.php
@@ -241,7 +241,7 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function dataGetAlterTableSQL()
+	public function dataGetAlterTableSql()
 	{
 		$f1 = '<field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />';
 		$f2 = '<field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />';
@@ -296,7 +296,7 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function dataGetColumnSQL()
+	public function dataGetColumnSql()
 	{
 		return array(
 			array(
@@ -330,7 +330,7 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function dataGetKeySQL()
+	public function dataGetKeySql()
 	{
 		return array(
 			array(
@@ -500,13 +500,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetAddColumnSQL()
+	public function testGetAddColumnSql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getAddColumnSQL(
+			$instance->getAddColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($this->sample['xml-title-field'])
 			),
@@ -526,13 +526,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetAddKeySQL()
+	public function testGetAddKeySql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getAddKeySQL(
+			$instance->getAddKeySql(
 				'jos_test',
 				array(
 					new \SimpleXmlElement($this->sample['xml-primary-key'])
@@ -558,13 +558,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider dataGetAlterTableSQL
 	 */
-	public function testGetAlterTableSQL($structure, $expected, $message)
+	public function testGetAlterTableSql($structure, $expected, $message)
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getAlterTableSQL($structure),
+			$instance->getAlterTableSql($structure),
 			$this->equalTo(
 				$expected
 			),
@@ -581,13 +581,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetChangeColumnSQL()
+	public function testGetChangeColumnSql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getChangeColumnSQL(
+			$instance->getChangeColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($this->sample['xml-title-field'])
 			),
@@ -611,13 +611,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider dataGetColumnSQL
 	 */
-	public function testGetColumnSQL($field, $expected, $message)
+	public function testGetColumnSql($field, $expected, $message)
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			strtolower($instance->getColumnSQL($field)),
+			strtolower($instance->getColumnSql($field)),
 			$this->equalTo(strtolower($expected)),
 			$message
 		);
@@ -630,13 +630,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropColumnSQL()
+	public function testGetDropColumnSql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropColumnSQL(
+			$instance->getDropColumnSql(
 				'jos_test',
 				'title'
 			),
@@ -654,13 +654,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropKeySQL()
+	public function testGetDropKeySql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropKeySQL(
+			$instance->getDropKeySql(
 				'jos_test',
 				'idx_title'
 			),
@@ -678,13 +678,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropPrimaryKeySQL()
+	public function testGetDropPrimaryKeySql()
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropPrimaryKeySQL(
+			$instance->getDropPrimaryKeySql(
 				'jos_test'
 			),
 			$this->equalTo(
@@ -753,13 +753,13 @@ class ImporterMySqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider dataGetKeySQL
 	 */
-	public function testGetKeySQL($field, $expected, $message)
+	public function testGetKeySql($field, $expected, $message)
 	{
 		$instance = new ImporterMySqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			strtolower($instance->getKeySQL($field)),
+			strtolower($instance->getKeySql($field)),
 			$this->equalTo(strtolower($expected)),
 			$message
 		);

--- a/Tests/ImporterPostgresqlInspector.php
+++ b/Tests/ImporterPostgresqlInspector.php
@@ -49,9 +49,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getAddColumnSQL($table, \SimpleXMLElement $field)
+	public function getAddColumnSql($table, \SimpleXMLElement $field)
 	{
-		return parent::getAddColumnSQL($table, $field);
+		return parent::getAddColumnSql($table, $field);
 	}
 
 	/**
@@ -63,9 +63,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getAddIndexSQL(\SimpleXMLElement $field)
+	public function getAddIndexSql(\SimpleXMLElement $field)
 	{
-		return parent::getAddIndexSQL($field);
+		return parent::getAddIndexSql($field);
 	}
 
 	/**
@@ -77,9 +77,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getAddSequenceSQL(\SimpleXMLElement $structure)
+	public function getAddSequenceSql(\SimpleXMLElement $structure)
 	{
-		return parent::getAddSequenceSQL($structure);
+		return parent::getAddSequenceSql($structure);
 	}
 
 	/**
@@ -91,9 +91,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getAlterTableSQL(\SimpleXMLElement $structure)
+	public function getAlterTableSql(\SimpleXMLElement $structure)
 	{
-		return parent::getAlterTableSQL($structure);
+		return parent::getAlterTableSql($structure);
 	}
 
 	/**
@@ -106,9 +106,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getChangeColumnSQL($table, \SimpleXMLElement $field)
+	public function getChangeColumnSql($table, \SimpleXMLElement $field)
 	{
-		return parent::getChangeColumnSQL($table, $field);
+		return parent::getChangeColumnSql($table, $field);
 	}
 
 	/**
@@ -120,9 +120,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getColumnSQL(\SimpleXMLElement $field)
+	public function getColumnSql(\SimpleXMLElement $field)
 	{
-		return parent::getColumnSQL($field);
+		return parent::getColumnSql($field);
 	}
 
 	/**
@@ -134,9 +134,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getChangeSequenceSQL(\SimpleXMLElement $structure)
+	public function getChangeSequenceSql(\SimpleXMLElement $structure)
 	{
-		return parent::getChangeSequenceSQL($structure);
+		return parent::getChangeSequenceSql($structure);
 	}
 
 	/**
@@ -149,9 +149,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getDropColumnSQL($table, $name)
+	public function getDropColumnSql($table, $name)
 	{
-		return parent::getDropColumnSQL($table, $name);
+		return parent::getDropColumnSql($table, $name);
 	}
 
 	/**
@@ -164,9 +164,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getDropKeySQL($table, $name)
+	public function getDropKeySql($table, $name)
 	{
-		return parent::getDropKeySQL($table, $name);
+		return parent::getDropKeySql($table, $name);
 	}
 
 	/**
@@ -179,9 +179,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getDropPrimaryKeySQL($table, $name)
+	public function getDropPrimaryKeySql($table, $name)
 	{
-		return parent::getDropPrimaryKeySQL($table, $name);
+		return parent::getDropPrimaryKeySql($table, $name);
 	}
 
 	/**
@@ -193,9 +193,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getDropIndexSQL($name)
+	public function getDropIndexSql($name)
 	{
-		return parent::getDropIndexSQL($name);
+		return parent::getDropIndexSql($name);
 	}
 
 	/**
@@ -207,9 +207,9 @@ class ImporterPostgresqlInspector extends \Joomla\Database\Postgresql\Postgresql
 	 *
 	 * @since   1.0
 	 */
-	public function getDropSequenceSQL($name)
+	public function getDropSequenceSql($name)
 	{
-		return parent::getDropSequenceSQL($name);
+		return parent::getDropSequenceSql($name);
 	}
 
 	/**

--- a/Tests/ImporterPostgresqlTest.php
+++ b/Tests/ImporterPostgresqlTest.php
@@ -266,7 +266,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function dataGetAlterTableSQL()
+	public function dataGetAlterTableSql()
 	{
 		$f1 = '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" ' .
 			'Comments="" />';
@@ -415,7 +415,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function dataGetColumnSQL()
+	public function dataGetColumnSql()
 	{
 		$sample = array(
 			'xml-id-field' => '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
@@ -609,7 +609,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetAddColumnSQL()
+	public function testGetAddColumnSql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
@@ -620,7 +620,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 			'xml-int-defnum' => '<field Field="title" Type="integer" Null="NO" Default="0" Comments="" />',);
 
 		$this->assertThat(
-			$instance->getAddColumnSQL(
+			$instance->getAddColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($sample['xml-title-field'])
 			),
@@ -632,7 +632,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 
 		// Test a field with a default value
 		$this->assertThat(
-			$instance->getAddColumnSQL(
+			$instance->getAddColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($sample['xml-title-def'])
 			),
@@ -644,7 +644,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 
 		// Test a field with a numeric default value
 		$this->assertThat(
-			$instance->getAddColumnSQL(
+			$instance->getAddColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($sample['xml-int-defnum'])
 			),
@@ -662,7 +662,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetAddSequenceSQL()
+	public function testGetAddSequenceSql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
@@ -671,7 +671,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 			'Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" /> ';
 
 		$this->assertThat(
-			$instance->getAddSequenceSQL(
+			$instance->getAddSequenceSql(
 				new \SimpleXmlElement($xmlIdSeq)
 			),
 			$this->equalTo(
@@ -688,7 +688,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetAddIndexSQL()
+	public function testGetAddIndexSql()
 	{
 		$xmlIndex = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" ' .
 			'Query="CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)" />';
@@ -699,7 +699,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getAddIndexSQL(
+			$instance->getAddIndexSql(
 					new \SimpleXmlElement($xmlIndex)
 			),
 			$this->equalTo(
@@ -709,7 +709,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 		);
 
 		$this->assertThat(
-			$instance->getAddIndexSQL(
+			$instance->getAddIndexSql(
 					new \SimpleXmlElement($xmlPrimaryKey)
 			),
 			$this->equalTo(
@@ -732,13 +732,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider dataGetAlterTableSQL
 	 */
-	public function testGetAlterTableSQL($structure, $expected, $message)
+	public function testGetAlterTableSql($structure, $expected, $message)
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getAlterTableSQL(
+			$instance->getAlterTableSql(
 				$structure
 			),
 			$this->equalTo(
@@ -757,7 +757,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetChangeColumnSQL()
+	public function testGetChangeColumnSql()
 	{
 		$xmlTitleField = '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />';
 
@@ -765,7 +765,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getChangeColumnSQL(
+			$instance->getChangeColumnSql(
 				'jos_test',
 				new \SimpleXmlElement($xmlTitleField)
 			),
@@ -785,7 +785,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetChangeSequenceSQL()
+	public function testGetChangeSequenceSql()
 	{
 		$xmlIdSeq = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" ' .
 			'Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" /> ';
@@ -794,7 +794,7 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getChangeSequenceSQL(
+			$instance->getChangeSequenceSql(
 				new \SimpleXmlElement($xmlIdSeq)
 			),
 			$this->equalTo(
@@ -817,13 +817,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @dataProvider dataGetColumnSQL
 	 */
-	public function testGetColumnSQL($field, $expected, $message)
+	public function testGetColumnSql($field, $expected, $message)
 	{
 		$instance	= new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			strtolower($instance->getColumnSQL($field)),
+			strtolower($instance->getColumnSql($field)),
 			$this->equalTo(strtolower($expected)),
 			$message
 		);
@@ -836,13 +836,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropColumnSQL()
+	public function testGetDropColumnSql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropColumnSQL(
+			$instance->getDropColumnSql(
 				'jos_test',
 				'title'
 			),
@@ -860,13 +860,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropIndexSQL()
+	public function testGetDropIndexSql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropIndexSQL(
+			$instance->getDropIndexSql(
 				'idx_title'
 			),
 			$this->equalTo(
@@ -883,13 +883,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropPrimaryKeySQL()
+	public function testGetDropPrimaryKeySql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropPrimaryKeySQL(
+			$instance->getDropPrimaryKeySql(
 				'jos_test', 'idx_jos_test_pkey'
 			),
 			$this->equalTo(
@@ -906,13 +906,13 @@ class ImporterPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testGetDropSequenceSQL()
+	public function testGetDropSequenceSql()
 	{
 		$instance = new ImporterPostgresqlInspector;
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			$instance->getDropSequenceSQL(
+			$instance->getDropSequenceSql(
 				'idx_jos_test_seq'
 			),
 			$this->equalTo(

--- a/Tests/Stubs/nosqldriver.php
+++ b/Tests/Stubs/nosqldriver.php
@@ -378,7 +378,7 @@ class NosqlDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		return false;
 	}

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -783,7 +783,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 *
 	 * @since   1.0
 	 */
-	public function hasUTFSupport()
+	public function hasUtfSupport()
 	{
 		return $this->utf;
 	}
@@ -1538,7 +1538,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 *
 	 * @since   1.0
 	 */
-	abstract public function setUTF();
+	abstract public function setUtf();
 
 	/**
 	 * Method to commit a transaction.

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -166,7 +166,7 @@ abstract class DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropColumnSQL($table, $name)
+	protected function getDropColumnSql($table, $name)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP COLUMN ' . $this->db->quoteName($name);
 
@@ -261,7 +261,7 @@ abstract class DatabaseImporter
 			if (in_array($tableName, $tables))
 			{
 				// The table already exists. Now check if there is any difference.
-				if ($queries = $this->getAlterTableSQL($xml->database->table_structure))
+				if ($queries = $this->getAlterTableql($xml->database->table_structure))
 				{
 					// Run the queries to upgrade the data structure.
 					foreach ($queries as $query)

--- a/src/Mysql/MysqlImporter.php
+++ b/src/Mysql/MysqlImporter.php
@@ -27,9 +27,9 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAddKeySQL($table, $keys)
+	protected function getAddKeySql($table, $keys)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySQL($keys);
+		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySql($keys);
 
 		return $sql;
 	}
@@ -43,7 +43,7 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAlterTableSQL(\SimpleXMLElement $structure)
+	protected function getAlterTableSql(\SimpleXMLElement $structure)
 	{
 		// Initialise variables.
 		$table = $this->getRealTableName($structure['name']);
@@ -71,7 +71,7 @@ class MysqlImporter extends DatabaseImporter
 
 				if ($change)
 				{
-					$alters[] = $this->getChangeColumnSQL($table, $field);
+					$alters[] = $this->getChangeColumnSql($table, $field);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -80,7 +80,7 @@ class MysqlImporter extends DatabaseImporter
 			else
 			{
 				// The field is new.
-				$alters[] = $this->getAddColumnSQL($table, $field);
+				$alters[] = $this->getAddColumnSql($table, $field);
 			}
 		}
 
@@ -88,7 +88,7 @@ class MysqlImporter extends DatabaseImporter
 		foreach ($oldFields as $name => $column)
 		{
 			// Delete the column.
-			$alters[] = $this->getDropColumnSQL($table, $name);
+			$alters[] = $this->getDropColumnSql($table, $name);
 		}
 
 		// Get the lookups for the old and new keys.
@@ -154,8 +154,8 @@ class MysqlImporter extends DatabaseImporter
 
 				if (!$same)
 				{
-					$alters[] = $this->getDropKeySQL($table, $name);
-					$alters[] = $this->getAddKeySQL($table, $keys);
+					$alters[] = $this->getDropKeySql($table, $name);
+					$alters[] = $this->getAddKeySql($table, $keys);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -164,7 +164,7 @@ class MysqlImporter extends DatabaseImporter
 			else
 			{
 				// This is a new key.
-				$alters[] = $this->getAddKeySQL($table, $keys);
+				$alters[] = $this->getAddKeySql($table, $keys);
 			}
 		}
 
@@ -173,11 +173,11 @@ class MysqlImporter extends DatabaseImporter
 		{
 			if (strtoupper($name) == 'PRIMARY')
 			{
-				$alters[] = $this->getDropPrimaryKeySQL($table);
+				$alters[] = $this->getDropPrimaryKeySql($table);
 			}
 			else
 			{
-				$alters[] = $this->getDropKeySQL($table, $name);
+				$alters[] = $this->getDropKeySql($table, $name);
 			}
 		}
 
@@ -194,10 +194,10 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getChangeColumnSQL($table, \SimpleXMLElement $field)
+	protected function getChangeColumnSql($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' CHANGE COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
-			. $this->getColumnSQL($field);
+			. $this->getColumnSql($field);
 
 		return $sql;
 	}
@@ -211,7 +211,7 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getColumnSQL(\SimpleXMLElement $field)
+	protected function getColumnSql(\SimpleXMLElement $field)
 	{
 		// Initialise variables.
 		// TODO Incorporate into parent class and use $this.
@@ -268,7 +268,7 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropKeySQL($table, $name)
+	protected function getDropKeySql($table, $name)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP KEY ' . $this->db->quoteName($name);
 
@@ -284,7 +284,7 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropPrimaryKeySQL($table)
+	protected function getDropPrimaryKeySql($table)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP PRIMARY KEY';
 
@@ -337,7 +337,7 @@ class MysqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getKeySQL($columns)
+	protected function getKeySql($columns)
 	{
 		// TODO Error checking on array and element types.
 

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -190,7 +190,7 @@ class MysqliDriver extends DatabaseDriver
 		}
 
 		// Set charactersets (needed for MySQL 4.1.2+).
-		$this->setUTF();
+		$this->setUtf();
 	}
 
 	/**
@@ -650,7 +650,7 @@ class MysqliDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		$this->connect();
 

--- a/src/Mysqli/MysqliImporter.php
+++ b/src/Mysqli/MysqliImporter.php
@@ -52,9 +52,9 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAddKeySQL($table, $keys)
+	protected function getAddKeySql($table, $keys)
 	{
-		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySQL($keys);
+		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD ' . $this->getKeySql($keys);
 
 		return $sql;
 	}
@@ -68,7 +68,7 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAlterTableSQL(\SimpleXMLElement $structure)
+	protected function getAlterTableSql(\SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
 		$oldFields = $this->db->getTableColumns($table);
@@ -95,7 +95,7 @@ class MysqliImporter extends DatabaseImporter
 
 				if ($change)
 				{
-					$alters[] = $this->getChangeColumnSQL($table, $field);
+					$alters[] = $this->getChangeColumnSql($table, $field);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -104,7 +104,7 @@ class MysqliImporter extends DatabaseImporter
 			else
 			{
 				// The field is new.
-				$alters[] = $this->getAddColumnSQL($table, $field);
+				$alters[] = $this->getAddColumnSql($table, $field);
 			}
 		}
 
@@ -112,7 +112,7 @@ class MysqliImporter extends DatabaseImporter
 		foreach ($oldFields as $name => $column)
 		{
 			// Delete the column.
-			$alters[] = $this->getDropColumnSQL($table, $name);
+			$alters[] = $this->getDropColumnSql($table, $name);
 		}
 
 		// Get the lookups for the old and new keys.
@@ -178,8 +178,8 @@ class MysqliImporter extends DatabaseImporter
 
 				if (!$same)
 				{
-					$alters[] = $this->getDropKeySQL($table, $name);
-					$alters[] = $this->getAddKeySQL($table, $keys);
+					$alters[] = $this->getDropKeySql($table, $name);
+					$alters[] = $this->getAddKeySql($table, $keys);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -188,7 +188,7 @@ class MysqliImporter extends DatabaseImporter
 			else
 			{
 				// This is a new key.
-				$alters[] = $this->getAddKeySQL($table, $keys);
+				$alters[] = $this->getAddKeySql($table, $keys);
 			}
 		}
 
@@ -197,11 +197,11 @@ class MysqliImporter extends DatabaseImporter
 		{
 			if (strtoupper($name) == 'PRIMARY')
 			{
-				$alters[] = $this->getDropPrimaryKeySQL($table);
+				$alters[] = $this->getDropPrimaryKeySql($table);
 			}
 			else
 			{
-				$alters[] = $this->getDropKeySQL($table, $name);
+				$alters[] = $this->getDropKeySql($table, $name);
 			}
 		}
 
@@ -218,10 +218,10 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getChangeColumnSQL($table, \SimpleXMLElement $field)
+	protected function getChangeColumnSql($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' CHANGE COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
-			. $this->getColumnSQL($field);
+			. $this->getColumnSql($field);
 
 		return $sql;
 	}
@@ -235,7 +235,7 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getColumnSQL(\SimpleXMLElement $field)
+	protected function getColumnSql(\SimpleXMLElement $field)
 	{
 		// TODO Incorporate into parent class and use $this.
 		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
@@ -291,7 +291,7 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropKeySQL($table, $name)
+	protected function getDropKeySql($table, $name)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP KEY ' . $this->db->quoteName($name);
 
@@ -307,7 +307,7 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropPrimaryKeySQL($table)
+	protected function getDropPrimaryKeySql($table)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP PRIMARY KEY';
 
@@ -359,7 +359,7 @@ class MysqliImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getKeySQL($columns)
+	protected function getKeySql($columns)
 	{
 		// TODO Error checking on array and element types.
 

--- a/src/Oracle/OracleDriver.php
+++ b/src/Oracle/OracleDriver.php
@@ -457,7 +457,7 @@ class OracleDriver extends PdoDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		return false;
 	}

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -715,7 +715,7 @@ abstract class PdoDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		return false;
 	}

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -868,7 +868,7 @@ class PostgresqlDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		$this->connect();
 
@@ -1215,7 +1215,7 @@ class PostgresqlDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function getStringPositionSQL($substring, $string)
+	public function getStringPositionSql($substring, $string)
 	{
 		$this->connect();
 

--- a/src/Postgresql/PostgresqlImporter.php
+++ b/src/Postgresql/PostgresqlImporter.php
@@ -51,7 +51,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAddIndexSQL(\SimpleXMLElement $field)
+	protected function getAddIndexSql(\SimpleXMLElement $field)
 	{
 		return (string) $field['Query'];
 	}
@@ -65,7 +65,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAlterTableSQL(\SimpleXMLElement $structure)
+	protected function getAlterTableSql(\SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
 		$oldFields = $this->db->getTableColumns($table);
@@ -108,7 +108,7 @@ class PostgresqlImporter extends DatabaseImporter
 
 				if ($change)
 				{
-					$alters[] = $this->getChangeSequenceSQL($kSeqName, $vSeq);
+					$alters[] = $this->getChangeSequenceSql($kSeqName, $vSeq);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -117,7 +117,7 @@ class PostgresqlImporter extends DatabaseImporter
 			else
 			{
 				// The sequence is new
-				$alters[] = $this->getAddSequenceSQL($newSequenceLook[$kSeqName][0]);
+				$alters[] = $this->getAddSequenceSql($newSequenceLook[$kSeqName][0]);
 			}
 		}
 
@@ -125,7 +125,7 @@ class PostgresqlImporter extends DatabaseImporter
 		foreach ($oldSeq as $name => $column)
 		{
 			// Delete the sequence.
-			$alters[] = $this->getDropSequenceSQL($name);
+			$alters[] = $this->getDropSequenceSql($name);
 		}
 
 		/* Field section */
@@ -145,7 +145,7 @@ class PostgresqlImporter extends DatabaseImporter
 
 				if ($change)
 				{
-					$alters[] = $this->getChangeColumnSQL($table, $field);
+					$alters[] = $this->getChangeColumnSql($table, $field);
 				}
 
 				// Unset this field so that what we have left are fields that need to be removed.
@@ -154,7 +154,7 @@ class PostgresqlImporter extends DatabaseImporter
 			else
 			{
 				// The field is new.
-				$alters[] = $this->getAddColumnSQL($table, $field);
+				$alters[] = $this->getAddColumnSql($table, $field);
 			}
 		}
 
@@ -162,7 +162,7 @@ class PostgresqlImporter extends DatabaseImporter
 		foreach ($oldFields as $name => $column)
 		{
 			// Delete the column.
-			$alters[] = $this->getDropColumnSQL($table, $name);
+			$alters[] = $this->getDropColumnSql($table, $name);
 		}
 
 		/* Index section */
@@ -203,7 +203,7 @@ class PostgresqlImporter extends DatabaseImporter
 
 				if (!$same)
 				{
-					$alters[] = $this->getDropIndexSQL($name);
+					$alters[] = $this->getDropIndexSql($name);
 					$alters[]  = (string) $newLookup[$name][0]['Query'];
 				}
 
@@ -222,11 +222,11 @@ class PostgresqlImporter extends DatabaseImporter
 		{
 			if ($oldLookup[$name][0]->is_primary == 'TRUE')
 			{
-				$alters[] = $this->getDropPrimaryKeySQL($table, $oldLookup[$name][0]->Index);
+				$alters[] = $this->getDropPrimaryKeySql($table, $oldLookup[$name][0]->Index);
 			}
 			else
 			{
-				$alters[] = $this->getDropIndexSQL($name);
+				$alters[] = $this->getDropIndexSql($name);
 			}
 		}
 
@@ -242,7 +242,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropSequenceSQL($name)
+	protected function getDropSequenceSql($name)
 	{
 		$sql = 'DROP SEQUENCE ' . $this->db->quoteName($name);
 
@@ -258,7 +258,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAddSequenceSQL(\SimpleXMLElement $field)
+	protected function getAddSequenceSql(\SimpleXMLElement $field)
 	{
 		/* For older database version that doesn't support these fields use default values */
 		if (version_compare($this->db->getVersion(), '9.1.0') < 0)
@@ -288,7 +288,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getChangeSequenceSQL(\SimpleXMLElement $field)
+	protected function getChangeSequenceSql(\SimpleXMLElement $field)
 	{
 		/* For older database version that doesn't support these fields use default values */
 		if (version_compare($this->db->getVersion(), '9.1.0') < 0)
@@ -318,10 +318,10 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getChangeColumnSQL($table, \SimpleXMLElement $field)
+	protected function getChangeColumnSql($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ALTER COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
-			. $this->getAlterColumnSQL($table, $field);
+			. $this->getAlterColumnSql($table, $field);
 
 		return $sql;
 	}
@@ -336,7 +336,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getAlterColumnSQL($table, \SimpleXMLElement $field)
+	protected function getAlterColumnSql($table, \SimpleXMLElement $field)
 	{
 		// TODO Incorporate into parent class and use $this.
 		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
@@ -390,7 +390,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getColumnSQL(\SimpleXMLElement $field)
+	protected function getColumnSql(\SimpleXMLElement $field)
 	{
 		// TODO Incorporate into parent class and use $this.
 		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
@@ -443,7 +443,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropIndexSQL($name)
+	protected function getDropIndexSql($name)
 	{
 		$sql = 'DROP INDEX ' . $this->db->quoteName($name);
 
@@ -460,7 +460,7 @@ class PostgresqlImporter extends DatabaseImporter
 	 *
 	 * @since   1.0
 	 */
-	protected function getDropPrimaryKeySQL($table, $name)
+	protected function getDropPrimaryKeySql($table, $name)
 	{
 		$sql = 'ALTER TABLE ONLY ' . $this->db->quoteName($table) . ' DROP CONSTRAINT ' . $this->db->quoteName($name);
 

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -314,7 +314,7 @@ class SqliteDriver extends PdoDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		$this->connect();
 

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -812,7 +812,7 @@ class SqlsrvDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setUTF()
+	public function setUtf()
 	{
 		// TODO: Remove this?
 	}


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.