### PR TITLE
Use $this->connection = null; rather than unset();

### DIFF
--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -46,7 +46,7 @@ class SqliteDriver extends PdoDriver
 	public function __destruct()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**
@@ -59,7 +59,7 @@ class SqliteDriver extends PdoDriver
 	public function disconnect()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue Use $this->connection = null; rather than unset();

### Summary of Changes
unset() will undeclare the class member variable, we don't want to do that.

### Testing Instructions
Merge by code review

### Documentation Changes Required
none
