### PR TITLE
PostgreSQL - return the same string each time of call __toString() on update query with join

### DIFF
--- a/Tests/QueryPostgresqlTest.php
+++ b/Tests/QueryPostgresqlTest.php
@@ -169,22 +169,43 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function test__toStringUpdate()
 	{
-		$q = new PostgresqlQuery($this->dbo);
+		// Test on ugly query
+		$this->_instance
+			->update('#__foo AS a')
+			->join('INNER', "b\roN\nb.id = a.id")
+			->set('a.hits = 0');
 
-		$q->update('#__foo AS a')
+		$string = (string) $this->_instance;
+
+		$this->assertEquals(
+			PHP_EOL . "UPDATE #__foo AS a" .
+			PHP_EOL . "SET a.hits = 0" .
+			PHP_EOL . "FROM b" .
+			PHP_EOL . "WHERE b.id = a.id",
+			$string
+		);
+
+		$this->_instance
+			->clear()
+			->update('#__foo AS a')
 			->join('INNER', 'b ON b.id = a.id')
 			->set('a.id = 2')
 			->where('b.id = 1');
 
-		$this->assertThat(
-			(string) $q,
-			$this->equalTo(
-				PHP_EOL . "UPDATE #__foo AS a" .
-				PHP_EOL . "SET a.id = 2" .
-				PHP_EOL . "FROM b" .
-				PHP_EOL . "WHERE b.id = 1 AND b.id = a.id"
-			),
-			'Tests for correct rendering.'
+		$string = (string) $this->_instance;
+
+		$this->assertEquals(
+			PHP_EOL . "UPDATE #__foo AS a" .
+			PHP_EOL . "SET a.id = 2" .
+			PHP_EOL . "FROM b" .
+			PHP_EOL . "WHERE b.id = 1 AND b.id = a.id",
+			$string
+		);
+
+		// Run method __toString() again on the same query
+		$this->assertEquals(
+			$string,
+			(string) $this->_instance
 		);
 	}
 

--- a/Tests/QueryPostgresqlTest.php
+++ b/Tests/QueryPostgresqlTest.php
@@ -23,6 +23,14 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	protected $dbo;
 
 	/**
+	 * The instance of the object to test.
+	 *
+	 * @var    PostgresqlQuery
+	 * @since  _VERSION_NAME_
+	 */
+	private $_instance;
+
+	/**
 	 * Data for the testNullDate test.
 	 *
 	 * @return  array
@@ -107,6 +115,27 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Callback for the dbo getQuery method.
+	 *
+	 * @param   boolean  $new  True to get a new query, false to get the last query.
+	 *
+	 * @return  PostgresqlQuery
+	 *
+	 * @since   _VERSION_NAME_
+	 */
+	public function mockGetQuery($new = false)
+	{
+		if ($new)
+		{
+			return new PostgresqlQuery($this->dbo);
+		}
+		else
+		{
+			return $this->$lastQuery;
+		}
+	}
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 *
@@ -124,6 +153,24 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 			$this,
 			array('escape' => array($this, 'mockEscape'))
 		);
+
+		$this->_instance = new  PostgresqlQuery($this->dbo);
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   _VERSION_NAME_
+	 */
+	protected function tearDown()
+	{
+		unset($this->dbo);
+		unset($this->_instance);
+		parent::tearDown();
 	}
 
 	/**
@@ -142,7 +189,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 			->innerJoin('b ON b.id = a.id')
 			->where('b.id = 1')
 			->group('a.id')
-				->having('COUNT(a.id) > 3')
+			->having('COUNT(a.id) > 3')
 			->order('a.id');
 
 		$this->assertThat(
@@ -1097,7 +1144,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testForUpdate ()
+	public function testForUpdate()
 	{
 		$q = new PostgresqlQuery($this->dbo);
 
@@ -1138,7 +1185,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testForShare ()
+	public function testForShare()
 	{
 		$q = new PostgresqlQuery($this->dbo);
 
@@ -1179,7 +1226,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @since   1.0
 	 */
-	public function testNoWait ()
+	public function testNoWait()
 	{
 		$q = new PostgresqlQuery($this->dbo);
 

--- a/Tests/QueryPostgresqlTest.php
+++ b/Tests/QueryPostgresqlTest.php
@@ -26,9 +26,9 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 * The instance of the object to test.
 	 *
 	 * @var    PostgresqlQuery
-	 * @since  _VERSION_NAME_
+	 * @since  __DEPLOY_VERSION__
 	 */
-	private $_instance;
+	private $instance;
 
 	/**
 	 * Data for the testNullDate test.
@@ -121,7 +121,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return  PostgresqlQuery
 	 *
-	 * @since   _VERSION_NAME_
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function mockGetQuery($new = false)
 	{
@@ -154,7 +154,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 			array('escape' => array($this, 'mockEscape'))
 		);
 
-		$this->_instance = new  PostgresqlQuery($this->dbo);
+		$this->instance = new  PostgresqlQuery($this->dbo);
 	}
 
 	/**
@@ -164,12 +164,12 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	 * @return void
 	 *
 	 * @see     PHPUnit_Framework_TestCase::tearDown()
-	 * @since   _VERSION_NAME_
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function tearDown()
 	{
 		unset($this->dbo);
-		unset($this->_instance);
+		unset($this->instance);
 		parent::tearDown();
 	}
 
@@ -217,12 +217,12 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 	public function test__toStringUpdate()
 	{
 		// Test on ugly query
-		$this->_instance
+		$this->instance
 			->update('#__foo AS a')
 			->join('INNER', "b\roN\nb.id = a.id")
 			->set('a.hits = 0');
 
-		$string = (string) $this->_instance;
+		$string = (string) $this->instance;
 
 		$this->assertEquals(
 			PHP_EOL . "UPDATE #__foo AS a" .
@@ -232,14 +232,14 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 			$string
 		);
 
-		$this->_instance
+		$this->instance
 			->clear()
 			->update('#__foo AS a')
 			->join('INNER', 'b ON b.id = a.id')
 			->set('a.id = 2')
 			->where('b.id = 1');
 
-		$string = (string) $this->_instance;
+		$string = (string) $this->instance;
 
 		$this->assertEquals(
 			PHP_EOL . "UPDATE #__foo AS a" .
@@ -252,7 +252,7 @@ class QueryPostgresqlTest extends \PHPUnit_Framework_TestCase
 		// Run method __toString() again on the same query
 		$this->assertEquals(
 			$string,
-			(string) $this->_instance
+			(string) $this->instance
 		);
 	}
 

--- a/src/Postgresql/PostgresqlQuery.php
+++ b/src/Postgresql/PostgresqlQuery.php
@@ -213,23 +213,36 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface, Prepa
 
 				if ($this->join)
 				{
-					$onWord = ' ON ';
+					$tmpFrom     = $this->from;
+					$tmpWhere    = $this->where ? clone $this->where : null;
+					$this->from  = null;
 
 					// Workaround for special case of JOIN with UPDATE
 					foreach ($this->join as $join)
 					{
 						$joinElem = $join->getElements();
 
-						$joinArray = explode($onWord, $joinElem[0]);
+						$joinArray = preg_split('/\sON\s/i', $joinElem[0], 2);
 
 						$this->from($joinArray[0]);
-						$this->where($joinArray[1]);
+
+						if (isset($joinArray[1]))
+						{
+							$this->where($joinArray[1]);
+						}
 					}
 
 					$query .= (string) $this->from;
-				}
 
-				if ($this->where)
+					if ($this->where)
+					{
+						$query .= (string) $this->where;
+					}
+
+						$this->from  = $tmpFrom;
+						$this->where = $tmpWhere;
+				}
+				elseif ($this->where)
 				{
 					$query .= (string) $this->where;
 				}

--- a/src/Postgresql/PostgresqlQuery.php
+++ b/src/Postgresql/PostgresqlQuery.php
@@ -239,8 +239,8 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface, Prepa
 						$query .= (string) $this->where;
 					}
 
-						$this->from  = $tmpFrom;
-						$this->where = $tmpWhere;
+					$this->from  = $tmpFrom;
+					$this->where = $tmpWhere;
 				}
 				elseif ($this->where)
 				{


### PR DESCRIPTION
Pull Request for Issue - backports https://github.com/joomla/joomla-cms/pull/13284

- Update (with join) query (PostgresqlQuery) on each call method __toString() generates different string.

### Summary of Changes
- Fix PostgreSQL update query to return the same string each time of call method __toString()
### Testing Instructions
Test by travis.
Code review.
### Documentation Changes Required
none