### PR TITLE
Use preg_match to ensure just a version check

### DIFF
--- a/Tests/DriverPgsqlTest.php
+++ b/Tests/DriverPgsqlTest.php
@@ -460,11 +460,9 @@ class DriverPgsqlTest extends DatabasePgsqlCase
 	public function testGetVersion()
 	{
 		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
-		$versionArray = explode(' ', $versionRow[0]);
+		preg_match('/((\d+)\.)((\d+)\.)(\*|\d+)/', $versionRow[0], $versionArray);
 
-		$version = rtrim($versionArray[1], ',');
-
-		$this->assertGreaterThanOrEqual($version, self::$driver->getVersion(), __LINE__);
+		$this->assertGreaterThanOrEqual($versionArray[0], self::$driver->getVersion(), __LINE__);
 	}
 
 	/**

--- a/Tests/DriverPostgresqlTest.php
+++ b/Tests/DriverPostgresqlTest.php
@@ -460,11 +460,9 @@ class DriverPostgresqlTest extends DatabasePostgresqlCase
 	public function testGetVersion()
 	{
 		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
-		$versionArray = explode(' ', $versionRow[0]);
+		preg_match('/((\d+)\.)((\d+)\.)(\*|\d+)/', $versionRow[0], $versionArray);
 
-		$version = rtrim($versionArray[1], ',');
-
-		$this->assertGreaterThanOrEqual($version, self::$driver->getVersion(), __LINE__);
+		$this->assertGreaterThanOrEqual($versionArray[0], self::$driver->getVersion(), __LINE__);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Use preg_match to ensure just a version check

This could be considered a superfluous change, but I believe using preg_match to get a patterned number string is a more robust way of getting the version from the `SELECT version();` query

This method should be much less error prone due to the environment differences.

### Testing Instructions
code review, tests pass

