### PR TITLE
Backport PR 10221 and PR 11198 from the CMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,31 @@ matrix:
       env: RUN_PHPCS="yes"
     - php: 7.0
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+        - postgresql
+        - redis-server
+      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
+    - php: 7.1
     - php: hhvm
 
 before_script:
   - composer self-update
   - composer update $COMPOSER_FLAGS
-  - mysql -e 'create database joomla_ut;'
-  - mysql joomla_ut < Tests/Stubs/mysql.sql
+  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then mysql -e 'create database joomla_ut;'; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhv* ]]; then mysql joomla_ut < Tests/Stubs/mysql.sql; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then mysql -u root -e 'create database joomla_ut;'; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then mysql -u root joomla_ut < Tests/Stubs/mysql.sql; fi
   - psql -c 'create database joomla_ut;' -U postgres
   - psql -d joomla_ut -a -f Tests/Stubs/postgresql.sql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
       services:
         - mysql
         - postgresql
-        - redis-server
   allow_failures:
     - php: 7.1
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: 7.1
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - php: 5.6
       env: RUN_PHPCS="yes"
     - php: 7.0
+    - php: 7.1
     - php: hhvm
       sudo: true
       dist: trusty


### PR DESCRIPTION
This PR Backports https://github.com/joomla/joomla-cms/pull/10221 and https://github.com/joomla/joomla-cms/pull/11198 from the CMS

This PR does not address the need for a PgSQL module for HHVM (a module that is version specific and not yet included in the core of HHVM)