### PR TITLE
Disable xdebug since travis is not doing code coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
     - php: hhvm
 
 before_script:
+  # Disable xdebug on php 7.0.* and lower.
+  - if [[ ( $TRAVIS_PHP_VERSION = 5.* ) || ( $TRAVIS_PHP_VERSION = 7.0 ) ]]; then phpenv config-rm xdebug.ini; fi
+
+  # Disable xdebug in hhvm.
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'xdebug.enable = 0' >> /etc/hhvm/php.ini; fi
+
   - composer self-update
   - composer update $COMPOSER_FLAGS
   - mysql -u root -e 'create database joomla_ut;'


### PR DESCRIPTION
Merge by code review, composer should no longer bark about xdebug running.