### PR TITLE
Add PDO PostgreSQL driver

### DIFF
--- a/Tests/DatabasePgsqlCase.php
+++ b/Tests/DatabasePgsqlCase.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+use Joomla\Test\TestDatabase;
+use Joomla\Database\DatabaseDriver;
+
+/**
+ * Abstract test case class for PDO PostgreSQL database testing.
+ *
+ * @since  1.0
+ */
+abstract class DatabasePgsqlCase extends TestDatabase
+{
+	/**
+	 * @var    array  The database driver options for the connection.
+	 * @since  1.0
+	 */
+	private static $options = array('driver' => 'pgsql');
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * An example DSN would be: host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public static function setUpBeforeClass()
+	{
+		// First let's look to see if we have a DSN defined or in the environment variables.
+		if (defined('JTEST_DATABASE_PGSQL_DSN') || getenv('JTEST_DATABASE_PGSQL_DSN'))
+		{
+			$dsn = defined('JTEST_DATABASE_PGSQL_DSN') ? JTEST_DATABASE_PGSQL_DSN : getenv('JTEST_DATABASE_PGSQL_DSN');
+		}
+		else
+		{
+			return;
+		}
+
+		// First let's trim the pgsql: part off the front of the DSN if it exists.
+		if (strpos($dsn, 'pgsql:') === 0)
+		{
+			$dsn = substr($dsn, 6);
+		}
+
+		// Split the DSN into its parts over semicolons.
+		$parts = explode(';', $dsn);
+
+		// Parse each part and populate the options array.
+		foreach ($parts as $part)
+		{
+			list ($k, $v) = explode('=', $part, 2);
+
+			switch ($k)
+			{
+				case 'host':
+					self::$options['host'] = $v;
+					break;
+				case 'port':
+					self::$options['port'] = $v;
+					break;
+				case 'dbname':
+					self::$options['database'] = $v;
+					break;
+				case 'user':
+					self::$options['user'] = $v;
+					break;
+				case 'pass':
+					self::$options['password'] = $v;
+					break;
+			}
+		}
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			self::$driver = DatabaseDriver::getInstance(self::$options);
+		}
+		catch (\RuntimeException $e)
+		{
+			self::$driver = null;
+		}
+
+		// If for some reason an exception object was returned set our database object to null.
+		if (self::$driver instanceof \Exception)
+		{
+			self::$driver = null;
+		}
+	}
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  \PHPUnit_Extensions_Database_DataSet_XmlDataSet
+	 *
+	 * @since   1.0
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  \PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection
+	 *
+	 * @since   1.0
+	 */
+	protected function getConnection()
+	{
+		// Compile the connection DSN.
+		$dsn = 'pgsql:host=' . self::$options['host'] . ';port=' . self::$options['port'] . ';dbname=' . self::$options['database'];
+
+		// Create the PDO object from the DSN and options.
+		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
+
+		return $this->createDefaultDBConnection($pdo, self::$options['database']);
+	}
+}

--- a/Tests/DriverPgsqlTest.php
+++ b/Tests/DriverPgsqlTest.php
@@ -1,0 +1,1111 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+/**
+ * Test class for Joomla\Database\Pgsql\PgsqlDriver.
+ *
+ * @since  1.0
+ */
+class DriverPgsqlTest extends DatabasePgsqlCase
+{
+	/**
+	 * Data for the testEscape test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestEscape()
+	{
+		return array(
+			/* ' will be escaped and become '' */
+			array("'%_abc123", false, '\'\'%_abc123'),
+			array("'%_abc123", true, '\'\'%_abc123'),
+			/* ' and \ will be escaped: the first become '', the latter \\ */
+			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
+			array("\'%_abc123", true, '\\\\\'\'%_abc123'));
+	}
+
+	/**
+	 * Data for the testGetEscaped test, proxies of escape, so same data test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestGetEscaped()
+	{
+		return array(
+			/* ' will be escaped and become '' */
+			array("'%_abc123", false), array("'%_abc123", true),
+			/* ' and \ will be escaped: the first become '', the latter \\ */
+			array("\'%_abc123", false), array("\'%_abc123", true));
+	}
+
+	/**
+	 * Data for the testTransactionRollback test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestTransactionRollback()
+	{
+		return array(array(null, 0), array('transactionSavepoint', 1));
+	}
+
+	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new \stdClass;
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
+	 * Data for the TestReplacePrefix test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestReplacePrefix()
+	{
+		return array(
+			/* no prefix inside, no change */
+			array('SELECT * FROM table', '#__', 'SELECT * FROM table'),
+			/* the prefix inside double quote has to be changed */
+			array('SELECT * FROM "#__table"', '#__', 'SELECT * FROM "jos_table"'),
+			/* the prefix inside single quote hasn't to be changed */
+			array('SELECT * FROM \'#__table\'', '#__', 'SELECT * FROM \'#__table\''),
+			/* mixed quote case */
+			array('SELECT * FROM \'#__table\', "#__tableSecond"', '#__', 'SELECT * FROM \'#__table\', "jos_tableSecond"'),
+			/* the prefix used in sequence name (single quote) has to be changed */
+			array('SELECT * FROM currval(\'#__table_id_seq\'::regclass)', '#__', 'SELECT * FROM currval(\'jos_table_id_seq\'::regclass)'),
+			/* using another prefix */
+			array('SELECT * FROM "#!-_table"', '#!-_', 'SELECT * FROM "jos_table"'));
+	}
+
+	/**
+	 * Data for testQuoteName test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestQuoteName()
+	{
+		return array(
+			/* no dot inside var */
+			array('jos_dbtest', null, '"jos_dbtest"'),
+			/* a dot inside var */
+			array('public.jos_dbtest', null, '"public"."jos_dbtest"'),
+			/* two dot inside var */
+			array('joomla_ut.public.jos_dbtest', null, '"joomla_ut"."public"."jos_dbtest"'),
+			/* using an array */
+			array(array('joomla_ut', 'dbtest'), null, array('"joomla_ut"', '"dbtest"')),
+			/* using an array with dotted name */
+			array(array('joomla_ut.dbtest', 'public.dbtest'), null, array('"joomla_ut"."dbtest"', '"public"."dbtest"')),
+			/* using an array with two dot in name */
+			array(array('joomla_ut.public.dbtest', 'public.dbtest.col'), null, array('"joomla_ut"."public"."dbtest"', '"public"."dbtest"."col"')),
+
+			/*** same tests with AS part ***/
+			array('jos_dbtest', 'test', '"jos_dbtest" AS "test"'),
+			array('public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'),
+			array('joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'),
+			array(array('joomla_ut', 'dbtest'), array('j_ut', 'tst'), array('"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"')),
+			array(
+				array('joomla_ut.dbtest', 'public.dbtest'),
+				array('j_ut_db', 'pub_tst'),
+				array('"joomla_ut"."dbtest" AS "j_ut_db"', '"public"."dbtest" AS "pub_tst"')),
+			array(
+				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
+				array('j_ut_p_db', 'pub_tst_col'),
+				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col" AS "pub_tst_col"')),
+			/* last test but with one null inside array */
+			array(
+				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
+				array('j_ut_p_db', null),
+				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col"')));
+	}
+
+	/**
+	 * Test destruct
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @todo    Implement test__destruct().
+	 */
+	public function test__destruct()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Check if connected() method returns true.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testConnected()
+	{
+		$this->assertThat(
+			self::$driver->connected(),
+			$this->equalTo(true),
+			'Not connected to database'
+		);
+	}
+
+	/**
+	 * Tests the escape method.
+	 *
+	 * @param   string  $text    The string to be escaped.
+	 * @param   bool    $extra   Optional parameter to provide extra escaping.
+	 * @param   string  $result  Correct string escaped
+	 *
+	 * @return  void
+	 *
+	 * @since         1.0
+	 * @dataProvider  dataTestEscape
+	 */
+	public function testEscape($text, $extra, $result)
+	{
+		$this->assertThat(
+			self::$driver->escape($text, $extra),
+			$this->equalTo($result),
+			'The string was not escaped properly'
+		);
+	}
+
+	/**
+	 * Test getAffectedRows method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAffectedRows()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->delete();
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		self::$driver->execute();
+
+		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the getCollation method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetCollation()
+	{
+		$this->assertContains('UTF-8', self::$driver->getCollation(), __LINE__);
+	}
+
+	/**
+	 * Tests the getNumRows method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetNumRows()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->where('description=' . self::$driver->quote('one'));
+		self::$driver->setQuery($query);
+
+		$res = self::$driver->execute();
+
+		$this->assertThat(self::$driver->getNumRows($res), $this->equalTo(2), __LINE__);
+	}
+
+	/**
+	 * Test getTableCreate function
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTableCreate()
+	{
+		$this->assertThat(
+			self::$driver->getTableCreate('jos_dbtest'),
+			$this->equalTo(''),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test getTableColumns function.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTableColumns()
+	{
+		$tableCol = array('id' => 'integer', 'title' => 'character varying', 'start_date' => 'timestamp without time zone', 'description' => 'text');
+
+		$this->assertThat(self::$driver->getTableColumns('jos_dbtest'), $this->equalTo($tableCol), __LINE__);
+
+		/* not only type field */
+		$id = new \stdClass;
+		$id->column_name = 'id';
+		$id->Field = 'id';
+		$id->type = 'integer';
+		$id->Type = 'integer';
+		$id->null = 'NO';
+		$id->Null = 'NO';
+		$id->Default = 'nextval(\'jos_dbtest_id_seq\'::regclass)';
+		$id->comments = '';
+
+		$title = new \stdClass;
+		$title->column_name = 'title';
+		$title->Field = 'title';
+		$title->type = 'character varying(50)';
+		$title->Type = 'character varying(50)';
+		$title->null = 'NO';
+		$title->Null = 'NO';
+		$title->Default = null;
+		$title->comments = '';
+
+		$start_date = new \stdClass;
+		$start_date->column_name = 'start_date';
+		$start_date->Field = 'start_date';
+		$start_date->type = 'timestamp without time zone';
+		$start_date->Type = 'timestamp without time zone';
+		$start_date->null = 'NO';
+		$start_date->Null = 'NO';
+		$start_date->Default = null;
+		$start_date->comments = '';
+
+		$description = new \stdClass;
+		$description->column_name = 'description';
+		$description->Field = 'description';
+		$description->type = 'text';
+		$description->Type = 'text';
+		$description->null = 'NO';
+		$description->Null = 'NO';
+		$description->Default = null;
+		$description->comments = '';
+
+		$this->assertThat(
+			self::$driver->getTableColumns('jos_dbtest', false),
+			$this->equalTo(array('id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description)),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test getTableKeys function.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTableKeys()
+	{
+		$pkey = new \stdClass;
+		$pkey->idxName = 'jos_assets_pkey';
+		$pkey->isPrimary = true;
+		$pkey->isUnique = true;
+		$pkey->Query = 'ALTER TABLE jos_assets ADD PRIMARY KEY (id)';
+
+		$asset = new \stdClass;
+		$asset->idxName = 'idx_asset_name';
+		$asset->isPrimary = false;
+		$asset->isUnique = true;
+		$asset->Query = 'CREATE UNIQUE INDEX idx_asset_name ON jos_assets USING btree (name)';
+
+		$lftrgt = new \stdClass;
+		$lftrgt->idxName = 'jos_assets_idx_lft_rgt';
+		$lftrgt->isPrimary = false;
+		$lftrgt->isUnique = false;
+		$lftrgt->Query = 'CREATE INDEX jos_assets_idx_lft_rgt ON jos_assets USING btree (lft, rgt)';
+
+		$id = new \stdClass;
+		$id->idxName = 'jos_assets_idx_parent_id';
+		$id->isPrimary = false;
+		$id->isUnique = false;
+		$id->Query = 'CREATE INDEX jos_assets_idx_parent_id ON jos_assets USING btree (parent_id)';
+
+		$this->assertThat(self::$driver->getTableKeys('jos_assets'), $this->equalTo(array($pkey, $id, $lftrgt, $asset)), __LINE__);
+	}
+
+	/**
+	 * Test getTableSequences function.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTableSequences()
+	{
+		$seq = new \stdClass;
+		$seq->sequence = 'jos_dbtest_id_seq';
+		$seq->schema = 'public';
+		$seq->table = 'jos_dbtest';
+		$seq->column = 'id';
+		$seq->data_type = 'bigint';
+
+		if (version_compare(self::$driver->getVersion(), '9.1.0') >= 0)
+		{
+			$seq->start_value = '1';
+			$seq->minimum_value = '1';
+			$seq->maximum_value = '9223372036854775807';
+			$seq->increment = '1';
+			$seq->cycle_option = 'NO';
+		}
+		else
+		{
+			$seq->minimum_value = null;
+			$seq->maximum_value = null;
+			$seq->increment = null;
+			$seq->cycle_option = null;
+		}
+
+		$this->assertThat(self::$driver->getTableSequences('jos_dbtest'), $this->equalTo(array($seq)), __LINE__);
+	}
+
+	/**
+	 * Tests the getTableList method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetTableList()
+	{
+		$expected = array(
+			"0" => "jos_assets",
+			"1" => "jos_categories",
+			"2" => "jos_content",
+			"3" => "jos_core_log_searches",
+			"4" => "jos_dbtest",
+			"5" => "jos_extensions",
+			"6" => "jos_languages",
+			"7" => "jos_log_entries",
+			"8" => "jos_menu",
+			"9" => "jos_menu_types",
+			"10" => "jos_modules",
+			"11" => "jos_modules_menu",
+			"12" => "jos_schemas",
+			"13" => "jos_session",
+			"14" => "jos_update_categories",
+			"15" => "jos_update_sites",
+			"16" => "jos_update_sites_extensions",
+			"17" => "jos_updates",
+			"18" => "jos_user_profiles",
+			"19" => "jos_user_usergroup_map",
+			"20" => "jos_usergroups",
+			"21" => "jos_users",
+			"22" => "jos_viewlevels");
+
+		$result = self::$driver->getTableList();
+
+		// Assert array size
+		$this->assertThat(count($result), $this->equalTo(count($expected)), __LINE__);
+
+		// Clear found element to check if all elements are present in any order
+		foreach ($result as $k => $v)
+		{
+			if (in_array($v, $expected))
+			{
+				// Ok case, value found so set value to zero
+				$result[$k] = '0';
+			}
+			else
+			{
+				// Error case, value NOT found so set value to one
+				$result[$k] = '1';
+			}
+		}
+
+		// If there's a one it will return true and test fails
+		$this->assertThat(in_array('1', $result), $this->equalTo(false), __LINE__);
+	}
+
+	/**
+	 * Tests the getVersion method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetVersion()
+	{
+		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
+		$versionArray = explode(' ', $versionRow[0]);
+
+		$this->assertGreaterThanOrEqual($versionArray[1], self::$driver->getVersion(), __LINE__);
+	}
+
+	/**
+	 * Tests the insertId method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testInsertid()
+	{
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test insertObject function
+	 *
+	 * @return   void
+	 *
+	 * @since    1.0
+	 */
+	public function testInsertObject()
+	{
+		self::$driver->setQuery('ALTER SEQUENCE jos_dbtest_id_seq RESTART WITH 1')->execute();
+
+		self::$driver->setQuery('TRUNCATE TABLE "jos_dbtest"')->execute();
+
+		$tst = new \stdClass;
+		$tst->title = "PostgreSQL test insertObject";
+		$tst->start_date = '2012-04-07 15:00:00';
+		$tst->description = "Test insertObject";
+
+		// Insert object without retrieving key
+		$ret = self::$driver->insertObject('#__dbtest', $tst);
+
+		$checkQuery = self::$driver->getQuery(true);
+		$checkQuery->select('COUNT(*)')
+			->from('#__dbtest')
+			->where('start_date = \'2012-04-07 15:00:00\'', 'AND')
+			->where('description = \'Test insertObject\'')
+			->where('title = \'PostgreSQL test insertObject\'');
+		self::$driver->setQuery($checkQuery);
+
+		$this->assertThat(self::$driver->loadResult(), $this->equalTo(1), __LINE__);
+		$this->assertThat($ret, $this->equalTo(true), __LINE__);
+
+		// Insert object retrieving the key
+		$tstK = new \stdClass;
+		$tstK->title = "PostgreSQL test insertObject with key";
+		$tstK->start_date = '2012-04-07 15:00:00';
+		$tstK->description = "Test insertObject with key";
+		$retK = self::$driver->insertObject('#__dbtest', $tstK, 'id');
+
+		$this->assertThat($tstK->id, $this->equalTo(2), __LINE__);
+		$this->assertThat($retK, $this->equalTo(true), __LINE__);
+	}
+
+	/**
+	 * Test isSupported function.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testIsSupported()
+	{
+		$this->assertThat(\Joomla\Database\Postgresql\PostgresqlDriver::isSupported(), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Test loadAssoc method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadAssoc()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('#__dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadAssoc();
+
+		$this->assertThat($result, $this->equalTo(array('title' => 'Testing')), __LINE__);
+	}
+
+	/**
+	 * Test loadAssocList method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadAssocList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('#__dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('title' => 'Testing'),
+					array('title' => 'Testing2'),
+					array('title' => 'Testing3'),
+					array('title' => 'Testing4')
+				)
+			),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test loadColumn method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadColumn()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('#__dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadColumn();
+
+		$this->assertThat($result, $this->equalTo(array('Testing', 'Testing2', 'Testing3', 'Testing4')), __LINE__);
+	}
+
+	/**
+	 * Test loadObject method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadObject()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('#__dbtest');
+		$query->where('description=' . self::$driver->quote('three'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadObject();
+
+		$objCompare = new \stdClass;
+		$objCompare->id = 3;
+		$objCompare->title = 'Testing3';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'three';
+
+		$this->assertThat($result, $this->equalTo($objCompare), __LINE__);
+	}
+
+	/**
+	 * Test loadObjectList method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadObjectList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('#__dbtest');
+		$query->order('id');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadObjectList();
+
+		$expected = array();
+
+		$objCompare = new \stdClass;
+		$objCompare->id = 1;
+		$objCompare->title = 'Testing';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'one';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new \stdClass;
+		$objCompare->id = 2;
+		$objCompare->title = 'Testing2';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'one';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new \stdClass;
+		$objCompare->id = 3;
+		$objCompare->title = 'Testing3';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'three';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new \stdClass;
+		$objCompare->id = 4;
+		$objCompare->title = 'Testing4';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'four';
+
+		$expected[] = clone $objCompare;
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test loadResult method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadResult()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('id');
+		$query->from('#__dbtest');
+		$query->where('title=' . self::$driver->quote('Testing2'));
+
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadResult();
+
+		$this->assertThat($result, $this->equalTo(2), __LINE__);
+	}
+
+	/**
+	 * Test loadRow method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadRow()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('#__dbtest');
+		$query->where('description=' . self::$driver->quote('three'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadRow();
+
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test loadRowList method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLoadRowList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('#__dbtest');
+		$query->where('description=' . self::$driver->quote('one'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadRowList();
+
+		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test the query method
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testQuery()
+	{
+		/* REPLACE is not present in PostgreSQL */
+		$query = self::$driver->getQuery(true);
+		$query->delete();
+		$query->from('#__dbtest')->where('id=5');
+		self::$driver->setQuery($query)->execute();
+
+		$query = self::$driver->getQuery(true);
+		$query->insert('#__dbtest')
+			->columns('id,title,start_date, description')
+			->values("5, 'testTitle','1970-01-01','testDescription'")
+			->returning('id');
+
+		self::$driver->setQuery($query);
+		$arr = self::$driver->loadResult();
+
+		$this->assertThat($arr, $this->equalTo(5), __LINE__);
+	}
+
+	/**
+	 * Test quoteName function, with and without dot notation.
+	 *
+	 * @param   string  $quoteMe   String to be quoted
+	 * @param   string  $asPart    String used for AS query part
+	 * @param   string  $expected  Expected string
+	 *
+	 * @return  void
+	 *
+	 * @since        1.0
+	 * @dataProvider dataTestQuoteName
+	 */
+	public function testQuoteName($quoteMe, $asPart, $expected)
+	{
+		$this->assertThat(self::$driver->quoteName($quoteMe, $asPart), $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the select method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSelect()
+	{
+		/* it's not possible to select a database, already done during connection, return true */
+		$this->assertThat(self::$driver->select('database'), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Tests the sqlValue method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSqlValue()
+	{
+		// Array of columns' description as that returned by getTableColumns
+		$tablCol = array(
+			'id' => 'integer',
+			'charVar' => 'character varying',
+			'timeStamp' => 'timestamp without time zone',
+			'nullDate' => 'timestamp without time zone',
+			'txt' => 'text',
+			'boolTrue' => 'boolean',
+			'boolFalse' => 'boolean',
+			'num' => 'numeric,',
+			'nullInt' => 'integer'
+		);
+
+		$values = array();
+
+		// Object containing fields of integer, character varying, timestamp and text type
+		$tst = new \stdClass;
+		$tst->id = '5';
+		$tst->charVar = "PostgreSQL test insertObject";
+		$tst->timeStamp = '2012-04-07 15:00:00';
+		$tst->nullDate = null;
+		$tst->txt = "Test insertObject";
+		$tst->boolTrue = true;
+		$tst->boolFalse = false;
+		$tst->num = '43.2';
+		$tst->nullInt = '';
+
+		foreach (get_object_vars($tst) as $key => $val)
+		{
+			$values[] = self::$driver->sqlValue($tablCol, $key, $val);
+		}
+
+		$this->assertThat(
+			implode(',', $values),
+			$this->equalTo(
+				"5,'PostgreSQL test insertObject','2012-04-07 15:00:00','1970-01-01 00:00:00','Test insertObject',TRUE,NULL,43.2,NULL"
+			),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test setUtf function
+	 *
+	 * @return   void
+	 */
+	public function testSetUtf()
+	{
+		$this->assertThat(self::$driver->setUtf(), $this->equalTo(0), __LINE__);
+	}
+
+	/**
+	 * Test Test method - there really isn't a lot to test here, but
+	 * this is present for the sake of completeness
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @deprecated  2.0
+	 */
+	public function testTest()
+	{
+		$this->assertThat(\Joomla\Database\Postgresql\PostgresqlDriver::test(), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Test updateObject function.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @todo    Implement testUpdateObject().
+	 */
+	public function testUpdateObject()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Tests the transactionCommit method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testTransactionCommit()
+	{
+		self::$driver->transactionStart();
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('#__dbtest')
+			->columns('id,title,start_date,description')
+			->values("6, 'testTitle','1970-01-01','testDescription'");
+
+		self::$driver->setQuery($queryIns)->execute();
+
+		self::$driver->transactionCommit();
+
+		/* check if value is present */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('#__dbtest')
+			->where('id=6');
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadRow();
+
+		$expected = array(6, 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the transactionRollback method, with and without savepoint.
+	 *
+	 * @param   string  $toSavepoint  Savepoint name to rollback transaction to
+	 * @param   int     $tupleCount   Number of tuple found after insertion and rollback
+	 *
+	 * @return  void
+	 *
+	 * @since        1.0
+	 * @dataProvider dataTestTransactionRollback
+	 */
+	public function testTransactionRollback($toSavepoint, $tupleCount)
+	{
+		self::$driver->transactionStart();
+
+		/* try to insert this tuple, inserted only when savepoint != null */
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('#__dbtest')
+			->columns('id, title, start_date, description')
+			->values("7, 'testRollback', '1970-01-01', 'testRollbackSp'");
+		self::$driver->setQuery($queryIns)->execute();
+
+		/* create savepoint only if is passed by data provider */
+		if (!is_null($toSavepoint))
+		{
+			self::$driver->transactionStart((boolean) $toSavepoint);
+		}
+
+		/* try to insert this tuple, always rolled back */
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('#__dbtest')
+			->columns('id, title, start_date, description')
+			->values("8, 'testRollback', '1972-01-01', 'testRollbackSp'");
+		self::$driver->setQuery($queryIns)->execute();
+
+		self::$driver->transactionRollback((boolean) $toSavepoint);
+
+		/* release savepoint and commit only if a savepoint exists */
+		if (!is_null($toSavepoint))
+		{
+			self::$driver->transactionCommit();
+		}
+
+		/* find how many rows have description='testRollbackSp' :
+		 *   - 0 if a savepoint doesn't exist
+		 *   - 1 if a savepoint exists
+		 */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('#__dbtest')
+			->where("description = 'testRollbackSp'");
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadRowList();
+
+		$this->assertThat(count($result), $this->equalTo($tupleCount), __LINE__);
+	}
+
+	/**
+	 * Tests the transactionStart method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testTransactionStart()
+	{
+		self::$driver->transactionStart();
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('#__dbtest')
+			->columns('id,title,start_date,description')
+			->values("6, 'testTitle','1970-01-01','testDescription'");
+
+		self::$driver->setQuery($queryIns)->execute();
+
+		/* check if is present an exclusive lock, it means a transaction is running */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('pg_catalog.pg_locks')
+			->where('transactionid NOTNULL');
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadAssocList();
+
+		$this->assertThat(count($result), $this->equalTo(1), __LINE__);
+	}
+
+	/**
+	 * Tests the renameTable method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testRenameTable()
+	{
+		$newTableName = 'bak_jos_dbtest';
+
+		self::$driver->renameTable('jos_dbtest', $newTableName);
+
+		/* check name change */
+		$tableList = self::$driver->getTableList();
+		$this->assertThat(in_array($newTableName, $tableList), $this->isTrue(), __LINE__);
+
+		/* check index change */
+		self::$driver->setQuery(
+			'SELECT relname
+							FROM pg_class
+							WHERE oid IN (
+								SELECT indexrelid
+								FROM pg_index, pg_class
+								WHERE pg_class.relname=\'' . $newTableName . '\' AND pg_class.oid=pg_index.indrelid );');
+
+		$oldIndexes = self::$driver->loadColumn();
+		$this->assertThat($oldIndexes[0], $this->equalTo('bak_jos_dbtest_pkey'), __LINE__);
+
+		/* check sequence change */
+		self::$driver->setQuery(
+			'SELECT relname
+							FROM pg_class
+							WHERE relkind = \'S\'
+							AND relnamespace IN (
+								SELECT oid
+								FROM pg_namespace
+								WHERE nspname NOT LIKE \'pg_%\'
+								AND nspname != \'information_schema\'
+							)
+							AND relname LIKE \'%' . $newTableName . '%\' ;');
+
+		$oldSequences = self::$driver->loadColumn();
+		$this->assertThat($oldSequences[0], $this->equalTo('bak_jos_dbtest_id_seq'), __LINE__);
+
+		/* restore initial state */
+		self::$driver->renameTable($newTableName, 'jos_dbtest');
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql replacePrefix method.
+	 *
+	 * @param   string  $stringToReplace  The string in which replace the prefix.
+	 * @param   string  $prefix           The prefix.
+	 * @param   string  $expected         The string expected.
+	 *
+	 * @return  void
+	 *
+	 * @since         1.0
+	 * @dataProvider  dataTestReplacePrefix
+	 */
+	public function testReplacePrefix($stringToReplace, $prefix, $expected)
+	{
+		$result = self::$driver->replacePrefix($stringToReplace, $prefix);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the getCreateDbQuery method.
+	 *
+	 * @param   \stdClass  $options  stdClass coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean    $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @since         1.0
+	 * @dataProvider  dataGetCreateDbQuery
+	 */
+	public function testGetCreateDbQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name) . ' OWNER ' . self::$driver->quoteName($options->db_user);
+
+		if ($utf)
+		{
+			$expected .= ' ENCODING ' . self::$driver->quote('UTF-8');
+		}
+
+		$result = self::$driver->getCreateDbQuery($options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' SET CLIENT_ENCODING TO ' . self::$driver->quote('UTF8');
+
+		$result = self::$driver->getAlterDbCharacterSet('test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+}

--- a/Tests/ExporterPgsqlInspector.php
+++ b/Tests/ExporterPgsqlInspector.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+/**
+ * Class to expose protected properties and methods in \Joomla\Database\Pgsql\PgsqlExporter for testing purposes
+ *
+ * @since  1.0
+ */
+class ExporterPgsqlInspector extends \Joomla\Database\Pgsql\PgsqlExporter
+{
+	/**
+	 * Gets any property from the class.
+	 *
+	 * @param   string  $property  The name of the class property.
+	 *
+	 * @return  mixed   The value of the class property.
+	 *
+	 * @since   1.0
+	 */
+	public function __get($property)
+	{
+		return $this->$property;
+	}
+
+	/**
+	 * Exposes the protected buildXml method.
+	 *
+	 * @return  string  An XML string
+	 *
+	 * @since   1.0
+	 * @throws  \Exception if an error occurs.
+	 */
+	public function buildXml()
+	{
+		return parent::buildXml();
+	}
+
+	/**
+	 * Exposes the protected buildXmlStructure method.
+	 *
+	 * @return  array  An array of XML lines (strings).
+	 *
+	 * @since   1.0
+	 * @throws  \Exception if an error occurs.
+	 */
+	public function buildXmlStructure()
+	{
+		return parent::buildXmlStructure();
+	}
+
+	/**
+	 * Exposes the protected getGenericTableName method.
+	 *
+	 * @param   string  $table  The name of a table.
+	 *
+	 * @return  string  The name of the table with the database prefix replaced with #__.
+	 *
+	 * @since   1.0
+	 */
+	public function getGenericTableName($table)
+	{
+		return parent::getGenericTableName($table);
+	}
+}

--- a/Tests/ExporterPgsqlTest.php
+++ b/Tests/ExporterPgsqlTest.php
@@ -1,0 +1,652 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+require_once __DIR__ . '/ExporterPgsqlInspector.php';
+
+/**
+ * Test the \Joomla\Database\Pgsql\PgsqlExporter class.
+ *
+ * @since  1.0
+ */
+class ExporterPgsqlTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    object  The mocked database object for use by test methods.
+	 * @since  1.0
+	 */
+	protected $dbo = null;
+
+	/**
+	 * @var    string  The last query sent to the dbo setQuery method.
+	 * @since  1.0
+	 */
+	protected $lastQuery = '';
+
+	/**
+	 * @var    bool  Boolean value to know if current database version is newer than 9.1.0
+	 * @since  1.0
+	 */
+	private $ver9dot1 = true;
+
+	/**
+	 * Sets up the testing conditions
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function setup()
+	{
+		parent::setUp();
+
+		// Set up the database object mock.
+		$this->dbo = $this->getMock(
+			'Joomla\\Database\\Pgsql\\PgsqlDriver',
+			array(
+				'getErrorNum',
+				'getPrefix',
+				'getTableColumns',
+				'getTableKeys',
+				'getTableSequences',
+				'getVersion',
+				'quoteName',
+				'loadObjectList',
+				'setQuery',
+			),
+			array(),
+			'',
+			false
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getPrefix')
+		->will(
+			$this->returnValue(
+				'jos_'
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableColumns')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'column_name' => 'id',
+						'type' => 'integer',
+						'null' => 'NO',
+						'default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'title',
+						'type' => 'character varying(50)',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'start_date',
+						'type' => 'timestamp without time zone',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'description',
+						'type' => 'text',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableKeys')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'idxName' => 'jos_dbtest_pkey',
+						'isPrimary' => 'TRUE',
+						'isUnique' => 'TRUE',
+						'Query' => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
+					)
+				)
+			)
+		);
+
+		/* Check if database is at least 9.1.0 */
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getVersion')
+		->will(
+			$this->returnValue(
+				'9.1.2'
+			)
+		);
+
+		if (version_compare($this->dbo->getVersion(), '9.1.0') >= 0)
+		{
+			$this->ver9dot1 = true;
+			$start_val = '1';
+		}
+		else
+		{
+			/* Older version */
+			$this->ver9dot1 = false;
+			$start_val = null;
+		}
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableSequences')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'sequence' => 'jos_dbtest_id_seq',
+						'schema' => 'public',
+						'table' => 'jos_dbtest',
+						'column' => 'id',
+						'data_type' => 'bigint',
+						'start_value' => $start_val,
+						'minimum_value' => '1',
+						'maximum_value' => '9223372036854775807',
+						'increment' => '1',
+						'cycle_option' => 'NO',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quoteName')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuoteName')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('setQuery')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackSetQuery')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('loadObjectList')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackLoadObjectList')
+			)
+		);
+	}
+
+	/**
+	 * Callback for the dbo loadObjectList method.
+	 *
+	 * @return array  An array of results based on the setting of the last query.
+	 *
+	 * @since  1.0
+	 */
+	public function callbackLoadObjectList()
+	{
+		return array();
+	}
+
+	/**
+	 * Callback for the dbo quoteName method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return string  The value passed wrapped in PostgreSQL quotes.
+	 *
+	 * @since  1.0
+	 */
+	public function callbackQuoteName($value)
+	{
+		return '"$value"';
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   string  $query  The query.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function callbackSetQuery($query)
+	{
+		$this->lastQuery = $query;
+	}
+
+	/**
+	 * Test the magic __toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toString()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+
+		if ($this->ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$expecting = '<?xml version="1.0"?>
+<postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <database name="">
+  <table_structure name="#__test">
+   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
+   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
+   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
+   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+  </table_structure>
+ </database>
+</postgresqldump>';
+
+		// Replace used to prevent platform conflicts
+		$this->assertThat(
+			preg_replace('/\v/', '', (string) $instance),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
+			),
+			'__toString has not returned the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the asXml method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testAsXml()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		$result = $instance->asXml();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'asXml must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->asFormat,
+			$this->equalTo('xml'),
+			'The asXml method should set the protected asFormat property to "xml".'
+		);
+	}
+
+	/**
+	 * Test the buildXML method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testBuildXml()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+
+		if ($this->ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$expecting = '<?xml version="1.0"?>
+<postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <database name="">
+  <table_structure name="#__test">
+   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
+   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
+   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
+   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+  </table_structure>
+ </database>
+</postgresqldump>';
+
+		// Replace used to prevent platform conflicts
+		$this->assertThat(
+			preg_replace('/\v/', '', $instance->buildXml()),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
+			),
+			'buildXml has not returned the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the buildXmlStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testBuildXmlStructure()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+
+		if ($this->ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$this->assertThat(
+			$instance->buildXmlStructure(),
+			$this->equalTo(
+				array(
+					'  <table_structure name="#__test">',
+					'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
+					$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />',
+					'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
+					'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
+					'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
+					'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
+					'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />',
+					'  </table_structure>'
+				)
+			),
+			'buildXmlStructure has not returned the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithNoDbo()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		try
+		{
+			$instance->check();
+		}
+		catch (\Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithNoTables()
+	{
+		$instance	= new ExporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		try
+		{
+			$instance->check();
+		}
+		catch (\Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithGoodInput()
+	{
+		$instance	= new ExporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+		$instance->from('foobar');
+
+		try
+		{
+			$result = $instance->check();
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'check must return an object to support chaining.'
+			);
+		}
+		catch (\Exception $e)
+		{
+			$this->fail(
+				'Check method should not throw exception with good setup: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the from method with bad input.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testFromWithBadInput()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		try
+		{
+			$instance->from(new \stdClass);
+		}
+		catch (\Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'From method should thrown an exception if argument is not a string or array.'
+		);
+	}
+
+	/**
+	 * Tests the from method with expected good inputs.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testFromWithGoodInput()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		try
+		{
+			$result = $instance->from('jos_foobar');
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'from must return an object to support chaining.'
+			);
+
+			$this->assertThat(
+				$instance->from,
+				$this->equalTo(array('jos_foobar')),
+				'The from method should convert a string input to an array.'
+			);
+		}
+		catch (\Exception $e)
+		{
+			$this->fail(
+				'From method should not throw exception with good input: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the method getGenericTableName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetGenericTableName()
+	{
+		$instance = new ExporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getGenericTableName('jos_test'),
+			$this->equalTo('#__test'),
+			'The testGetGenericTableName should replace the database prefix with #__.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testSetDboWithGoodInput()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		try
+		{
+			$result = $instance->setDbo($this->dbo);
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'setDbo must return an object to support chaining.'
+			);
+		}
+		catch (\PHPUnit_Framework_Error $e)
+		{
+			// Unknown error has occurred.
+			$this->fail(
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the withStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testWithStructure()
+	{
+		$instance = new ExporterPgsqlInspector;
+
+		$result = $instance->withStructure();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'withStructure must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isTrue(),
+			'The default use of withStructure should result in true.'
+		);
+
+		$instance->withStructure(true);
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isTrue(),
+			'The explicit use of withStructure with true should result in true.'
+		);
+
+		$instance->withStructure(false);
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isFalse(),
+			'The explicit use of withStructure with false should result in false.'
+		);
+	}
+}

--- a/Tests/ImporterPgsqlInspector.php
+++ b/Tests/ImporterPgsqlInspector.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+/**
+ * Class to expose protected properties and methods in \Joomla\Database\Pgsql\PgsqlImporter for testing purposes
+ *
+ * @since  1.0
+ */
+class ImporterPgsqlInspector extends \Joomla\Database\Pgsql\PgsqlImporter
+{
+	/**
+	 * Gets any property from the class.
+	 *
+	 * @param   string  $property  The name of the class property.
+	 *
+	 * @return  mixed   The value of the class property.
+	 *
+	 * @since   1.0
+	 */
+	public function __get($property)
+	{
+		return $this->$property;
+	}
+
+	/**
+	 * Exposes the protected check method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function check()
+	{
+		return parent::check();
+	}
+
+	/**
+	 * Exposes the protected getAddColumnSQL method.
+	 *
+	 * @param   string            $table  The table name.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getAddColumnSql($table, \SimpleXMLElement $field)
+	{
+		return parent::getAddColumnSql($table, $field);
+	}
+
+	/**
+	 * Exposes the protected getAddKeySQL method.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML index definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getAddIndexSql(\SimpleXMLElement $field)
+	{
+		return parent::getAddIndexSql($field);
+	}
+
+	/**
+	 * Exposes the protected getAddSequenceSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML sequence definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getAddSequenceSql(\SimpleXMLElement $structure)
+	{
+		return parent::getAddSequenceSql($structure);
+	}
+
+	/**
+	 * Exposes the protected getAlterTableSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML structure of the table.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function getAlterTableSql(\SimpleXMLElement $structure)
+	{
+		return parent::getAlterTableSql($structure);
+	}
+
+	/**
+	 * Exposes the protected getChangeColumnSQL method.
+	 *
+	 * @param   string            $table  The table name.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getChangeColumnSql($table, \SimpleXMLElement $field)
+	{
+		return parent::getChangeColumnSql($table, $field);
+	}
+
+	/**
+	 * Exposes the protected getColumnSQL method.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getColumnSql(\SimpleXMLElement $field)
+	{
+		return parent::getColumnSql($field);
+	}
+
+	/**
+	 * Exposes the protected getChangeSequenceSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML sequence definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getChangeSequenceSql(\SimpleXMLElement $structure)
+	{
+		return parent::getChangeSequenceSql($structure);
+	}
+
+	/**
+	 * Exposes the protected getDropColumnSQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The name of the field to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getDropColumnSql($table, $name)
+	{
+		return parent::getDropColumnSql($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropKeySQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The name of the key to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getDropKeySql($table, $name)
+	{
+		return parent::getDropKeySql($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropPrimaryKeySQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The constraint name.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getDropPrimaryKeySql($table, $name)
+	{
+		return parent::getDropPrimaryKeySql($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropIndexSQL method.
+	 *
+	 * @param   string  $name  The index name.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getDropIndexSql($name)
+	{
+		return parent::getDropIndexSql($name);
+	}
+
+	/**
+	 * Exposes the protected getDropSequenceSQL method.
+	 *
+	 * @param   string  $name  The index name.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function getDropSequenceSql($name)
+	{
+		return parent::getDropSequenceSql($name);
+	}
+
+	/**
+	 * Exposes the protected getIdxLookup method.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the indexes for the table.
+	 *
+	 * @return  array	The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   1.0
+	 * @throws	Exception
+	 */
+	public function getIdxLookup($keys)
+	{
+		return parent::getIdxLookup($keys);
+	}
+
+	/**
+	 * Exposes the protected getSeqLookup method.
+	 *
+	 * @param   array  $sequences  An array of objects that comprise the sequences for the table.
+	 *
+	 * @return  array	The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   1.0
+	 * @throws	Exception
+	 */
+	public function getSeqLookup($sequences)
+	{
+		return parent::getSeqLookup($sequences);
+	}
+
+	/**
+	 * Exposes the protected getRealTableName method.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  string	The real name of the table.
+	 *
+	 * @since   1.0
+	 */
+	public function getRealTableName($table)
+	{
+		return parent::getRealTableName($table);
+	}
+
+	/**
+	 * Exposes the protected mergeStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  Exception on error.
+	 */
+	public function mergeStructure()
+	{
+		return parent::mergeStructure();
+	}
+
+	/**
+	 * Exposes the protected withStructure method.
+	 *
+	 * @param   boolean  $setting  True to export the structure, false to not.
+	 *
+	 * @return  void
+	 *
+	 * @since	1.0
+	 */
+	public function withStructure($setting = true)
+	{
+		return parent::withStructure($setting);
+	}
+}

--- a/Tests/ImporterPgsqlTest.php
+++ b/Tests/ImporterPgsqlTest.php
@@ -1,0 +1,1059 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+require_once __DIR__ . '/ImporterPgsqlInspector.php';
+
+/**
+ * Test the JDatabaseImporterPgsql class.
+ *
+ * @since  1.0
+ */
+class ImporterPgsqlTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    object  The mocked database object for use by test methods.
+	 * @since  1.0
+	 */
+	protected $dbo = null;
+
+	/**
+	 * @var    string  The last query sent to the dbo setQuery method.
+	 * @since  1.0
+	 */
+	protected $lastQuery = '';
+
+	/**
+	 * Sets up the testing conditions
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function setup()
+	{
+		parent::setUp();
+
+		// Set up the database object mock.
+		$this->dbo = $this->getMock(
+			'Joomla\\Database\\Pgsql\\PgsqlDriver',
+			array(
+				'getErrorNum',
+				'getPrefix',
+				'getTableColumns',
+				'getTableKeys',
+				'getTableSequences',
+				'getAddSequenceSQL',
+				'getChangeSequenceSQL',
+				'getDropSequenceSQL',
+				'getAddIndexSQL',
+				'getVersion',
+				'quoteName',
+				'loadObjectList',
+				'quote',
+				'setQuery',
+			),
+			array(),
+			'',
+			false
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getPrefix')
+		->will(
+			$this->returnValue(
+				'jos_'
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableColumns')
+		->will(
+			$this->returnValue(
+				array(
+					'id' => (object) array(
+						'Field' => 'id',
+						'Type' => 'integer',
+						'Null' => 'NO',
+						'Default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'Comments' => '',
+					),
+					'title' => (object) array(
+						'Field' => 'title',
+						'Type' => 'character varying(50)',
+						'Null' => 'NO',
+						'Default' => 'NULL',
+						'Comments' => '',
+					),
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableKeys')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'Index' => 'jos_dbtest_pkey',
+						'is_primary' => 'TRUE',
+						'is_unique' => 'TRUE',
+						'Query' => 'ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)',
+					),
+					(object) array(
+						'Index' => 'jos_dbtest_idx_name',
+						'is_primary' => 'FALSE',
+						'is_unique' => 'FALSE',
+						'Query' => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
+					)
+				)
+			)
+		);
+
+		// Check if database is at least 9.1.0
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getVersion')
+		->will(
+			$this->returnValue(
+				'7.1.2'
+			)
+		);
+
+		if (version_compare($this->dbo->getVersion(), '9.1.0') >= 0)
+		{
+			$start_val = '1';
+		}
+		else
+		{
+			/* Older version */
+			$start_val = null;
+		}
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableSequences')
+		->will(
+			$this->returnValue(
+			array(
+					(object) array(
+						'Name' => 'jos_dbtest_id_seq',
+						'Schema' => 'public',
+						'Table' => 'jos_dbtest',
+						'Column' => 'id',
+						'Type' => 'bigint',
+						'Start_Value' => $start_val,
+						'Min_Value' => '1',
+						'Max_Value' => '9223372036854775807',
+						'Increment' => '1',
+						'Cycle_option' => 'NO',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quoteName')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuoteName')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quote')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuote')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('setQuery')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackSetQuery')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('loadObjectList')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackLoadObjectList')
+			)
+		);
+	}
+
+	/**
+	 * Callback for the dbo loadObjectList method.
+	 *
+	 * @return array  An array of results based on the setting of the last query.
+	 *
+	 * @since  1.0
+	 */
+	public function callbackLoadObjectList()
+	{
+		return array('');
+	}
+
+	/**
+	 * Callback for the dbo quote method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since  1.0
+	 */
+	public function callbackQuote($value)
+	{
+		return "'$value'";
+	}
+
+	/**
+	 * Callback for the dbo quoteName method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since  1.0
+	 */
+	public function callbackQuoteName($value)
+	{
+		return "\"$value\"";
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   string  $query  The query.
+	 *
+	 * @return  void
+	 *
+	 * @since  1.0
+	 */
+	public function callbackSetQuery($query)
+	{
+		$this->lastQuery = $query;
+	}
+
+	/**
+	 * Data for the testGetAlterTableSQL test.
+	 *
+	 * @return  array  Each array element must be an array with 3 elements: SimpleXMLElement field, expected result, error message.
+	 *
+	 * @since   1.0
+	 */
+	public function dataGetAlterTableSql()
+	{
+		$f1 = '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" ' .
+			'Comments="" />';
+		$f2 = '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />';
+		$f3 = '<field Field="alias" Type="character varying(255)" Null="NO" Default="test" Comments="" />';
+		$f2_def = '<field Field="title" Type="character varying(50)" Null="NO" Default="add default" Comments="" />';
+
+		$k1 = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
+		$k2 = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX jos_dbtest_idx_name ON' .
+			' jos_dbtest USING btree (name)" />';
+		$k3 = '<key Index="jos_dbtest_idx_title" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX ' .
+			'jos_dbtest_idx_title ON jos_dbtest USING btree (title)" />';
+		$k4 = '<key Index="jos_dbtest_uidx_name" is_primary="FALSE" is_unique="TRUE" Query="CREATE UNIQUE INDEX ' .
+			'jos_dbtest_uidx_name ON jos_dbtest USING btree (name)" />';
+		$pk = '<key Index="jos_dbtest_title_pkey" is_primary="TRUE" is_unique="TRUE" ' .
+			'Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)" />';
+
+		$s1 = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="1" ' .
+			'Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />';
+		$s2 = '<sequence Name="jos_dbtest_title_seq" Schema="public" Table="jos_dbtest" Column="title" Type="bigint" Start_Value="1" Min_Value="1" ' .
+			'Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />';
+
+		$addSequence = 'CREATE SEQUENCE jos_dbtest_title_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 ' .
+			'NO CYCLE OWNED BY "public.jos_dbtest.title"';
+		$changeCol = "ALTER TABLE \"jos_test\" ALTER COLUMN \"title\"  TYPE character " .
+			"varying(50),\nALTER COLUMN \"title\" SET NOT NULL,\nALTER COLUMN \"title\" SET DEFAULT 'add default'";
+		$changeSeq = "CREATE SEQUENCE jos_dbtest_title_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 " .
+			"START 1 NO CYCLE OWNED BY \"public.jos_dbtest.title\"";
+
+		return array(
+			array(
+				new \SimpleXmlElement('<table_structure name="#__dbtest">' . $s1 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+				),
+				'getAlterTableSQL should not change anything.'
+			),
+			array(
+				// Add col
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $f3 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE "jos_test" ADD COLUMN "alias" character varying(255) NOT NULL DEFAULT \'test\'',
+				),
+				'getAlterTableSQL should add the new alias column.'
+			),
+			array(
+				// Add idx
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k3 . '</table_structure>'),
+				array('CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)',),
+				'getAlterTableSQL should add the new key.'
+			),
+			array(
+				// Add unique idx
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k4 . '</table_structure>'),
+				array(
+					'CREATE UNIQUE INDEX jos_dbtest_uidx_name ON jos_dbtest USING btree (name)',
+				),
+				'getAlterTableSQL should add the new unique key.'
+			),
+			array(
+				// Add sequence
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					$addSequence,
+				),
+				'getAlterTableSQL should add the new sequence.'
+			),
+			array(
+				// Add pkey
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $pk . '</table_structure>'),
+				array(
+					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
+				),
+				'getAlterTableSQL should add the new sequence.'
+			),
+			array(
+				// Drop col
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE "jos_test" DROP COLUMN "title"',
+				),
+				'getAlterTableSQL should remove the title column.'
+			),
+			array(
+				// Drop idx
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . '</table_structure>'),
+				array(
+					"DROP INDEX \"jos_dbtest_idx_name\""
+				),
+				'getAlterTableSQL should change sequence.'
+			),
+			array(
+				// Drop seq
+				new \SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'DROP SEQUENCE "jos_dbtest_id_seq"',
+				),
+				'getAlterTableSQL should drop the sequence.'
+			),
+			array(
+			// Drop pkey
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"',
+				),
+				'getAlterTableSQL should drop the old primary key.'
+			),
+			array(
+				// Change col
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2_def . $k1 . $k2 . '</table_structure>'),
+				array($changeCol,),
+				'getAlterTableSQL should change title field.'
+			),
+			array(
+				// Change seq
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					$changeSeq,
+					"DROP SEQUENCE \"jos_dbtest_id_seq\"",),
+				'getAlterTableSQL should change sequence.'
+			),
+			array(
+				// Change idx
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k3 . '</table_structure>'),
+				array(
+					"CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)",
+					'DROP INDEX "jos_dbtest_idx_name"'
+				),
+				'getAlterTableSQL should change index.'
+			),
+			array(
+				// Change pkey
+				new \SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $pk . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
+					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"'
+				),
+				'getAlterTableSQL should change primary key.'
+			),
+		);
+	}
+
+	/**
+	 * Data for the testGetColumnSQL test.
+	 *
+	 * @return  array  Each array element must be an array with 3 elements: SimpleXMLElement field, expected result, error message.
+	 *
+	 * @since   1.0
+	 */
+	public function dataGetColumnSql()
+	{
+		$sample = array(
+			'xml-id-field' => '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
+			'xml-title-field' => '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
+			'xml-title-def' => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
+			'xml-body-field' => '<field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',);
+
+		return array(
+			array(
+				new \SimpleXmlElement(
+					$sample['xml-id-field']
+				),
+				'"id" serial',
+				'Typical primary key field',
+			),
+			array(
+				new \SimpleXmlElement(
+					$sample['xml-title-field']
+				),
+				'"title" character varying(50) NOT NULL',
+				'Typical text field',
+			),
+			array(
+				new \SimpleXmlElement(
+					$sample['xml-body-field']
+				),
+				'"description" text NOT NULL',
+				'Typical blob field',
+			),
+			array(
+				new \SimpleXmlElement(
+					$sample['xml-title-def']
+				),
+				'"title" character varying(50) NOT NULL DEFAULT \'this is a test\'',
+				'Typical text field with default value',
+			),
+		);
+	}
+
+	/**
+	 * Tests the asXml method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testAsXml()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		$result = $instance->asXml();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'asXml must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->asFormat,
+			$this->equalTo('xml'),
+			'The asXml method should set the protected asFormat property to "xml".'
+		);
+	}
+
+	/**
+	 * Tests the check method
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithNoDbo()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		try
+		{
+			$instance->check();
+		}
+		catch (\Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithNoFrom()
+	{
+		$instance	= new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		try
+		{
+			$instance->check();
+		}
+		catch (\Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testCheckWithGoodInput()
+	{
+		$instance	= new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+		$instance->from('foobar');
+
+		try
+		{
+			$result = $instance->check();
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'check must return an object to support chaining.'
+			);
+		}
+		catch (\Exception $e)
+		{
+			$this->fail(
+				'Check method should not throw exception with good setup: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the from method with expected good inputs.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testFromWithGoodInput()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		try
+		{
+			$result = $instance->from('foobar');
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'from must return an object to support chaining.'
+			);
+
+			$this->assertThat(
+				$instance->from,
+				$this->equalTo('foobar'),
+				'The from method did not store the value as expected.'
+			);
+		}
+		catch (\Exception $e)
+		{
+			$this->fail(
+				'From method should not throw exception with good input: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the getAddColumnSQL method.
+	 *
+	 * Note that combinations of fields are tested in testGetColumnSQL.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAddColumnSql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$sample = array(
+			'xml-title-field' => '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
+			'xml-title-def' => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
+			'xml-int-defnum' => '<field Field="title" Type="integer" Null="NO" Default="0" Comments="" />',);
+
+		$this->assertThat(
+			$instance->getAddColumnSql(
+				'jos_test',
+				new \SimpleXmlElement($sample['xml-title-field'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" character varying(50) NOT NULL'
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+
+		// Test a field with a default value
+		$this->assertThat(
+			$instance->getAddColumnSql(
+				'jos_test',
+				new \SimpleXmlElement($sample['xml-title-def'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" character varying(50) NOT NULL DEFAULT \'this is a test\''
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+
+		// Test a field with a numeric default value
+		$this->assertThat(
+			$instance->getAddColumnSql(
+				'jos_test',
+				new \SimpleXmlElement($sample['xml-int-defnum'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" integer NOT NULL DEFAULT 0'
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAddSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAddSequenceSql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$xmlIdSeq = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" ' .
+			'Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" /> ';
+
+		$this->assertThat(
+			$instance->getAddSequenceSql(
+				new \SimpleXmlElement($xmlIdSeq)
+			),
+			$this->equalTo(
+				'CREATE SEQUENCE jos_dbtest_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 NO CYCLE OWNED BY "public.jos_dbtest.id"'
+			),
+			'getAddSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAddIndexSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetAddIndexSql()
+	{
+		$xmlIndex = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" ' .
+			'Query="CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)" />';
+		$xmlPrimaryKey = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" ' .
+			'Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
+
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAddIndexSql(
+					new \SimpleXmlElement($xmlIndex)
+			),
+			$this->equalTo(
+				"CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)"
+			),
+			'testGetAddIndexSQL did not yield the expected result.'
+		);
+
+		$this->assertThat(
+			$instance->getAddIndexSql(
+					new \SimpleXmlElement($xmlPrimaryKey)
+			),
+			$this->equalTo(
+				"ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)"
+			),
+			'testGetAddIndexSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAlterTableSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  XML structure of field
+	 * @param   string            $expected   Expected string
+	 * @param   string            $message    Error message
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 *
+	 * @dataProvider dataGetAlterTableSQL
+	 */
+	public function testGetAlterTableSql($structure, $expected, $message)
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAlterTableSql(
+				$structure
+			),
+			$this->equalTo(
+				$expected
+			),
+			$message
+		);
+	}
+
+	/**
+	 * Tests the getChangeColumnSQL method.
+	 *
+	 * Note that combinations of fields is tested in testGetColumnSQL
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetChangeColumnSql()
+	{
+		$xmlTitleField = '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />';
+
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getChangeColumnSql(
+				'jos_test',
+				new \SimpleXmlElement($xmlTitleField)
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ALTER COLUMN "title"  TYPE character varying(50),' . "\n" .
+				'ALTER COLUMN "title" SET NOT NULL,' . "\n" .
+				'ALTER COLUMN "title" DROP DEFAULT'
+			),
+			'getChangeColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getChangeSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetChangeSequenceSql()
+	{
+		$xmlIdSeq = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" ' .
+			'Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" /> ';
+
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getChangeSequenceSql(
+				new \SimpleXmlElement($xmlIdSeq)
+			),
+			$this->equalTo(
+				'ALTER SEQUENCE jos_dbtest_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 OWNED BY "public.jos_dbtest.id"'
+			),
+			'getChangeSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getColumnSQL method.
+	 *
+	 * @param   SimpleXmlElement  $field     The database field as an object.
+	 * @param   string            $expected  The expected result from the getColumnSQL method.
+	 * @param   string            $message   The error message to display if the result does not match the expected value.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 *
+	 * @dataProvider dataGetColumnSQL
+	 */
+	public function testGetColumnSql($field, $expected, $message)
+	{
+		$instance	= new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			strtolower($instance->getColumnSql($field)),
+			$this->equalTo(strtolower($expected)),
+			$message
+		);
+	}
+
+	/**
+	 * Tests the getDropColumnSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetDropColumnSql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropColumnSql(
+				'jos_test',
+				'title'
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" DROP COLUMN "title"'
+			),
+			'getDropColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropKeySQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetDropIndexSql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropIndexSql(
+				'idx_title'
+			),
+			$this->equalTo(
+				'DROP INDEX "idx_title"'
+			),
+			'getDropKeySQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropPrimaryKeySQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetDropPrimaryKeySql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropPrimaryKeySql(
+				'jos_test', 'idx_jos_test_pkey'
+			),
+			$this->equalTo(
+				'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "idx_jos_test_pkey"'
+			),
+			'getDropPrimaryKeySQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetDropSequenceSql()
+	{
+		$instance = new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropSequenceSql(
+				'idx_jos_test_seq'
+			),
+			$this->equalTo(
+				'DROP SEQUENCE "idx_jos_test_seq"'
+			),
+			'getDropSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getIdxLookup method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGetIdxLookup()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		$o1 = (object) array('Index' => 'id', 'foo' => 'bar1');
+		$o2 = (object) array('Index' => 'id', 'foo' => 'bar2');
+		$o3 = (object) array('Index' => 'title', 'foo' => 'bar3');
+
+		$this->assertThat(
+			$instance->getIdxLookup(
+				array($o1, $o2, $o3)
+			),
+			$this->equalTo(
+				array(
+					'id' => array($o1, $o2),
+					'title' => array($o3)
+				)
+			),
+			'getIdxLookup, using array input, did not yield the expected result.'
+		);
+
+		$o1 = new \SimpleXmlElement('<key Index="id" foo="bar1" />');
+		$o2 = new \SimpleXmlElement('<key Index="id" foo="bar2" />');
+		$o3 = new \SimpleXmlElement('<key Index="title" foo="bar3" />');
+
+		$this->assertThat(
+			$instance->getIdxLookup(
+				array($o1, $o2, $o3)
+			),
+			$this->equalTo(
+				array(
+					'id' => array($o1, $o2),
+					'title' => array($o3)
+				)
+			),
+			'getIdxLookup, using SimpleXmlElement input, did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getRealTableName method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testGetRealTableName()
+	{
+		$instance	= new ImporterPgsqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getRealTableName('#__test'),
+			$this->equalTo('jos_test'),
+			'getRealTableName should return the name of the table with #__ converted to the database prefix.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  1.0
+	 */
+	public function testSetDboWithGoodInput()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		try
+		{
+			$result = $instance->setDbo($this->dbo);
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'setDbo must return an object to support chaining.'
+			);
+		}
+		catch (\PHPUnit_Framework_Error $e)
+		{
+			// Unknown error has occurred.
+			$this->fail(
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the withStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testWithStructure()
+	{
+		$instance = new ImporterPgsqlInspector;
+
+		$result = $instance->withStructure();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'withStructure must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isTrue(),
+			'The default use of withStructure should result in true.'
+		);
+
+		$instance->withStructure(true);
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isTrue(),
+			'The explicit use of withStructure with true should result in true.'
+		);
+
+		$instance->withStructure(false);
+		$this->assertThat(
+			$instance->options->withStructure,
+			$this->isFalse(),
+			'The explicit use of withStructure with false should result in false.'
+		);
+	}
+}

--- a/Tests/IteratorPgsqlTest.php
+++ b/Tests/IteratorPgsqlTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+/**
+ * Test class for Joomla\Database\Pgsql\PgsqlIteragor.
+ *
+ * @since  1.0
+ */
+class IteratorPgsqlTest extends DatabasePgsqlCase
+{
+	/**
+	 * Data provider for the testForEach method
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function casesForEachData()
+	{
+		return array(
+			// Testing 'stdClass' type without specific index, offset or limit
+			array(
+				'title',
+				'#__dbtest',
+				null,
+				'stdClass',
+				0,
+				0,
+				array(
+					(object) array('title' => 'Testing'),
+					(object) array('title' => 'Testing2'),
+					(object) array('title' => 'Testing3'),
+					(object) array('title' => 'Testing4')
+				),
+				null
+			),
+
+			// Testing 'stdClass' type, limit=2 without specific index or offset
+			array(
+				'title',
+				'#__dbtest',
+				null,
+				'stdClass',
+				2,
+				0,
+				array(
+					(object) array('title' => 'Testing'),
+					(object) array('title' => 'Testing2')
+				),
+				null
+			),
+
+			// Testing 'stdClass' type, offset=2 without specific index or limit
+			array(
+				'title',
+				'#__dbtest',
+				null,
+				'stdClass',
+				20,
+				2,
+				array(
+					(object) array('title' => 'Testing3'),
+					(object) array('title' => 'Testing4')
+				),
+				null
+			),
+
+			// Testing 'stdClass' type, index='title' without specific offset or limit
+			array(
+				'title, id',
+				'#__dbtest',
+				'title',
+				'stdClass',
+				0,
+				0,
+				array(
+					'Testing' => (object) array('title' => 'Testing', 'id' => '1'),
+					'Testing2' => (object) array('title' => 'Testing2', 'id' => '2'),
+					'Testing3' => (object) array('title' => 'Testing3', 'id' => '3'),
+					'Testing4' => (object) array('title' => 'Testing4', 'id' => '4')
+				),
+				null,
+			),
+
+			// Testing 'UnexistingClass' type, index='title' without specific offset or limit
+			array(
+				'title',
+				'#__dbtest',
+				'title',
+				'UnexistingClass',
+				0,
+				0,
+				array(),
+				'InvalidArgumentException',
+			),
+		);
+	}
+
+	/**
+	 * Test foreach control
+	 *
+	 * @param   string   $select     Fields to select
+	 * @param   string   $from       Table to search for
+	 * @param   string   $column     The column to use as a key.
+	 * @param   string   $class      The class on which to bind the result rows.
+	 * @param   integer  $limit      The result set record limit.
+	 * @param   integer  $offset     The result set record offset.
+	 * @param   array    $expected   Array of expected results
+	 * @param   mixed    $exception  Exception thrown
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider casesForEachData
+	 *
+	 * @since    1.0
+	 */
+	public function testForEach($select, $from, $column, $class, $limit, $offset, $expected, $exception)
+	{
+		if ($exception)
+		{
+			$this->setExpectedException($exception);
+		}
+
+		self::$driver->setQuery(self::$driver->getQuery(true)->select($select)->from($from)->setLimit($limit, $offset));
+		$iterator = self::$driver->getIterator($column, $class);
+
+		// Run the Iterator pattern
+		$this->assertThat(
+			iterator_to_array($iterator),
+			$this->equalTo($expected),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test count
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testCount()
+	{
+		self::$driver->setQuery(self::$driver->getQuery(true)->select('title')->from('#__dbtest'));
+		$this->assertThat(
+			count(self::$driver->getIterator()),
+			$this->equalTo(4),
+			__LINE__
+		);
+
+		self::$driver->setQuery(self::$driver->getQuery(true)->select('title')->from('#__dbtest')->setLimit(2));
+		$this->assertThat(
+			count(self::$driver->getIterator()),
+			$this->equalTo(2),
+			__LINE__
+		);
+
+		self::$driver->setQuery(self::$driver->getQuery(true)->select('title')->from('#__dbtest')->setLimit(2, 3));
+		$this->assertThat(
+			count(self::$driver->getIterator()),
+			$this->equalTo(1),
+			__LINE__
+		);
+	}
+}

--- a/Tests/QueryPgsqlTest.php
+++ b/Tests/QueryPgsqlTest.php
@@ -1,0 +1,1249 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+use Joomla\Database\Pgsql\PgsqlQuery;
+use Joomla\Test\TestHelper;
+
+/**
+ * Test class for \Joomla\Database\Pgsql\PgsqlQuery.
+ *
+ * @since  1.0
+ */
+class QueryPgsqlTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    \Joomla\Database\DatabaseDriver  A mock of the DatabaseDriver object for testing purposes.
+	 * @since  1.0
+	 */
+	protected $dbo;
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestNullDate()
+	{
+		return array(
+			// Quoted, expected
+			array(true, "'_1970-01-01 00:00:00_'"),
+			array(false, "1970-01-01 00:00:00"),
+		);
+	}
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestQuote()
+	{
+		return array(
+			// Text, escaped, expected
+			array('text', false, '\'text\''),
+		);
+	}
+
+	/**
+	 * Data for the testJoin test.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function dataTestJoin()
+	{
+		return array(
+			// $type, $conditions
+			array('', 		'b ON b.id = a.id'),
+			array('INNER',	'b ON b.id = a.id'),
+			array('OUTER',	'b ON b.id = a.id'),
+			array('LEFT',	'b ON b.id = a.id'),
+			array('RIGHT',	'b ON b.id = a.id'),
+		);
+	}
+
+	/**
+	 * A mock callback for the database escape method.
+	 *
+	 * We use this method to ensure that DatabaseQuery's escape method uses the
+	 * the database object's escape method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function mockEscape($text)
+	{
+		return "{$text}";
+	}
+
+	/**
+	 * A mock callback for the database quoteName method.
+	 *
+	 * We use this method to ensure that DatabaseQuery's quoteName method uses the
+	 * the database object's quoteName method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   1.0
+	 */
+	public function mockQuoteName($text)
+	{
+		return '"' . $text . '"';
+	}
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->dbo = Mock\Driver::create($this, '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+
+		// Mock the escape method to ensure the API is calling the DBO's escape method.
+		TestHelper::assignMockCallbacks(
+			$this->dbo,
+			$this,
+			array('escape' => array($this, 'mockEscape'))
+		);
+	}
+
+	/**
+	 * Test for the PgsqlQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringSelect()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->group('a.id')
+				->having('COUNT(a.id) > 3')
+			->order('a.id');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . "SELECT a.id" .
+				PHP_EOL . "FROM a" .
+				PHP_EOL . "INNER JOIN b ON b.id = a.id" .
+				PHP_EOL . "WHERE b.id = 1" .
+				PHP_EOL . "GROUP BY a.id" .
+				PHP_EOL . "HAVING COUNT(a.id) > 3" .
+				PHP_EOL . "ORDER BY a.id"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for the PgsqlQuery::__string method for a 'update' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringUpdate()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->update('#__foo AS a')
+			->join('INNER', 'b ON b.id = a.id')
+			->set('a.id = 2')
+			->where('b.id = 1');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . "UPDATE #__foo AS a" .
+				PHP_EOL . "SET a.id = 2" .
+				PHP_EOL . "FROM b" .
+				PHP_EOL . "WHERE b.id = 1 AND b.id = a.id"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for year extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringYear()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->year($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (YEAR FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for month extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringMonth()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->month($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (MONTH FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for day extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringDay()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->day($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (DAY FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for hour extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringHour()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->hour($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (HOUR FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for minute extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringMinute()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->minute($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (MINUTE FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for seconds extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringSecond()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$q->select($q->second($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "SELECT EXTRACT (SECOND FROM \"col\")" . PHP_EOL . "FROM table")
+		);
+	}
+
+	/**
+	 * Test for INSERT INTO clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function test__toStringInsert_subquery()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$subq = new PgsqlQuery($this->dbo);
+		$subq->select('col2')->where('a=1');
+
+		$q->insert('table')->columns('col')->values($subq);
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "INSERT INTO table" . PHP_EOL . "(col)" . PHP_EOL . "(" . PHP_EOL . "SELECT col2" . PHP_EOL . "WHERE a=1)")
+		);
+
+		$q->clear();
+		$q->insert('table')->columns('col')->values('3');
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "INSERT INTO table" . PHP_EOL . "(col) VALUES " . PHP_EOL . "(3)")
+		);
+	}
+
+	/**
+	 * Test for the castAsChar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testCastAsChar()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->castAsChar('123'),
+			$this->equalTo('123::text'),
+			'The default castAsChar behaviour is quote the input.'
+		);
+	}
+
+	/**
+	 * Test for the charLength method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testCharLength()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->charLength('a.title'),
+			$this->equalTo('CHAR_LENGTH(a.title)')
+		);
+	}
+
+	/**
+	 * Test chaining.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testChaining()
+	{
+		$q = $this->dbo->getQuery(true)->select('foo');
+
+		$this->assertThat(
+			$q,
+			$this->isInstanceOf('\Joomla\Database\DatabaseQuery')
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing all types and clauses).
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testClear_all()
+	{
+		$properties = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		$q = new PgsqlQuery($this->dbo);
+
+		// First pass - set the values.
+		foreach ($properties as $property)
+		{
+			TestHelper::setValue($q, $property, $property);
+		}
+
+		// Clear the whole query.
+		$q->clear();
+
+		// Check that all properties have been cleared
+		foreach ($properties as $property)
+		{
+			$this->assertThat(
+				$q->$property,
+				$this->equalTo(null)
+			);
+		}
+
+		// And check that the type has been cleared.
+		$this->assertThat(
+			$q->type,
+			$this->equalTo(null)
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing each clause).
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testClear_clause()
+	{
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		// Test each clause.
+		foreach ($clauses as $clause)
+		{
+			$q = new PgsqlQuery($this->dbo);
+
+			// Set the clauses
+			foreach ($clauses as $clause2)
+			{
+				TestHelper::setValue($q, $clause2, $clause2);
+			}
+
+			// Clear the clause.
+			$q->clear($clause);
+
+			// Check that clause was cleared.
+			$this->assertThat(
+				$q->$clause,
+				$this->equalTo(null)
+			);
+
+			// Check the state of the other clauses.
+			foreach ($clauses as $clause2)
+			{
+				if ($clause != $clause2)
+				{
+					$this->assertThat(
+						$q->$clause2,
+						$this->equalTo($clause2),
+						"Clearing '$clause' resulted in '$clause2' having a value of " . $q->$clause2 . '.'
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Test for the clear method (clearing each query type).
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testClear_type()
+	{
+		$types = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+		);
+
+		$q = new PgsqlQuery($this->dbo);
+
+		// Set the clauses.
+		foreach ($clauses as $clause)
+		{
+			TestHelper::setValue($q, $clause, $clause);
+		}
+
+		// Check that all properties have been cleared
+		foreach ($types as $type)
+		{
+			// Set the type.
+			TestHelper::setValue($q, $type, $type);
+
+			// Clear the type.
+			$q->clear($type);
+
+			// Check the type has been cleared.
+			$this->assertThat(
+				$q->type,
+				$this->equalTo(null)
+			);
+
+			$this->assertThat(
+				$q->$type,
+				$this->equalTo(null)
+			);
+
+			// Now check the claues have not been affected.
+			foreach ($clauses as $clause)
+			{
+				$this->assertThat(
+					$q->$clause,
+					$this->equalTo($clause)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Test for "concatenate" words.
+	 *
+	 * @return  void
+	 */
+	public function testConcatenate()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar')),
+			$this->equalTo('foo || bar'),
+			'Tests without separator.'
+		);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar'), ' and '),
+			$this->equalTo("foo || '_ and _' || bar"),
+			'Tests without separator.'
+		);
+	}
+
+	/**
+	 * Test for FROM clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testFrom()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->from('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->from('#__bar');
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo,#__bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for GROUP clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testGroup()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->group('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->group('bar');
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo,bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for HAVING clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testHaving()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->having('COUNT(foo) > 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 AND COUNT(bar) > 2'),
+			'Tests rendered value after second use.'
+		);
+
+		// Reset the field to test the glue.
+		TestHelper::setValue($q, 'having', null);
+		$q->having('COUNT(foo) > 1', 'OR');
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 OR COUNT(bar) > 2'),
+			'Tests rendered value with OR glue.'
+		);
+	}
+
+	/**
+	 * Test for INNER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testInnerJoin()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$q2 = new PgsqlQuery($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->innerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('INNER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for JOIN clause using dataprovider to test all types of join.
+	 *
+	 * @param   string  $type        Type of JOIN, could be INNER, OUTER, LEFT, RIGHT
+	 * @param   string  $conditions  Join condition
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @dataProvider  dataTestJoin
+	 */
+	public function testJoin($type, $conditions)
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->join('INNER', 'foo ON foo.id = bar.id'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->join[0]),
+			$this->equalTo('INNER JOIN foo ON foo.id = bar.id'),
+			'Tests that first join renders correctly.'
+		);
+
+		$q->join('OUTER', 'goo ON goo.id = car.id');
+
+		$this->assertThat(
+			trim($q->join[1]),
+			$this->equalTo('OUTER JOIN goo ON goo.id = car.id'),
+			'Tests that second join renders correctly.'
+		);
+	}
+
+	/**
+	 * Test for LEFT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLeftJoin()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$q2 = new PgsqlQuery($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->leftJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('LEFT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $quoted    The value of the quoted argument.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @dataProvider  dataTestNullDate
+	 */
+	public function testNullDate($quoted, $expected)
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->nullDate($quoted),
+			$this->equalTo($expected),
+			'The nullDate method should be a proxy for the JDatabase::getNullDate method.'
+		);
+	}
+
+	/**
+	 * Test for ORDER clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testOrder()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->order('column'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column'),
+			'Tests rendered value.'
+		);
+
+		$q->order('col2');
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column,col2'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for OUTER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testOuterJoin()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$q2 = new PgsqlQuery($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->outerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('OUTER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $text      The value to be quoted.
+	 * @param   boolean  $escape    True to escape the string, false to leave it unchanged.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @dataProvider  dataTestQuote
+	 */
+	public function testQuote($text, $escape, $expected)
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->quote('test'),
+			$this->equalTo("'_test_'"),
+			'The quote method should be a proxy for the DatabaseDriver::quote method.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testQuoteName()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->quoteName('test'),
+			$this->equalTo('"test"'),
+			'The quoteName method should be a proxy for the DatabaseDriver::quoteName method.'
+		);
+	}
+
+	/**
+	 * Test for RIGHT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testRightJoin()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$q2 = new PgsqlQuery($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->rightJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('RIGHT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for SELECT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testSelect()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->select('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			$q->type,
+			$this->equalTo('select'),
+			'Tests the type property is set correctly.'
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo'),
+			'Tests the select element is set correctly.'
+		);
+
+		$q->select('bar');
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar'),
+			'Tests the second use appends correctly.'
+		);
+
+		$q->select(
+			array(
+				'goo', 'car'
+			)
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar,goo,car'),
+			'Tests the second use appends correctly.'
+		);
+	}
+
+	/**
+	 * Test for WHERE clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testWhere()
+	{
+		$q = new PgsqlQuery($this->dbo);
+		$this->assertThat(
+			$q->where('foo = 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			)
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Clear the where
+		TestHelper::setValue($q, 'where', null);
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			),
+			'OR'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE bar = 2 OR goo = 3'),
+			'Tests rendered value with glue.'
+		);
+	}
+
+	/**
+	 * Tests the PgsqlQuery::escape method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testEscape()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->escape('foo'),
+			$this->equalTo('foo')
+		);
+	}
+
+	/**
+	 * Test for FOR UPDATE clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testForUpdate ()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->forUpdate('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo'),
+			'Tests rendered value.'
+		);
+
+		$q->forUpdate('#__bar');
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo, #__bar'),
+			'Tests rendered value.'
+		);
+
+		// Testing glue
+		TestHelper::setValue($q, 'forUpdate', null);
+		$q->forUpdate('#__foo', ';');
+		$q->forUpdate('#__bar');
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo; #__bar'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for FOR SHARE clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testForShare ()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->forShare('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo'),
+			'Tests rendered value.'
+		);
+
+		$q->forShare('#__bar');
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo, #__bar'),
+			'Tests rendered value.'
+		);
+
+		// Testing glue
+		TestHelper::setValue($q, 'forShare', null);
+		$q->forShare('#__foo', ';');
+		$q->forShare('#__bar');
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo; #__bar'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for NOWAIT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testNoWait ()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->noWait(),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->noWait),
+			$this->equalTo('NOWAIT'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for LIMIT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testLimit()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->limit('5'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->limit),
+			$this->equalTo('LIMIT 5'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for OFFSET clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testOffset()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->offset('10'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->offset),
+			$this->equalTo('OFFSET 10'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for RETURNING clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testReturning()
+	{
+		$q = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$q->returning('id'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->returning),
+			$this->equalTo('RETURNING id'),
+			'Tests rendered value.'
+		);
+	}
+}

--- a/phpunit.travis.xml
+++ b/phpunit.travis.xml
@@ -4,6 +4,7 @@
 	<php>
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
+		<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
 		<!--<const name="JTEST_DATABASE_ORACLE_DSN" value="host=localhost;port=1521;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />-->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
 	<php>
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
+		<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_ORACLE_DSN" value="host=localhost;port=1521;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -186,7 +186,7 @@ class MysqlDriver extends PdoDriver
 	 */
 	public static function isSupported()
 	{
-		return in_array('mysql', \PDO::getAvailableDrivers());
+		return class_exists('\\PDO') && in_array('mysql', \PDO::getAvailableDrivers());
 	}
 
 	/**
@@ -361,20 +361,6 @@ class MysqlDriver extends PdoDriver
 		$tables = $this->loadColumn();
 
 		return $tables;
-	}
-
-	/**
-	 * Get the version of the database connector.
-	 *
-	 * @return  string  The database connector version.
-	 *
-	 * @since   1.0
-	 */
-	public function getVersion()
-	{
-		$this->connect();
-
-		return $this->getOption(\PDO::ATTR_SERVER_VERSION);
 	}
 
 	/**

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -94,8 +94,7 @@ abstract class PdoDriver extends DatabaseDriver
 	 */
 	public function __destruct()
 	{
-		$this->freeResult();
-		unset($this->connection);
+		$this->disconnect();
 	}
 
 	/**
@@ -316,7 +315,8 @@ abstract class PdoDriver extends DatabaseDriver
 	public function disconnect()
 	{
 		$this->freeResult();
-		unset($this->connection);
+
+		$this->connection = null;
 	}
 
 	/**
@@ -486,6 +486,20 @@ abstract class PdoDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Get the version of the database connector.
+	 *
+	 * @return  string  The database connector version.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getVersion()
+	{
+		$this->connect();
+
+		return $this->getOption(\PDO::ATTR_SERVER_VERSION);
+	}
+
+	/**
 	 * Get a query to run and verify the database is operational.
 	 *
 	 * @return  string  The query to check the health of the DB.
@@ -598,10 +612,8 @@ abstract class PdoDriver extends DatabaseDriver
 		{
 			return $this->prepared->rowCount();
 		}
-		else
-		{
-			return 0;
-		}
+
+		return 0;
 	}
 
 	/**
@@ -621,14 +633,13 @@ abstract class PdoDriver extends DatabaseDriver
 		{
 			return $cursor->rowCount();
 		}
-		elseif ($this->prepared instanceof \PDOStatement)
+
+		if ($this->prepared instanceof \PDOStatement)
 		{
 			return $this->prepared->rowCount();
 		}
-		else
-		{
-			return 0;
-		}
+
+		return 0;
 	}
 
 	/**

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -1,0 +1,973 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Pgsql;
+
+use Joomla\Database\Pdo\PdoDriver;
+use Psr\Log;
+
+/**
+ * PostgreSQL PDO Database Driver
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PgsqlDriver extends PdoDriver
+{
+	/**
+	 * The database driver name
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $name = 'pgsql';
+
+	/**
+	 * The character(s) used to quote SQL statement names such as table names or field names,
+	 * etc. The child classes should define this as necessary.  If a single character string the
+	 * same character is used for both sides of the quoted name, else the first character will be
+	 * used for the opening quote and the second for the closing quote.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nameQuote = '"';
+
+	/**
+	 * The null or zero representation of a timestamp for the database driver.  This should be
+	 * defined in child classes to hold the appropriate value for the engine.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDate = '1970-01-01 00:00:00';
+
+	/**
+	 * The minimum supported database version.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $dbMinimum = '8.3.18';
+
+	/**
+	 * Operator used for concatenation
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $concat_operator = '||';
+
+	/**
+	 * Database object constructor
+	 *
+	 * @param   array  $options  List of options used to configure the connection
+	 *
+	 * @since	__DEPLOY_VERSION__
+	 */
+	public function __construct($options)
+	{
+		$options['driver']   = 'pgsql';
+		$options['host']     = (isset($options['host'])) ? $options['host'] : 'localhost';
+		$options['user']     = (isset($options['user'])) ? $options['user'] : '';
+		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
+		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
+		$options['port']     = (isset($options['port'])) ? $options['port'] : null;
+
+		// Finalize initialization
+		parent::__construct($options);
+	}
+
+	/**
+	 * Connects to the database if needed.
+	 *
+	 * @return  void  Returns void if the database connected successfully.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function connect()
+	{
+		if ($this->getConnection())
+		{
+			return;
+		}
+
+		parent::connect();
+
+		$this->setQuery('SET standard_conforming_strings = off')->execute();
+	}
+
+	/**
+	 * Disconnects the database.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function disconnect()
+	{
+		// Close the connection.
+		if (is_resource($this->connection))
+		{
+			pg_close($this->connection);
+		}
+
+		$this->connection = null;
+	}
+
+	/**
+	 * Drops a table from the database.
+	 *
+	 * @param   string   $tableName  The name of the database table to drop.
+	 * @param   boolean  $ifExists   Optionally specify that the table must exist before it is dropped.
+	 *
+	 * @return  boolean	true
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function dropTable($tableName, $ifExists = true)
+	{
+		$this->setQuery('DROP TABLE ' . ($ifExists ? 'IF EXISTS ' : '') . $this->quoteName($tableName))->execute();
+
+		return true;
+	}
+
+	/**
+	 * Method to get the database collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database or boolean false if not supported.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getCollation()
+	{
+		$this->setQuery('SHOW LC_COLLATE');
+		$array = $this->loadAssocList();
+
+		return $array[0]['lc_collate'];
+	}
+
+	/**
+	 * Shows the table CREATE statement that creates the given tables.
+	 *
+	 * This is unsuported by PostgreSQL.
+	 *
+	 * @param   mixed  $tables  A table name or a list of table names.
+	 *
+	 * @return  string  An empty string because this function is not supported by PostgreSQL.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getTableCreate($tables)
+	{
+		return '';
+	}
+
+	/**
+	 * Retrieves field information about a given table.
+	 *
+	 * @param   string   $table     The name of the database table.
+	 * @param   boolean  $typeOnly  True to only return field types.
+	 *
+	 * @return  array  An array of fields for the database table.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getTableColumns($table, $typeOnly = true)
+	{
+		$this->connect();
+
+		$result = array();
+
+		$tableSub = $this->replacePrefix($table);
+
+		$this->setQuery('
+			SELECT a.attname AS "column_name",
+				pg_catalog.format_type(a.atttypid, a.atttypmod) as "type",
+				CASE WHEN a.attnotnull IS TRUE
+					THEN \'NO\'
+					ELSE \'YES\'
+				END AS "null",
+				CASE WHEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true) IS NOT NULL
+					THEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true)
+				END as "Default",
+				CASE WHEN pg_catalog.col_description(a.attrelid, a.attnum) IS NULL
+				THEN \'\'
+				ELSE pg_catalog.col_description(a.attrelid, a.attnum)
+				END  AS "comments"
+			FROM pg_catalog.pg_attribute a
+			LEFT JOIN pg_catalog.pg_attrdef adef ON a.attrelid=adef.adrelid AND a.attnum=adef.adnum
+			LEFT JOIN pg_catalog.pg_type t ON a.atttypid=t.oid
+			WHERE a.attrelid =
+				(SELECT oid FROM pg_catalog.pg_class WHERE relname=' . $this->quote($tableSub) . '
+					AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE
+					nspname = \'public\')
+				)
+			AND a.attnum > 0 AND NOT a.attisdropped
+			ORDER BY a.attnum'
+		);
+
+		$fields = $this->loadObjectList();
+
+		if ($typeOnly)
+		{
+			foreach ($fields as $field)
+			{
+				$result[$field->column_name] = preg_replace("/[(0-9)]/", '', $field->type);
+			}
+		}
+		else
+		{
+			foreach ($fields as $field)
+			{
+				// Do some dirty translation to MySQL output.
+				// @todo: Come up with and implement a standard across databases.
+				$result[$field->column_name] = (object) array(
+					'column_name' => $field->column_name,
+					'type' => $field->type,
+					'null' => $field->null,
+					'Default' => $field->Default,
+					'comments' => '',
+					'Field' => $field->column_name,
+					'Type' => $field->type,
+					'Null' => $field->null,
+					// @todo: Improve query above to return primary key info as well
+					// 'Key' => ($field->PK == '1' ? 'PRI' : '')
+				);
+			}
+		}
+
+		// Change Postgresql's NULL::* type with PHP's null one
+		foreach ($fields as $field)
+		{
+			if (preg_match("/^NULL::*/", $field->Default))
+			{
+				$field->Default = null;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  array  An array of the column specification for the table.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getTableKeys($table)
+	{
+		$this->connect();
+
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		if (in_array($table, $tableList))
+		{
+			// Get the details columns information.
+			$this->setQuery('
+				SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique",
+					CASE WHEN indisprimary = true THEN
+						( SELECT \'ALTER TABLE \' || tablename || \' ADD \' || pg_catalog.pg_get_constraintdef(const.oid, true)
+							FROM pg_constraint AS const WHERE const.conname= pgClassFirst.relname )
+					ELSE pg_catalog.pg_get_indexdef(indexrelid, 0, true)
+					END AS "Query"
+				FROM pg_indexes
+				LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
+				LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
+				WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
+			);
+
+			return $this->loadObjectList();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Method to get an array of all tables in the database.
+	 *
+	 * @return  array  An array of all the tables in the database.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getTableList()
+	{
+		$query = $this->getQuery(true)
+			->select('table_name')
+			->from('information_schema.tables')
+			->where('table_type = ' . $this->quote('BASE TABLE'))
+			->where('table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ')')
+			->order('table_name ASC');
+
+		$this->setQuery($query);
+
+		return $this->loadColumn();
+	}
+
+	/**
+	 * Get the details list of sequences for a table.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  array  An array of sequences specification for the table.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getTableSequences($table)
+	{
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		if (in_array($table, $tableList))
+		{
+			$name = array(
+				's.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type',
+				'info.minimum_value', 'info.maximum_value', 'info.increment', 'info.cycle_option'
+			);
+
+			$as = array('sequence', 'schema', 'table', 'column', 'data_type', 'minimum_value', 'maximum_value', 'increment', 'cycle_option');
+
+			if (version_compare($this->getVersion(), '9.1.0') >= 0)
+			{
+				$name[] .= 'info.start_value';
+				$as[] .= 'start_value';
+			}
+
+			// Get the details columns information.
+			$query = $this->getQuery(true)
+				->select($this->quoteName($name, $as))
+				->from('pg_class AS s')
+				->leftJoin("pg_depend d ON d.objid = s.oid AND d.classid = 'pg_class'::regclass AND d.refclassid = 'pg_class'::regclass")
+				->leftJoin('pg_class t ON t.oid = d.refobjid')
+				->leftJoin('pg_namespace n ON n.oid = t.relnamespace')
+				->leftJoin('pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid')
+				->leftJoin('information_schema.sequences AS info ON info.sequence_name = s.relname')
+				->where('s.relkind = ' . $this->quote('S') . ' AND d.deptype = ' . $this->quote('a') . ' AND t.relname = ' . $this->quote($table));
+			$this->setQuery($query);
+
+			return $this->loadObjectList();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Locks a table in the database.
+	 *
+	 * @param   string  $tableName  The name of the table to unlock.
+	 *
+	 * @return  PgsqlDriver  Returns this object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function lockTable($tableName)
+	{
+		$this->transactionStart();
+		$this->setQuery('LOCK TABLE ' . $this->quoteName($tableName) . ' IN ACCESS EXCLUSIVE MODE')->execute();
+
+		return $this;
+	}
+
+	/**
+	 * Renames a table in the database.
+	 *
+	 * @param   string  $oldTable  The name of the table to be renamed
+	 * @param   string  $newTable  The new name for the table.
+	 * @param   string  $backup    Not used by PostgreSQL.
+	 * @param   string  $prefix    Not used by PostgreSQL.
+	 *
+	 * @return  PgsqlDriver  Returns this object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function renameTable($oldTable, $newTable, $backup = null, $prefix = null)
+	{
+		$this->connect();
+
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		// Origin Table does not exist
+		if (!in_array($oldTable, $tableList))
+		{
+			// Origin Table not found
+			throw new \RuntimeException('Table not found in Postgresql database.');
+		}
+
+		// Rename indexes
+		$subQuery = $this->getQuery(true)
+			->select('indexrelid')
+			->from('pg_index, pg_class')
+			->where('pg_class.relname = ' . $this->quote($oldTable))
+			->where('pg_class.oid = pg_index.indrelid');
+
+		$this->setQuery(
+			$this->getQuery(true)
+				->select('relname')
+				->from('pg_class')
+				->where('oid IN (' . (string) $subQuery . ')')
+		);
+
+		$oldIndexes = $this->loadColumn();
+
+		foreach ($oldIndexes as $oldIndex)
+		{
+			$changedIdxName = str_replace($oldTable, $newTable, $oldIndex);
+			$this->setQuery('ALTER INDEX ' . $this->escape($oldIndex) . ' RENAME TO ' . $this->escape($changedIdxName))->execute();
+		}
+
+		// Rename sequences
+		$subQuery = $this->getQuery(true)
+			->select('oid')
+			->from('pg_namespace')
+			->where('nspname NOT LIKE ' . $this->quote('pg_%'))
+			->where('nspname != ' . $this->quote('information_schema'));
+
+		$this->setQuery(
+			$this->getQuery(true)
+				->select('relname')
+				->from('pg_class')
+				->where('relkind = ' . $this->quote('S'))
+				->where('relnamespace IN (' . (string) $subQuery . ')')
+				->where('relname LIKE ' . $this->quote("%$oldTable%"))
+		);
+
+		$oldSequences = $this->loadColumn();
+
+		foreach ($oldSequences as $oldSequence)
+		{
+			$changedSequenceName = str_replace($oldTable, $newTable, $oldSequence);
+			$this->setQuery('ALTER SEQUENCE ' . $this->escape($oldSequence) . ' RENAME TO ' . $this->escape($changedSequenceName))->execute();
+		}
+
+		// Rename table
+		$this->setQuery('ALTER TABLE ' . $this->escape($oldTable) . ' RENAME TO ' . $this->escape($newTable))->execute();
+
+		return true;
+	}
+
+	/**
+	 * This function return a field value as a prepared string to be used in a SQL statement.
+	 *
+	 * @param   array   $columns      Array of table's column returned by ::getTableColumns.
+	 * @param   string  $field_name   The table field's name.
+	 * @param   string  $field_value  The variable value to quote and return.
+	 *
+	 * @return  string  The quoted string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function sqlValue($columns, $field_name, $field_value)
+	{
+		switch ($columns[$field_name])
+		{
+			case 'boolean':
+				$val = 'NULL';
+
+				if ($field_value == 't')
+				{
+					$val = 'TRUE';
+				}
+				elseif ($field_value == 'f')
+				{
+					$val = 'FALSE';
+				}
+				break;
+
+			case 'bigint':
+			case 'bigserial':
+			case 'integer':
+			case 'money':
+			case 'numeric':
+			case 'real':
+			case 'smallint':
+			case 'serial':
+			case 'numeric,':
+				$val = strlen($field_value) == 0 ? 'NULL' : $field_value;
+				break;
+
+			case 'date':
+			case 'timestamp without time zone':
+				if (empty($field_value))
+				{
+					$field_value = $this->getNullDate();
+				}
+
+				$val = $this->quote($field_value);
+
+				break;
+
+			default:
+				$val = $this->quote($field_value);
+				break;
+		}
+
+		return $val;
+	}
+
+	/**
+	 * Method to commit a transaction.
+	 *
+	 * @param   boolean  $toSavepoint  If true, commit to the last savepoint.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function transactionCommit($toSavepoint = false)
+	{
+		$this->connect();
+
+		if (!$toSavepoint || $this->transactionDepth <= 1)
+		{
+			parent::transactionCommit($toSavepoint);
+		}
+		else
+		{
+			$this->transactionDepth--;
+		}
+	}
+
+	/**
+	 * Method to roll back a transaction.
+	 *
+	 * @param   boolean  $toSavepoint  If true, rollback to the last savepoint.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function transactionRollback($toSavepoint = false)
+	{
+		$this->connect();
+
+		if (!$toSavepoint || $this->transactionDepth <= 1)
+		{
+			parent::transactionRollback($toSavepoint);
+		}
+		else
+		{
+			$savepoint = 'SP_' . ($this->transactionDepth - 1);
+			$this->setQuery('ROLLBACK TO SAVEPOINT ' . $this->quoteName($savepoint));
+
+			if ($this->execute())
+			{
+				$this->transactionDepth--;
+				$this->setQuery('RELEASE SAVEPOINT ' . $this->quoteName($savepoint))->execute();
+			}
+		}
+	}
+
+	/**
+	 * Method to initialize a transaction.
+	 *
+	 * @param   boolean  $asSavepoint  If true and a transaction is already active, a savepoint will be created.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function transactionStart($asSavepoint = false)
+	{
+		$this->connect();
+
+		if (!$asSavepoint || !$this->transactionDepth)
+		{
+			parent::transactionStart($asSavepoint);
+		}
+		else
+		{
+			$savepoint = 'SP_' . $this->transactionDepth;
+			$this->setQuery('SAVEPOINT ' . $this->quoteName($savepoint));
+
+			if ($this->execute())
+			{
+				$this->transactionDepth++;
+			}
+		}
+	}
+
+	/**
+	 * Inserts a row into a table based on an object's properties.
+	 *
+	 * @param   string  $table    The name of the database table to insert into.
+	 * @param   object  &$object  A reference to an object whose public properties match the table fields.
+	 * @param   string  $key      The name of the primary key. If provided the object property is updated.
+	 *
+	 * @return  boolean    True on success.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function insertObject($table, &$object, $key = null)
+	{
+		$columns = $this->getTableColumns($table);
+
+		$fields = array();
+		$values = array();
+
+		// Iterate over the object variables to build the query fields and values.
+		foreach (get_object_vars($object) as $k => $v)
+		{
+			// Skip columns that don't exist in the table.
+			if (! array_key_exists($k, $columns))
+			{
+				continue;
+			}
+
+			// Only process non-null scalars.
+			if (is_array($v) or is_object($v) or $v === null)
+			{
+				continue;
+			}
+
+			// Ignore any internal fields or primary keys with value 0.
+			if (($k[0] == "_") || ($k == $key && $v === 0))
+			{
+				continue;
+			}
+
+			// Prepare and sanitize the fields and values for the database query.
+			$fields[] = $this->quoteName($k);
+			$values[] = $this->sqlValue($columns, $k, $v);
+		}
+
+		// Create the base insert statement.
+		$query = $this->getQuery(true);
+
+		$query->insert($this->quoteName($table))
+			->columns($fields)
+			->values(implode(',', $values));
+
+		$retVal = false;
+
+		if ($key)
+		{
+			$query->returning($key);
+
+			// Set the query and execute the insert.
+			$this->setQuery($query);
+
+			$id = $this->loadResult();
+
+			if ($id)
+			{
+				$object->$key = $id;
+				$retVal = true;
+			}
+		}
+		else
+		{
+			// Set the query and execute the insert.
+			$this->setQuery($query);
+
+			if ($this->execute())
+			{
+				$retVal = true;
+			}
+		}
+
+		return $retVal;
+	}
+
+	/**
+	 * Test to see if the PostgreSQL connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isSupported()
+	{
+		return class_exists('\\PDO') && in_array('pgsql', \PDO::getAvailableDrivers());
+	}
+
+	/**
+	 * Returns an array containing database's table list.
+	 *
+	 * @return  array  The database's table list.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function showTables()
+	{
+		$query = $this->getQuery(true)
+			->select('table_name')
+			->from('information_schema.tables')
+			->where('table_type=' . $this->quote('BASE TABLE'))
+			->where('table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ' )');
+
+		$this->setQuery($query);
+
+		return $this->loadColumn();
+	}
+
+	/**
+	 * Get the substring position inside a string
+	 *
+	 * @param   string  $substring  The string being sought
+	 * @param   string  $string     The string/column being searched
+	 *
+	 * @return  integer  The position of $substring in $string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getStringPositionSql($substring, $string)
+	{
+		$this->setQuery("SELECT POSITION($substring IN $string)");
+		$position = $this->loadRow();
+
+		return $position['position'];
+	}
+
+	/**
+	 * Generate a random value
+	 *
+	 * @return  float  The random generated number
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getRandom()
+	{
+		$this->setQuery('SELECT RANDOM()');
+		$random = $this->loadAssoc();
+
+		return $random['random'];
+	}
+
+	/**
+	 * Get the query string to alter the database character set.
+	 *
+	 * @param   string  $dbName  The database name
+	 *
+	 * @return  string  The query that alter the database query string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAlterDbCharacterSet($dbName)
+	{
+		return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' SET CLIENT_ENCODING TO ' . $this->quote('UTF8');
+	}
+
+	/**
+	 * Get the query string to create new Database in correct PostgreSQL syntax.
+	 *
+	 * @param   object   $options  object coming from "initialise" function to pass user and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set, not used in PostgreSQL "CREATE DATABASE" query.
+	 *
+	 * @return  string	The query that creates database, owned by $options['user']
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getCreateDbQuery($options, $utf)
+	{
+		$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' OWNER ' . $this->quoteName($options->db_user);
+
+		if ($utf)
+		{
+			$query .= ' ENCODING ' . $this->quote('UTF-8');
+		}
+
+		return $query;
+	}
+
+	/**
+	 * This function replaces a string identifier <var>$prefix</var> with the string held is the <var>tablePrefix</var> class variable.
+	 *
+	 * @param   string  $sql     The SQL statement to prepare.
+	 * @param   string  $prefix  The common table prefix.
+	 *
+	 * @return  string  The processed SQL statement.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function replacePrefix($sql, $prefix = '#__')
+	{
+		$sql = trim($sql);
+
+		if (strpos($sql, '\''))
+		{
+			// Sequence name quoted with ' ' but need to be replaced
+			if (strpos($sql, 'currval'))
+			{
+				$sql = explode('currval', $sql);
+
+				for ($nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2)
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+
+				$sql = implode('currval', $sql);
+			}
+
+			// Sequence name quoted with ' ' but need to be replaced
+			if (strpos($sql, 'nextval'))
+			{
+				$sql = explode('nextval', $sql);
+
+				for ($nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2)
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+
+				$sql = implode('nextval', $sql);
+			}
+
+			// Sequence name quoted with ' ' but need to be replaced
+			if (strpos($sql, 'setval'))
+			{
+				$sql = explode('setval', $sql);
+
+				for ($nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2)
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+
+				$sql = implode('setval', $sql);
+			}
+
+			$explodedQuery = explode('\'', $sql);
+
+			for ($nIndex = 0; $nIndex < count($explodedQuery); $nIndex = $nIndex + 2)
+			{
+				if (strpos($explodedQuery[$nIndex], $prefix))
+				{
+					$explodedQuery[$nIndex] = str_replace($prefix, $this->tablePrefix, $explodedQuery[$nIndex]);
+				}
+			}
+
+			$replacedQuery = implode('\'', $explodedQuery);
+		}
+		else
+		{
+			$replacedQuery = str_replace($prefix, $this->tablePrefix, $sql);
+		}
+
+		return $replacedQuery;
+	}
+
+	/**
+	 * Unlocks tables in the database, this command does not exist in PostgreSQL, it is automatically done on commit or rollback.
+	 *
+	 * @return  PgsqlDriver  Returns this object to support chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function unlockTables()
+	{
+		$this->transactionCommit();
+
+		return $this;
+	}
+
+	/**
+	 * Updates a row in a table based on an object's properties.
+	 *
+	 * @param   string   $table    The name of the database table to update.
+	 * @param   object   &$object  A reference to an object whose public properties match the table fields.
+	 * @param   array    $key      The name of the primary key.
+	 * @param   boolean  $nulls    True to update null fields or false to ignore them.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function updateObject($table, &$object, $key, $nulls = false)
+	{
+		$columns = $this->getTableColumns($table);
+		$fields  = array();
+		$where   = array();
+
+		if (is_string($key))
+		{
+			$key = array($key);
+		}
+
+		if (is_object($key))
+		{
+			$key = (array) $key;
+		}
+
+		// Create the base update statement.
+		$statement = 'UPDATE ' . $this->quoteName($table) . ' SET %s WHERE %s';
+
+		// Iterate over the object variables to build the query fields/value pairs.
+		foreach (get_object_vars($object) as $k => $v)
+		{
+			// Skip columns that don't exist in the table.
+			if (! array_key_exists($k, $columns))
+			{
+				continue;
+			}
+
+			// Only process scalars that are not internal fields.
+			if (is_array($v) or is_object($v) or $k[0] == '_')
+			{
+				continue;
+			}
+
+			// Set the primary key to the WHERE clause instead of a field to update.
+			if (in_array($k, $key))
+			{
+				$key_val = $this->sqlValue($columns, $k, $v);
+				$where[] = $this->quoteName($k) . '=' . $key_val;
+				continue;
+			}
+
+			// Prepare and sanitize the fields and values for the database query.
+			if ($v === null)
+			{
+				// If the value is null and we do not want to update nulls then ignore this field.
+				if (!$nulls)
+				{
+					continue;
+				}
+
+				// If the value is null and we want to update nulls then set it.
+				$val = 'NULL';
+			}
+			else
+			// The field is not null so we prep it for update.
+			{
+				$val = $this->sqlValue($columns, $k, $v);
+			}
+
+			// Add the field to be updated.
+			$fields[] = $this->quoteName($k) . '=' . $val;
+		}
+
+		// We don't have any fields to update.
+		if (empty($fields))
+		{
+			return true;
+		}
+
+		// Set the query and execute the update.
+		$this->setQuery(sprintf($statement, implode(",", $fields), implode(' AND ', $where)));
+
+		return $this->execute();
+	}
+}

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -103,24 +103,6 @@ class PgsqlDriver extends PdoDriver
 	}
 
 	/**
-	 * Disconnects the database.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function disconnect()
-	{
-		// Close the connection.
-		if (is_resource($this->connection))
-		{
-			pg_close($this->connection);
-		}
-
-		$this->connection = null;
-	}
-
-	/**
 	 * Drops a table from the database.
 	 *
 	 * @param   string   $tableName  The name of the database table to drop.
@@ -229,6 +211,16 @@ class PgsqlDriver extends PdoDriver
 		{
 			foreach ($fields as $field)
 			{
+				if (stristr(strtolower($field->type), "character varying"))
+				{
+					$field->Default = "";
+				}
+
+				if (stristr(strtolower($field->type), "text"))
+				{
+					$field->Default = "";
+				}
+
 				// Do some dirty translation to MySQL output.
 				// @todo: Come up with and implement a standard across databases.
 				$result[$field->column_name] = (object) array(
@@ -643,7 +635,7 @@ class PgsqlDriver extends PdoDriver
 			}
 
 			// Ignore any internal fields or primary keys with value 0.
-			if (($k[0] == "_") || ($k == $key && $v === 0))
+			if (($k[0] == "_") || ($k == $key && (($v === 0) || ($v === '0'))))
 			{
 				continue;
 			}

--- a/src/Pgsql/PgsqlExporter.php
+++ b/src/Pgsql/PgsqlExporter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Pgsql;
+
+use Joomla\Database\Postgresql\PostgresqlExporter;
+
+/**
+ * PDO PostgreSQL Database Exporter.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PgsqlExporter extends PostgresqlExporter
+{
+	/**
+	 * Checks if all data and options are in order prior to exporting.
+	 *
+	 * @return  PgsqlExporter  Method supports chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception if an error is encountered.
+	 */
+	public function check()
+	{
+		// Check if the db connector has been set.
+		if (!($this->db instanceof PgsqlDriver))
+		{
+			throw new \Exception('Database connection wrong type.');
+		}
+
+		// Check if the tables have been specified.
+		if (empty($this->from))
+		{
+			throw new \Exception('ERROR: No Tables Specified');
+		}
+
+		return $this;
+	}
+}

--- a/src/Pgsql/PgsqlImporter.php
+++ b/src/Pgsql/PgsqlImporter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Pgsql;
+
+use Joomla\Database\Postgresql\PostgresqlImporter;
+
+/**
+ * PDO PostgreSQL Database Importer.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PgsqlImporter extends PostgresqlImporter
+{
+	/**
+	 * Checks if all data and options are in order prior to exporting.
+	 *
+	 * @return  PgsqlImporter  Method supports chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \Exception if an error is encountered.
+	 */
+	public function check()
+	{
+		// Check if the db connector has been set.
+		if (!($this->db instanceof PgsqlDriver))
+		{
+			throw new \Exception('Database connection wrong type.');
+		}
+
+		// Check if the tables have been specified.
+		if (empty($this->from))
+		{
+			throw new \Exception('ERROR: No Tables Specified');
+		}
+
+		return $this;
+	}
+}

--- a/src/Pgsql/PgsqlIterator.php
+++ b/src/Pgsql/PgsqlIterator.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Pgsql;
+
+use Joomla\Database\Pdo\PdoIterator;
+
+/**
+ * PDO PostgreSQL Database Iterator.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PgsqlIterator extends PdoIterator
+{
+}

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Pgsql;
+
+use Joomla\Database\Postgresql\PostgresqlQuery;
+use Joomla\Database\Query\PreparableInterface;
+
+/**
+ * PDO PostgreSQL Query Building Class.
+ *
+ * @since  1.0
+ */
+class PgsqlQuery extends PostgresqlQuery implements PreparableInterface
+{
+	/**
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bounded = array();
+
+	/**
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
+	 *
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
+	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
+	 * @param   array           $driverOptions  Optional driver options to be used.
+	 *
+	 * @return  PgsqlQuery
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function bind($key = null, &$value = null, $dataType = \PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	{
+		// Case 1: Empty Key (reset $bounded array)
+		if (empty($key))
+		{
+			$this->bounded = array();
+
+			return $this;
+		}
+
+		// Case 2: Key Provided, null value (unset key from $bounded array)
+		if (is_null($value))
+		{
+			if (isset($this->bounded[$key]))
+			{
+				unset($this->bounded[$key]);
+			}
+
+			return $this;
+		}
+
+		$obj = new \stdClass;
+
+		$obj->value = &$value;
+		$obj->dataType = $dataType;
+		$obj->length = $length;
+		$obj->driverOptions = $driverOptions;
+
+		// Case 3: Simply add the Key/Value into the bounded array
+		$this->bounded[$key] = $obj;
+
+		return $this;
+	}
+
+	/**
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
+	 *
+	 * @param   mixed  $key  The bounded variable key to retrieve.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function &getBounded($key = null)
+	{
+		if (empty($key))
+		{
+			return $this->bounded;
+		}
+
+		if (isset($this->bounded[$key]))
+		{
+			return $this->bounded[$key];
+		}
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  PgsqlQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case null:
+				$this->bounded = array();
+				break;
+		}
+
+		return parent::clear($clause);
+	}
+}


### PR DESCRIPTION
Creates a new database driver for using PostgreSQL with a PDO based connection.

Also moves the `MysqlDriver::getVersion()` method into the `PdoDriver` is this looks to be a generalized PDO function versus specific to that adapter.