### PR TITLE
Prepared statement support for SQL Server

### DIFF
--- a/Tests/DriverSqlsrvTest.php
+++ b/Tests/DriverSqlsrvTest.php
@@ -485,6 +485,33 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 	}
 
 	/**
+	 * Test the execute method with a prepared statement
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testExecutePreparedStatement()
+	{
+		$title       = 'testTitle';
+		$startDate   = '2013-04-01 00:00:00.000';
+		$description = 'description';
+
+		/** @var \Joomla\Database\Sqlsrv\SqlsrvQuery $query */
+		$query = self::$driver->getQuery(true);
+		$query->insert('jos_dbtest')
+			->columns('title,start_date,description')
+			->values('?, ?, ?');
+		$query->bind(1, $title);
+		$query->bind(2, $startDate);
+		$query->bind(3, $description);
+
+		self::$driver->setQuery($query);
+
+		$this->assertNotEquals(self::$driver->execute(), false, __LINE__);
+	}
+
+	/**
 	 * Tests the renameTable method
 	 *
 	 * @return  void

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -10,6 +10,7 @@ namespace Joomla\Database\Sqlsrv;
 
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseQuery;
+use Joomla\Database\Query\PreparableInterface;
 use Joomla\Database\Query\QueryElement;
 
 /**
@@ -17,7 +18,7 @@ use Joomla\Database\Query\QueryElement;
  *
  * @since  1.0
  */
-class SqlsrvQuery extends DatabaseQuery
+class SqlsrvQuery extends DatabaseQuery implements PreparableInterface
 {
 	/**
 	 * The character(s) used to quote SQL statement names such as table names or field names,
@@ -38,6 +39,14 @@ class SqlsrvQuery extends DatabaseQuery
 	 * @since  1.0
 	 */
 	protected $null_date = '1900-01-01 00:00:00';
+
+	/**
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bounded = array();
 
 	/**
 	 * Magic function to convert the query to a string.
@@ -93,6 +102,96 @@ class SqlsrvQuery extends DatabaseQuery
 		}
 
 		return $query;
+	}
+
+	/**
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
+	 *
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
+	 * @param   string          $dataType       The corresponding bind type. (Unused)
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters. (Unused)
+	 * @param   array           $driverOptions  Optional driver options to be used. (Unused)
+	 *
+	 * @return  SqlsrvQuery
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function bind($key = null, &$value = null, $dataType = 's', $length = 0, $driverOptions = array())
+	{
+		// Case 1: Empty Key (reset $bounded array)
+		if (empty($key))
+		{
+			$this->bounded = array();
+
+			return $this;
+		}
+
+		// Case 2: Key Provided, null value (unset key from $bounded array)
+		if (is_null($value))
+		{
+			if (isset($this->bounded[$key]))
+			{
+				unset($this->bounded[$key]);
+			}
+
+			return $this;
+		}
+
+		$obj        = new \stdClass;
+		$obj->value = &$value;
+
+		// Case 3: Simply add the Key/Value into the bounded array
+		$this->bounded[$key] = $obj;
+
+		return $this;
+	}
+
+	/**
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
+	 *
+	 * @param   mixed  $key  The bounded variable key to retrieve.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function &getBounded($key = null)
+	{
+		if (empty($key))
+		{
+			return $this->bounded;
+		}
+
+		if (isset($this->bounded[$key]))
+		{
+			return $this->bounded[$key];
+		}
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  SqlsrvQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case null:
+				$this->bounded = array();
+				break;
+		}
+
+		return parent::clear($clause);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This completes having all of the package's drivers support prepared statements by adding support for the driver it was missing in; SQL Server.

### Testing Instructions

Use the `testExecutePreparedStatement` case as an example of how to bind variables for use in a prepared query.

### Documentation Changes Required

N/A