### PR TITLE
Fix the PDO cursors

### DIFF
--- a/phpunit.travis.xml
+++ b/phpunit.travis.xml
@@ -4,7 +4,7 @@
 	<php>
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=root;pass=" />
-		<!--<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />-->
+		<const name="JTEST_DATABASE_PGSQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=postgres;pass=" />
 		<!--<const name="JTEST_DATABASE_ORACLE_DSN" value="host=localhost;port=1521;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />-->

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -684,7 +684,7 @@ abstract class PdoDriver extends DatabaseDriver
 	 *
 	 * @since   1.0
 	 */
-	public function setQuery($query, $offset = null, $limit = null, $driverOptions = array())
+	public function setQuery($query, $offset = null, $limit = null, $driverOptions = array(\PDO::ATTR_CURSOR => \PDO::CURSOR_SCROLL))
 	{
 		$this->connect();
 


### PR DESCRIPTION
Pull Request for Issues #53 and #54

### Summary of Changes
$driverOptions should default to array(\PDO::ATTR_CURSOR => \PDO::CURSOR_SCROLL)
http://www.dragonbe.com/2015/07/speeding-up-database-calls-with-pdo-and.html

> we need to ensure the cursor is now scrollable so we can use row by row control.

### Testing Instructions
Review Travis CI tests, we now have successful tests

Any real world use of the database package should work after applying this patch

### Documentation Changes Required
We many need to specify that the $driverOptions must include `\PDO::ATTR_CURSOR => \PDO::CURSOR_SCROLL` in the `array()` to ensure the cursor is now scrollable so we can use row by row control
