### PR TITLE
Add extendWhere, orWhere and andWhere methods to database query class.

### DIFF
--- a/Tests/QueryTest.php
+++ b/Tests/QueryTest.php
@@ -1548,9 +1548,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
 		// Add more columns but specify different glue.
 		// Note that the change of glue is ignored.
-		$this->_instance->where(array('faz = 4', 'gaz = 5'), 'OR');
+		$this->instance->where(array('faz = 4', 'gaz = 5'), 'OR');
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3 AND faz = 4 AND gaz = 5'),
 			'Tests rendered value after third use, array input and different glue.'
 		);
@@ -1582,13 +1582,13 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	public function testExtendWhere()
 	{
 		$this->assertThat(
-			$this->_instance->where('foo = 1')->extendWhere('ABC', 'bar = 2'),
-			$this->identicalTo($this->_instance),
+			$this->instance->where('foo = 1')->extendWhere('ABC', 'bar = 2'),
+			$this->identicalTo($this->instance),
 			'Tests chaining.'
 		);
 
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '(foo = 1) ABC '
 				. PHP_EOL . '(bar = 2)'),
@@ -1596,9 +1596,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions.
-		$this->_instance->extendWhere('XYZ', array('baz = 3', 'goo = 4'));
+		$this->instance->extendWhere('XYZ', array('baz = 3', 'goo = 4'));
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '(foo = 1) ABC '
@@ -1608,9 +1608,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions with some different glue.
-		$this->_instance->extendWhere('STU', array('faz = 5', 'gaz = 6'), 'VWX');
+		$this->instance->extendWhere('STU', array('faz = 5', 'gaz = 6'), 'VWX');
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '('
@@ -1632,13 +1632,13 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	public function testOrWhere()
 	{
 		$this->assertThat(
-			$this->_instance->where('foo = 1')->orWhere('bar = 2'),
-			$this->identicalTo($this->_instance),
+			$this->instance->where('foo = 1')->orWhere('bar = 2'),
+			$this->identicalTo($this->instance),
 			'Tests chaining.'
 		);
 
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '(foo = 1) OR '
 				. PHP_EOL . '(bar = 2)'),
@@ -1646,9 +1646,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions.
-		$this->_instance->orWhere(array('baz = 3', 'goo = 4'));
+		$this->instance->orWhere(array('baz = 3', 'goo = 4'));
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '(foo = 1) OR '
@@ -1658,9 +1658,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions with some different glue.
-		$this->_instance->orWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->instance->orWhere(array('faz = 5', 'gaz = 6'), 'XOR');
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '('
@@ -1682,13 +1682,13 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	public function testAndWhere()
 	{
 		$this->assertThat(
-			$this->_instance->where('foo = 1')->andWhere('bar = 2'),
-			$this->identicalTo($this->_instance),
+			$this->instance->where('foo = 1')->andWhere('bar = 2'),
+			$this->identicalTo($this->instance),
 			'Tests chaining.'
 		);
 
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '(foo = 1) AND '
 				. PHP_EOL . '(bar = 2)'),
@@ -1696,9 +1696,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions.
-		$this->_instance->andWhere(array('baz = 3', 'goo = 4'));
+		$this->instance->andWhere(array('baz = 3', 'goo = 4'));
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '(foo = 1) AND '
@@ -1708,9 +1708,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 		);
 
 		// Add another set of where conditions with some different glue.
-		$this->_instance->andWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->instance->andWhere(array('faz = 5', 'gaz = 6'), 'XOR');
 		$this->assertThat(
-			trim(TestReflection::getValue($this->_instance, 'where')),
+			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE '
 				. PHP_EOL . '('
 				. PHP_EOL . '('

--- a/Tests/QueryTest.php
+++ b/Tests/QueryTest.php
@@ -1546,6 +1546,15 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 			'Tests rendered value after second use and array input.'
 		);
 
+		// Add more columns but specify different glue.
+		// Note that the change of glue is ignored.
+		$this->_instance->where(array('faz = 4', 'gaz = 5'), 'OR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3 AND faz = 4 AND gaz = 5'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+
 		// Clear the where
 		TestHelper::setValue($this->instance, 'where', null);
 		$this->instance->where(
@@ -1560,6 +1569,156 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 			trim(TestHelper::getValue($this->instance, 'where')),
 			$this->equalTo('WHERE bar = 2 OR goo = 3'),
 			'Tests rendered value with glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::extendWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.3
+	 */
+	public function testExtendWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->extendWhere('ABC', 'bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->extendWhere('XYZ', array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)) XYZ '
+				. PHP_EOL . '(baz = 3 AND goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->extendWhere('STU', array('faz = 5', 'gaz = 6'), 'VWX');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) ABC '
+				. PHP_EOL . '(bar = 2)) XYZ '
+				. PHP_EOL . '(baz = 3 AND goo = 4)) STU '
+				. PHP_EOL . '(faz = 5 VWX gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::orWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.3
+	 */
+	public function testOrWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->orWhere('bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->orWhere(array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)) OR '
+				. PHP_EOL . '(baz = 3 AND goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->orWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) OR '
+				. PHP_EOL . '(bar = 2)) OR '
+				. PHP_EOL . '(baz = 3 AND goo = 4)) OR '
+				. PHP_EOL . '(faz = 5 XOR gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::andWhere method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.3
+	 */
+	public function testAndWhere()
+	{
+		$this->assertThat(
+			$this->_instance->where('foo = 1')->andWhere('bar = 2'),
+			$this->identicalTo($this->_instance),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)'),
+			'Tests rendered value.'
+		);
+
+		// Add another set of where conditions.
+		$this->_instance->andWhere(array('baz = 3', 'goo = 4'));
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)) AND '
+				. PHP_EOL . '(baz = 3 OR goo = 4)'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Add another set of where conditions with some different glue.
+		$this->_instance->andWhere(array('faz = 5', 'gaz = 6'), 'XOR');
+		$this->assertThat(
+			trim(TestReflection::getValue($this->_instance, 'where')),
+			$this->equalTo('WHERE '
+				. PHP_EOL . '('
+				. PHP_EOL . '('
+				. PHP_EOL . '(foo = 1) AND '
+				. PHP_EOL . '(bar = 2)) AND '
+				. PHP_EOL . '(baz = 3 OR goo = 4)) AND '
+				. PHP_EOL . '(faz = 5 XOR gaz = 6)'),
+			'Tests rendered value after third use, array input and different glue.'
 		);
 	}
 

--- a/Tests/QueryTest.php
+++ b/Tests/QueryTest.php
@@ -1573,11 +1573,11 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the JDatabaseQuery::extendWhere method.
+	 * Tests the \Joomla\Database\DatabaseQuery::extendWhere method.
 	 *
 	 * @return  void
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testExtendWhere()
 	{
@@ -1623,11 +1623,11 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the JDatabaseQuery::orWhere method.
+	 * Tests the \Joomla\Database\DatabaseQuery::orWhere method.
 	 *
 	 * @return  void
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testOrWhere()
 	{
@@ -1673,11 +1673,11 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the JDatabaseQuery::andWhere method.
+	 * Tests the \Joomla\Database\DatabaseQuery::andWhere method.
 	 *
 	 * @return  void
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testAndWhere()
 	{

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1409,7 +1409,7 @@ abstract class DatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.6
+	 * @since   1.3
 	 */
 	public function extendWhere($outerGlue, $conditions, $innerGlue = 'AND')
 	{
@@ -1434,7 +1434,7 @@ abstract class DatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.6
+	 * @since   1.3
 	 */
 	public function orWhere($conditions, $glue = 'AND')
 	{
@@ -1453,7 +1453,7 @@ abstract class DatabaseQuery
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   3.6
+	 * @since   1.3
 	 */
 	public function andWhere($conditions, $glue = 'OR')
 	{

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1396,6 +1396,72 @@ abstract class DatabaseQuery
 	}
 
 	/**
+	 * Extend the WHERE clause with a single condition or an array of conditions, with a potentially
+	 * different logical operator from the one in the current WHERE clause.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->extendWhere('XOR', array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) XOR (c = 3 AND d = 4)
+	 *
+	 * @param   string  $outerGlue   The glue by which to join the conditions to the current WHERE conditions.
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $innerGlue   The glue by which to join the conditions. Defaults to AND.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.6
+	 */
+	public function extendWhere($outerGlue, $conditions, $innerGlue = 'AND')
+	{
+		// Replace the current WHERE with a new one which has the old one as an unnamed child.
+		$this->where = new JDatabaseQueryElement('WHERE', $this->where->setName('()'), " $outerGlue ");
+
+		// Append the new conditions as a new unnamed child.
+		$this->where->append(new JDatabaseQueryElement('()', $conditions, " $innerGlue "));
+
+		return $this;
+	}
+
+	/**
+	 * Extend the WHERE clause with an OR and a single condition or an array of conditions.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->orWhere(array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) OR (c = 3 AND d = 4)
+	 *
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to AND.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.6
+	 */
+	public function orWhere($conditions, $glue = 'AND')
+	{
+		return $this->extendWhere('OR', $conditions, $glue);
+	}
+
+	/**
+	 * Extend the WHERE clause with an AND and a single condition or an array of conditions.
+	 *
+	 * Usage:
+	 * $query->where(array('a = 1', 'b = 2'))->andWhere(array('c = 3', 'd = 4'));
+	 * will produce: WHERE ((a = 1 AND b = 2) AND (c = 3 OR d = 4)
+	 *
+	 * @param   mixed   $conditions  A string or array of WHERE conditions.
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to OR.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   3.6
+	 */
+	public function andWhere($conditions, $glue = 'OR')
+	{
+		return $this->extendWhere('AND', $conditions, $glue);
+	}
+
+
+	/**
 	 * Method to provide deep copy support to nested objects and arrays when cloning.
 	 *
 	 * @return  void

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1460,7 +1460,6 @@ abstract class DatabaseQuery
 		return $this->extendWhere('AND', $conditions, $glue);
 	}
 
-
 	/**
 	 * Method to provide deep copy support to nested objects and arrays when cloning.
 	 *

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1407,17 +1407,17 @@ abstract class DatabaseQuery
 	 * @param   mixed   $conditions  A string or array of WHERE conditions.
 	 * @param   string  $innerGlue   The glue by which to join the conditions. Defaults to AND.
 	 *
-	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 * @return  DatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function extendWhere($outerGlue, $conditions, $innerGlue = 'AND')
 	{
 		// Replace the current WHERE with a new one which has the old one as an unnamed child.
-		$this->where = new JDatabaseQueryElement('WHERE', $this->where->setName('()'), " $outerGlue ");
+		$this->where = new Query\QueryElement('WHERE', $this->where->setName('()'), " $outerGlue ");
 
 		// Append the new conditions as a new unnamed child.
-		$this->where->append(new JDatabaseQueryElement('()', $conditions, " $innerGlue "));
+		$this->where->append(new Query\QueryElement('()', $conditions, " $innerGlue "));
 
 		return $this;
 	}
@@ -1432,9 +1432,9 @@ abstract class DatabaseQuery
 	 * @param   mixed   $conditions  A string or array of WHERE conditions.
 	 * @param   string  $glue        The glue by which to join the conditions. Defaults to AND.
 	 *
-	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 * @return  DatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function orWhere($conditions, $glue = 'AND')
 	{
@@ -1451,9 +1451,9 @@ abstract class DatabaseQuery
 	 * @param   mixed   $conditions  A string or array of WHERE conditions.
 	 * @param   string  $glue        The glue by which to join the conditions. Defaults to OR.
 	 *
-	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 * @return  DatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function andWhere($conditions, $glue = 'OR')
 	{

--- a/src/Query/QueryElement.php
+++ b/src/Query/QueryElement.php
@@ -112,9 +112,9 @@ class QueryElement
 	 *
 	 * @param   string  $name  Name of the element.
 	 *
-	 * @return  JDatabaseQueryElement  Returns this object to allow chaining.
+	 * @return  DatabaseQueryElement  Returns this object to allow chaining.
 	 *
-	 * @since   1.3
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setName($name)
 	{

--- a/src/Query/QueryElement.php
+++ b/src/Query/QueryElement.php
@@ -108,6 +108,22 @@ class QueryElement
 	}
 
 	/**
+	 * Sets the name of this element.
+	 *
+	 * @param   string  $name  Name of the element.
+	 *
+	 * @return  JDatabaseQueryElement  Returns this object to allow chaining.
+	 *
+	 * @since   1.3
+	 */
+	public function setName($name)
+	{
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
 	 * Method to provide deep copy support to nested objects and arrays
 	 * when cloning.
 	 *


### PR DESCRIPTION
Brings work from the CMS by @chrisdavenport over to the Framework.

CMS PR's https://github.com/joomla/joomla-cms/pull/8718 and https://github.com/joomla/joomla-cms/pull/5837

Testing instructions and details listed in https://github.com/joomla/joomla-cms/pull/5837