### PR TITLE
Fix Travis Testing to get error reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,5 @@ before_script:
   - psql -d joomla_ut -a -f Tests/Stubs/postgresql.sql
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --configuration phpunit.travis.xml
   - if [ "$RUN_PHPCS" == "yes" ]; then vendor/bin/phpcs -p --report=full --extensions=php --standard=.travis/phpcs/Joomla/ruleset.xml src/; fi;

--- a/phpunit.travis.xml
+++ b/phpunit.travis.xml
@@ -4,7 +4,7 @@
 	<php>
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
-		<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
+		<!--<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />-->
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
 		<!--<const name="JTEST_DATABASE_ORACLE_DSN" value="host=localhost;port=1521;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />-->


### PR DESCRIPTION
Pull Request for Issue #43 

### Summary of Changes
- phpunit.travis.xml must be specified in .travis.yml since it's not automatically picked up by php unit
- `JTEST_DATABASE_PGSQL_DSN` is commented out since some of those tests cause php unit to fail to complete testing

### Testing Instructions
Review travis logs. The Travis build errors are fixed and you can now see the phpunit errors are reported

### Documentation Changes Required
none

### Additional notes
The following tests in `JTEST_DATABASE_PGSQL_DSN` are causing php unit to fail to complete testing; if `JTEST_DATABASE_PGSQL_DSN` was not commented out in `phpunit.travis.xml`.
- DriverPostgresqlTest::testRenameTable
- DriverPostgresqlTest::testTransactionStart
- DriverPostgresqlTest::testTransactionCommit
- DriverPostgresqlTest::testInsertObject
- DriverPostgresqlTest::testGetVersion
- DriverPostgresqlTest::testInsertid
- DriverPgsqlTest::testGetVersion
- DriverPgsqlTest::testInsertid
- DriverPgsqlTest::testRenameTable

These tests could be excluded from the test suit until they are fixed