### PR TITLE
Kill the composer cache to prevent random errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,6 @@ environment:
   - dependencies: current
     php_ver_target: 7.1
 
-## Cache composer bits
-cache:
-    - '%LOCALAPPDATA%\Composer\files -> composer.lock'
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1


### PR DESCRIPTION
Pull Request for Issue `"./composer.lock" does not contain valid JSON` on appveyor caused by a random  randomly

### Summary of Changes
Kill the composer cache to prevent random `"./composer.lock" does not contain valid JSON` errors
### Testing Instructions
code review
### Documentation Changes Required
none