### PR TITLE
Backport Set collation from CMS Schema

### DIFF
--- a/Tests/Stubs/mysql.sql
+++ b/Tests/Stubs/mysql.sql
@@ -7,6 +7,8 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
+/* Set collation */;
+ALTER DATABASE joomla_ut CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 # Dump of table jos_dbtest
 # ------------------------------------------------------------


### PR DESCRIPTION
Fixes collation issues in the unit test `getCollation` (solves 2 test failures DriverMysqlTest::testGetCollation and DriverMysqliTest::testGetCollation)
