### PR TITLE
Removes checks in execute for a connection

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -513,16 +513,6 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		if (!is_object($this->connection))
-		{
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}',
-				array('code' => $this->errorNum, 'message' => $this->errorMsg)
-			);
-			throw new \RuntimeException($this->errorMsg, $this->errorNum);
-		}
-
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$sql = $this->replacePrefix((string) $this->sql);
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -361,16 +361,6 @@ abstract class PdoDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		if (!is_object($this->connection))
-		{
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}',
-				array('code' => $this->errorNum, 'message' => $this->errorMsg)
-			);
-			throw new \RuntimeException($this->errorMsg, $this->errorNum);
-		}
-
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$sql = $this->replacePrefix((string) $this->sql);
 

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -678,16 +678,6 @@ class PostgresqlDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		if (!is_resource($this->connection))
-		{
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}',
-				array('code' => $this->errorNum, 'message' => $this->errorMsg)
-			);
-			throw new \RuntimeException($this->errorMsg, $this->errorNum);
-		}
-
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$sql = $this->replacePrefix((string) $this->sql);
 

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -572,16 +572,6 @@ class SqlsrvDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		if (!is_resource($this->connection))
-		{
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}',
-				array('code' => $this->errorNum, 'message' => $this->errorMsg)
-			);
-			throw new \RuntimeException($this->errorMsg, $this->errorNum);
-		}
-
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$sql = $this->replacePrefix((string) $this->sql);
 


### PR DESCRIPTION
The `connect` method in these classes throw exceptions whenever a non-valid occasion occurs so these checks are unreachable. On top of that the errorNum and errorMsg variables are no longer populated in the connect method meaning they either display no data or data from a previous failed query