### PR TITLE
Use $this->connection = null; rather than unset();

### DIFF
--- a/src/Oracle/OracleDriver.php
+++ b/src/Oracle/OracleDriver.php
@@ -81,7 +81,7 @@ class OracleDriver extends PdoDriver
 	public function __destruct()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**
@@ -120,7 +120,7 @@ class OracleDriver extends PdoDriver
 	{
 		// Close the connection.
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue Use $this->connection = null; rather than unset();

### Summary of Changes
Use $this->connection = null; rather than unset();
unset() will undeclare the class member variable, we don't want to do that.

### Testing Instructions
merge by code review

### Documentation Changes Required
none
