### PR TITLE
Remove `autocommit` from transactionStart

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -886,9 +886,6 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		// Disallow auto commit
-		$this->connection->autocommit(false);
-
 		if (!$asSavepoint || !$this->transactionDepth)
 		{
 			if ($this->executeUnpreparedQuery('START TRANSACTION'))


### PR DESCRIPTION
Pull Request for Issue #55 

#### Summary
Setting `autocommit(false)` is causing problems with the transactions

This fixes the four Mysqli Iterator tests

#### Additional notes
There are still 2 errors in the DriverPostgresqlTests
