### PR TITLE
use object oriented style property

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -526,7 +526,7 @@ class MysqliDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return $this->connection->get_server_info();
+		return $this->connection->server_info;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue hhvm doesn't have the mysqli::get_server_info() method

### Summary of Changes
Replace Procedural style get with object oriented style property

### Testing Instructions
Travis tests pass and HHVM doesn't error

note: there is an issue with Travis CI trusty causing the following issue(s) with the Mysql and mysqli PDO portion of the drivers, We'll likely need to restart the tests at some point once travis fixes their issue
```php
PDOException: SQLSTATE[HY000] [2002] Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
```

### Documentation Changes Required
none
