### PR TITLE
Prepared Statement Support for MySQLi Driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,8 @@ matrix:
 before_script:
   - composer self-update
   - composer update $COMPOSER_FLAGS
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then mysql -e 'create database joomla_ut;'; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then mysql joomla_ut < Tests/Stubs/mysql.sql; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then mysql -u root -e 'create database joomla_ut;'; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then mysql -u root joomla_ut < Tests/Stubs/mysql.sql; fi
+  - mysql -u root -e 'create database joomla_ut;'
+  - mysql -u root joomla_ut < Tests/Stubs/mysql.sql
   - psql -c 'create database joomla_ut;' -U postgres
   - psql -d joomla_ut -a -f Tests/Stubs/postgresql.sql
 

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -587,7 +587,40 @@ class DriverMysqliTest extends DatabaseMysqliCase
 	 */
 	public function testExecute()
 	{
-		self::$driver->setQuery("REPLACE INTO `jos_dbtest` SET `id` = 5, `title` = 'testTitle'");
+		self::$driver->setQuery(
+			"REPLACE INTO `jos_dbtest` SET `id` = 5, `title` = 'testTitle', `start_date` = '1980-04-18 00:00:00', `description` = 'Testing'"
+		);
+
+		$this->assertThat(self::$driver->execute(), $this->isTrue(), __LINE__);
+
+		$this->assertThat(self::$driver->insertid(), $this->equalTo(5), __LINE__);
+	}
+
+	/**
+	 * Test the execute method with a prepared statement
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testExecutePreparedStatement()
+	{
+		$id          = 5;
+		$title       = 'testTitle';
+		$startDate   = '1980-04-18 00:00:00';
+		$description = 'Testing';
+
+		/** @var \Joomla\Database\Mysqli\MysqliQuery $query */
+		$query = self::$driver->getQuery(true);
+		$query->setQuery(
+			"REPLACE INTO `jos_dbtest` SET `id` = ?, `title` = ?, `start_date` = ?, `description` = ?"
+		);
+		$query->bind(1, $id, 'i');
+		$query->bind(2, $title);
+		$query->bind(3, $startDate);
+		$query->bind(4, $description);
+
+		self::$driver->setQuery($query);
 
 		$this->assertThat(self::$driver->execute(), $this->isTrue(), __LINE__);
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "joomla/test": "~1.0",
-        "phpunit/phpunit": "~4.8|~5.0",
+        "phpunit/phpunit": "~4.8|>=5.0 <5.4",
         "phpunit/dbunit": "~1.3",
         "squizlabs/php_codesniffer": "1.*"
     },

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -736,9 +736,9 @@ class MysqliDriver extends DatabaseDriver
 	/**
 	 * Sets the SQL statement string for later execution.
 	 *
-	 * @param   DatabaseQuery|string    $query          The SQL statement to set either as a DatabaseQuery object or a string.
-	 * @param   integer                 $offset         The affected row offset to set.
-	 * @param   integer                 $limit          The maximum affected rows to set.
+	 * @param   DatabaseQuery|string  $query   The SQL statement to set either as a DatabaseQuery object or a string.
+	 * @param   integer               $offset  The affected row offset to set.
+	 * @param   integer               $limit   The maximum affected rows to set.
 	 *
 	 * @return  MysqliDriver  This object to support method chaining.
 	 *

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -369,7 +369,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return $this->connection->affected_rows();
+		return $this->connection->affected_rows;
 	}
 
 	/**
@@ -540,7 +540,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return $this->connection->insert_id();
+		return $this->connection->insert_id;
 	}
 
 	/**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -121,7 +121,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		if (is_resource($this->connection))
 		{
-			mysqli_close($this->connection);
+			$this->connection->close();
 		}
 	}
 
@@ -274,7 +274,7 @@ class MysqliDriver extends DatabaseDriver
 		// Close the connection.
 		if (is_callable($this->connection, 'close'))
 		{
-			mysqli_close($this->connection);
+			$this->connection->close();
 		}
 
 		$this->connection = null;
@@ -294,7 +294,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		$result = mysqli_real_escape_string($this->getConnection(), $text);
+		$result = $this->connection->real_escape_string($text);
 
 		if ($extra)
 		{
@@ -313,7 +313,7 @@ class MysqliDriver extends DatabaseDriver
 	 */
 	public static function isSupported()
 	{
-		return (function_exists('mysqli_connect'));
+		return function_exists('mysqli_connect');
 	}
 
 	/**
@@ -327,7 +327,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		if (is_object($this->connection))
 		{
-			return mysqli_ping($this->connection);
+			return $this->connection->ping();
 		}
 
 		return false;
@@ -366,7 +366,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return mysqli_affected_rows($this->connection);
+		return $this->connection->affected_rows();
 	}
 
 	/**
@@ -522,7 +522,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return mysqli_get_server_info($this->connection);
+		return $this->connection->get_server_info();
 	}
 
 	/**
@@ -537,7 +537,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return mysqli_insert_id($this->connection);
+		return $this->connection->insert_id();
 	}
 
 	/**
@@ -645,8 +645,8 @@ class MysqliDriver extends DatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->executed)
 		{
-			$this->errorNum = (int) mysqli_errno($this->connection);
-			$this->errorMsg = (string) mysqli_error($this->connection) . "\n-- SQL --\n" . $sql;
+			$this->errorNum = (int) $this->connection->errno;
+			$this->errorMsg = (string) $this->connection->error . "\n-- SQL --\n" . $sql;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())
@@ -725,7 +725,7 @@ class MysqliDriver extends DatabaseDriver
 			return false;
 		}
 
-		if (!mysqli_select_db($this->connection, $database))
+		if (!$this->connection->select_db($database))
 		{
 			throw new \RuntimeException('Could not connect to database.');
 		}
@@ -823,7 +823,7 @@ class MysqliDriver extends DatabaseDriver
 		{
 			$this->connect();
 
-			if (mysqli_commit($this->connection))
+			if ($this->connection->commit())
 			{
 				$this->transactionDepth = 0;
 			}
@@ -850,7 +850,7 @@ class MysqliDriver extends DatabaseDriver
 		{
 			$this->connect();
 
-			if (mysqli_rollback($this->connection))
+			if ($this->connection->rollback())
 			{
 				$this->transactionDepth = 0;
 			}
@@ -881,7 +881,7 @@ class MysqliDriver extends DatabaseDriver
 		$this->connect();
 
 		// Disallow auto commit
-		mysqli_autocommit($this->connection, false);
+		$this->connection->autocommit(false);
 
 		if (!$asSavepoint || !$this->transactionDepth)
 		{
@@ -916,13 +916,13 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		$cursor = @mysqli_query($this->connection, $sql);
+		$cursor = $this->connection->query($sql);
 
 		// If an error occurred handle it.
 		if (!$cursor)
 		{
-			$this->errorNum = (int) mysqli_errno($this->connection);
-			$this->errorMsg = (string) mysqli_error($this->connection) . "\n-- SQL --\n" . $sql;
+			$this->errorNum = (int) $this->connection->errno;
+			$this->errorMsg = (string) $this->connection->error . "\n-- SQL --\n" . $sql;
 
 			// Check if the server was disconnected.
 			if (!$this->connected())

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -10,13 +10,14 @@ namespace Joomla\Database\Mysqli;
 
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Query\LimitableInterface;
+use Joomla\Database\Query\PreparableInterface;
 
 /**
  * MySQLi Query Building Class.
  *
  * @since  1.0
  */
-class MysqliQuery extends DatabaseQuery implements LimitableInterface
+class MysqliQuery extends DatabaseQuery implements LimitableInterface, PreparableInterface
 {
 	/**
 	 * The offset for the result set.

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -35,6 +35,105 @@ class MysqliQuery extends DatabaseQuery implements LimitableInterface
 	protected $limit;
 
 	/**
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bounded = array();
+
+	/**
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
+	 *
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
+	 * @param   string          $dataType       The corresponding bind type.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters. (Unused)
+	 * @param   array           $driverOptions  Optional driver options to be used. (Unused)
+	 *
+	 * @return  MysqliQuery
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function bind($key = null, &$value = null, $dataType = 's', $length = 0, $driverOptions = array())
+	{
+		// Case 1: Empty Key (reset $bounded array)
+		if (empty($key))
+		{
+			$this->bounded = array();
+
+			return $this;
+		}
+
+		// Case 2: Key Provided, null value (unset key from $bounded array)
+		if (is_null($value))
+		{
+			if (isset($this->bounded[$key]))
+			{
+				unset($this->bounded[$key]);
+			}
+
+			return $this;
+		}
+
+		$obj           = new \stdClass;
+		$obj->value    = &$value;
+		$obj->dataType = $dataType;
+
+		// Case 3: Simply add the Key/Value into the bounded array
+		$this->bounded[$key] = $obj;
+
+		return $this;
+	}
+
+	/**
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
+	 *
+	 * @param   mixed  $key  The bounded variable key to retrieve.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function &getBounded($key = null)
+	{
+		if (empty($key))
+		{
+			return $this->bounded;
+		}
+
+		if (isset($this->bounded[$key]))
+		{
+			return $this->bounded[$key];
+		}
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  MysqliQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case null:
+				$this->bounded = array();
+				break;
+		}
+
+		return parent::clear($clause);
+	}
+
+	/**
 	 * Method to modify a query already in string format with the needed
 	 * additions to make the query limited to a particular number of
 	 * results, or start at a particular offset.


### PR DESCRIPTION
Exposes support for prepared statements to the MySQLi driver by way of the existing `Query\PreparableInterface` API.

Note this API was originally created for PDO based drivers so it has a "funny" API for our non-PDO code.  None the less it's still usable.

Also consistently uses the OOP style `mysqli` API versus procedural since we're storing an object anyway.  Only in methods where a cursor can be injected does the procedural style remain.

Support for PostgreSQL and SQL Server will be forthcoming.