### PR TITLE
use Joomla location for the php5.6 SQLSRV dll file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,13 +32,13 @@ install:
         } Else {
           appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
         }
-    - cinst -y sqlite
+    - appveyor-retry cinst -y sqlite
     - cd c:\tools\php
     # Get the MSSQL DLL's
     - ps: >-
         If ($env:PHP -eq "1") {
           If ($env:php_ver_target -eq "5.6") {
-            appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
+            appveyor DownloadFile https://cdn.joomla.org/ci/php-sqlsrv.zip
             7z x php-sqlsrv.zip > $null
             copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
             copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll


### PR DESCRIPTION
Pull Request for Issue fix flaky download os php5.6 sqlsrv dll files

### Summary of Changes
use Joomla location for the php5.6 SQLSRV dll file
add appveyor-retry to the SQLite download

### Testing Instructions
unit tests pass
### Documentation Changes Required
none