### PR TITLE
Events, Monitoring, Remove Debug

### DIFF
--- a/Tests/DatabaseDriverTest.php
+++ b/Tests/DatabaseDriverTest.php
@@ -9,7 +9,6 @@ namespace Joomla\Database\Tests;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Test\TestHelper;
 use Joomla\Test\TestDatabase;
-use Psr\Log;
 
 require_once __DIR__ . '/Stubs/nosqldriver.php';
 
@@ -22,31 +21,6 @@ class DatabaseDriverTest extends TestDatabase
 	 * @var  DatabaseDriver
 	 */
 	protected $instance;
-
-	/**
-	 * A store to track if logging is working.
-	 *
-	 * @var  array
-	 */
-	protected $logs;
-
-	/**
-	 * Mocks the log method to track if logging is working.
-	 *
-	 * @param   Log\LogLevel  $level    The level.
-	 * @param   string        $message  The message.
-	 * @param   array         $context  The context.
-	 *
-	 * @return  void
-	 */
-	public function mockLog($level, $message, $context)
-	{
-		$this->logs[] = array(
-			'level' => $level,
-			'message' => $message,
-			'context' => $context,
-		);
-	}
 
 	/**
 	 * Test for the Joomla\Database\DatabaseDriver::__call method.
@@ -257,36 +231,6 @@ SQL
 			'12.1',
 			$this->instance->getMinimum()
 		);
-	}
-
-	/**
-	 * Tests the Driver::log method.
-	 *
-	 * @covers  Joomla\Database\DatabaseDriver::log
-	 * @covers  Joomla\Database\DatabaseDriver::setLogger
-	 */
-	public function testLog()
-	{
-		$this->logs = array();
-
-		$mockLogger = $this->getMockBuilder('Psr\Log\LoggerInterface')
-			->getMock();
-
-		$mockLogger->expects($this->any())
-			->method('log')
-			->willReturnCallback(array($this, 'mockLog'));
-
-		$this->instance->log(Log\LogLevel::DEBUG, 'Debug', array('sql' => true));
-
-		$this->assertEmpty($this->logs);
-
-		// Set the logger and try again.
-		$this->instance->setLogger($mockLogger);
-		$this->instance->log(Log\LogLevel::DEBUG, 'Debug', array('sql' => true));
-
-		$this->assertSame(Log\LogLevel::DEBUG, $this->logs[0]['level']);
-		$this->assertSame('Debug', $this->logs[0]['message']);
-		$this->assertSame(array('sql' => true), $this->logs[0]['context']);
 	}
 
 	/**

--- a/Tests/DatabaseDriverTest.php
+++ b/Tests/DatabaseDriverTest.php
@@ -242,17 +242,6 @@ SQL
 	}
 
 	/**
-	 * Tests the Joomla\Database\DatabaseDriver::setDebug method.
-	 */
-	public function testSetDebug()
-	{
-		$this->assertInternalType(
-			'boolean',
-			$this->instance->setDebug(true)
-		);
-	}
-
-	/**
 	 * Tests the Joomla\Database\DatabaseDriver::setQuery method.
 	 */
 	public function testSetQuery()

--- a/Tests/Mock/Driver.php
+++ b/Tests/Mock/Driver.php
@@ -53,7 +53,6 @@ class Driver
 			'getConnectors',
 			'getDateFormat',
 			'getInstance',
-			'getLog',
 			'getNullDate',
 			'getNumRows',
 			'getPrefix',

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "GPL-2.0+",
     "require": {
         "php": "^5.5.9|~7.0",
+        "joomla/event": "~2.0@dev",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -80,14 +80,6 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 	protected $cursor;
 
 	/**
-	 * The database driver debugging state.
-	 *
-	 * @var    boolean
-	 * @since  1.0
-	 */
-	protected $debug = false;
-
-	/**
 	 * The affected row limit for the current SQL statement.
 	 *
 	 * @var    integer
@@ -466,7 +458,6 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 	{
 		// Initialise object variables.
 		$this->database    = (isset($options['database'])) ? $options['database'] : '';
-		$this->debug       = (isset($options['debug'])) ? $options['debug'] : false;
 		$this->tablePrefix = (isset($options['prefix'])) ? $options['prefix'] : '';
 		$this->count       = 0;
 		$this->errorNum    = 0;
@@ -1475,23 +1466,6 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 	 * @throws  \RuntimeException
 	 */
 	abstract public function renameTable($oldTable, $newTable, $backup = null, $prefix = null);
-
-	/**
-	 * Sets the database debugging state for the driver.
-	 *
-	 * @param   boolean  $level  True to enable debugging.
-	 *
-	 * @return  boolean  The old debugging level.
-	 *
-	 * @since   1.0
-	 */
-	public function setDebug($level)
-	{
-		$previous    = $this->debug;
-		$this->debug = (bool) $level;
-
-		return $previous;
-	}
 
 	/**
 	 * Sets the SQL statement string for later execution.

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -197,11 +197,18 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 	/**
 	 * DatabaseFactory object
 	 *
-<<<<<<< HEAD
 	 * @var    DatabaseFactory
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $factory;
+
+	/**
+	 * Query monitor object
+	 *
+	 * @var    QueryMonitorInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $monitor;
 
 	/**
 	 * Get a list of available database connectors.
@@ -277,6 +284,7 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 		$options['database'] = (isset($options['database'])) ? $options['database'] : null;
 		$options['select']   = (isset($options['select'])) ? $options['select'] : true;
 		$options['factory']  = (isset($options['factory'])) ? $options['factory'] : new DatabaseFactory;
+		$options['monitor']  = (isset($options['monitor'])) ? $options['monitor'] : null;
 
 		// Get the options signature for the database connector.
 		$signature = md5(serialize($options));
@@ -468,6 +476,9 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 
 		// Register the DatabaseFactory
 		$this->factory = isset($options['factory']) ? $options['factory'] : new DatabaseFactory;
+
+		// Register the query monitor if available
+		$this->monitor = isset($options['monitor']) ? $options['monitor'] : null;
 	}
 
 	/**

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -8,6 +8,9 @@
 
 namespace Joomla\Database;
 
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\EventInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -16,9 +19,9 @@ use Psr\Log\LoggerAwareTrait;
  *
  * @since  1.0
  */
-abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
+abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface, DispatcherAwareInterface
 {
-	use LoggerAwareTrait;
+	use LoggerAwareTrait, DispatcherAwareTrait;
 
 	/**
 	 * The name of the database.
@@ -465,6 +468,27 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 
 		// Register the DatabaseFactory
 		$this->factory = isset($options['factory']) ? $options['factory'] : new DatabaseFactory;
+	}
+
+	/**
+	 * Dispatch an event.
+	 *
+	 * @param   EventInterface  $event  The event to dispatch
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function dispatchEvent(EventInterface $event)
+	{
+		try
+		{
+			$this->getDispatcher()->dispatch($event->getName(), $event);
+		}
+		catch (\UnexpectedValueException $exception)
+		{
+			// Don't error if a dispatcher hasn't been set
+		}
 	}
 
 	/**

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -11,17 +11,15 @@ namespace Joomla\Database;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\EventInterface;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 
 /**
  * Joomla Framework Database Driver Class
  *
  * @since  1.0
  */
-abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface, DispatcherAwareInterface
+abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInterface
 {
-	use LoggerAwareTrait, DispatcherAwareTrait;
+	use DispatcherAwareTrait;
 
 	/**
 	 * The name of the database.
@@ -1183,27 +1181,6 @@ abstract class DatabaseDriver implements DatabaseInterface, LoggerAwareInterface
 		$this->freeResult($cursor);
 
 		return $array;
-	}
-
-	/**
-	 * Logs a message.
-	 *
-	 * @param   string  $level    The level for the log. Use constants belonging to Psr\Log\LogLevel.
-	 * @param   string  $message  The message.
-	 * @param   array   $context  Additional context.
-	 *
-	 * @return  $this
-	 *
-	 * @since   1.0
-	 */
-	public function log($level, $message, array $context = [])
-	{
-		if ($this->logger)
-		{
-			$this->logger->log($level, $message, $context);
-		}
-
-		return $this;
 	}
 
 	/**

--- a/src/DatabaseEvents.php
+++ b/src/DatabaseEvents.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database;
+
+/**
+ * Class defining the events dispatched by the database API
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class DatabaseEvents
+{
+	/**
+	 * Private constructor to prevent instantiation of this class
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function __construct()
+	{
+	}
+
+	/**
+	 * Database event which is dispatched after the connection to the database server is opened.
+	 *
+	 * Listeners to this event receive a `Joomla\Database\Event\ConnectionEvent` object.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const POST_CONNECT = 'onAfterConnect';
+
+	/**
+	 * Database event which is dispatched after the connection to the database server is closed.
+	 *
+	 * Listeners to this event receive a `Joomla\Database\Event\ConnectionEvent` object.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const POST_DISCONNECT = 'onAfterDisconnect';
+}

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -259,18 +259,7 @@ abstract class DatabaseImporter
 					foreach ($queries as $query)
 					{
 						$this->db->setQuery((string) $query);
-
-						try
-						{
-							$this->db->execute();
-						}
-						catch (\RuntimeException $e)
-						{
-							$this->db->log(LogLevel::DEBUG, 'Fail: ' . $this->db->getQuery());
-							throw $e;
-						}
-
-						$this->db->log(LogLevel::DEBUG, 'Pass: ' . $this->db->getQuery());
+						$this->db->execute();
 					}
 				}
 			}
@@ -280,18 +269,7 @@ abstract class DatabaseImporter
 				$sql = $this->xmlToCreate($table);
 
 				$this->db->setQuery((string) $sql);
-
-				try
-				{
-					$this->db->execute();
-				}
-				catch (\RuntimeException $e)
-				{
-					$this->db->log(LogLevel::DEBUG, 'Fail: ' . $this->db->getQuery());
-					throw $e;
-				}
-
-				$this->db->log(LogLevel::DEBUG, 'Pass: ' . $this->db->getQuery());
+				$this->db->execute();
 			}
 		}
 	}

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\Database;
 
-use Psr\Log\LogLevel;
-
 /**
  * Joomla Framework Database Importer Class
  *

--- a/src/Event/ConnectionEvent.php
+++ b/src/Event/ConnectionEvent.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Event;
+
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\Event;
+
+/**
+ * Database connection event
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ConnectionEvent extends Event
+{
+	/**
+	 * DatabaseInterface object for this event
+	 *
+	 * @var    DatabaseInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $driver;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string             $name    The event name.
+	 * @param   DatabaseInterface  $driver  The DatabaseInterface object for this event.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($name, DatabaseInterface $driver)
+	{
+		parent::__construct($name);
+
+		$this->driver = $driver;
+	}
+
+	/**
+	 * Retrieve the DatabaseInterface object attached to this event.
+	 *
+	 * @return  DatabaseInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getDriver()
+	{
+		return $this->driver;
+	}
+}

--- a/src/Monitor/ChainedMonitor.php
+++ b/src/Monitor/ChainedMonitor.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Monitor;
+
+use Joomla\Database\QueryMonitorInterface;
+
+/**
+ * Chained query monitor allowing multiple monitors to be executed.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ChainedMonitor implements QueryMonitorInterface
+{
+	/**
+	 * The query monitors stored to this chain
+	 *
+	 * @var    QueryMonitorInterface[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $monitors = [];
+
+	/**
+	 * Register a monitor to the chain.
+	 *
+	 * @param   QueryMonitorInterface  $monitor  The monitor to add.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addMonitor(QueryMonitorInterface $monitor)
+	{
+		$this->monitors[] = $monitor;
+	}
+
+	/**
+	 * Act on a query being started.
+	 *
+	 * @param   string  $sql  The SQL to be executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function startQuery($sql)
+	{
+		foreach ($this->monitors as $monitor)
+		{
+			$monitor->startQuery($sql);
+		}
+	}
+
+	/**
+	 * Act on a query being stopped.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopQuery()
+	{
+		foreach ($this->monitors as $monitor)
+		{
+			$monitor->stopQuery();
+		}
+	}
+}

--- a/src/Monitor/LoggingMonitor.php
+++ b/src/Monitor/LoggingMonitor.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Monitor;
+
+use Joomla\Database\QueryMonitorInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Query monitor handling logging of queries.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LoggingMonitor implements QueryMonitorInterface, LoggerAwareInterface
+{
+	use LoggerAwareTrait;
+
+	/**
+	 * Act on a query being started.
+	 *
+	 * @param   string  $sql  The SQL to be executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function startQuery($sql)
+	{
+		if ($this->logger)
+		{
+			// Add the query to the object queue.
+			$this->logger->info(
+				'Query Executed: {sql}',
+				['sql' => $sql, 'trace' => debug_backtrace()]
+			);
+		}
+	}
+
+	/**
+	 * Act on a query being stopped.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopQuery()
+	{
+		// Nothing to do
+	}
+}

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -10,7 +10,6 @@ namespace Joomla\Database\Mysql;
 
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Pdo\PdoDriver;
-use Psr\Log;
 
 /**
  * MySQL database driver supporting PDO based connections

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -578,15 +578,10 @@ class MysqliDriver extends DatabaseDriver
 		// Increment the query counter.
 		$this->count++;
 
-		// If debugging is enabled then let's log the query.
-		if ($this->debug)
+		// If there is a monitor registered, let it know we are starting this query
+		if ($this->monitor)
 		{
-			// Add the query to the object queue.
-			$this->log(
-				Log\LogLevel::DEBUG,
-				'{sql}',
-				['sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace()]
-			);
+			$this->monitor->startQuery($sql);
 		}
 
 		// Reset the error values.
@@ -638,6 +633,12 @@ class MysqliDriver extends DatabaseDriver
 			{
 				$this->cursor = true;
 			}
+		}
+
+		// If there is a monitor registered, let it know we have finished this query
+		if ($this->monitor)
+		{
+			$this->monitor->stopQuery();
 		}
 
 		// If an error occurred handle it.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -9,7 +9,9 @@
 namespace Joomla\Database\Mysqli;
 
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseEvents;
 use Joomla\Database\DatabaseQuery;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
@@ -235,6 +237,8 @@ class MysqliDriver extends DatabaseDriver
 
 		// Set charactersets (needed for MySQL 4.1.2+).
 		$this->utf = $this->setUtf();
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
 	}
 
 	/**
@@ -284,6 +288,8 @@ class MysqliDriver extends DatabaseDriver
 		}
 
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -17,7 +17,6 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\PreparableInterface;
 use Joomla\Database\Query\LimitableInterface;
-use Psr\Log;
 
 /**
  * MySQLi Database Driver
@@ -222,9 +221,10 @@ class MysqliDriver extends DatabaseDriver
 
 		if (!$connected)
 		{
-			$this->log(Log\LogLevel::ERROR, 'Could not connect to MySQL: ' . $this->connection->connect_error);
-
-			throw new ConnectionFailureException('Could not connect to MySQL.', $this->connection->connect_errno);
+			throw new ConnectionFailureException(
+				'Could not connect to MySQL: ' . $this->connection->connect_error,
+				$this->connection->connect_errno
+			);
 		}
 
 		// If auto-select is enabled select the given database.
@@ -659,12 +659,6 @@ class MysqliDriver extends DatabaseDriver
 				catch (ConnectionFailureException $e)
 				// If connect fails, ignore that exception and throw the normal exception.
 				{
-					$this->log(
-						Log\LogLevel::ERROR,
-						'Database query failed (error #{code}): {message}; Failed query: {sql}',
-						['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-					);
-
 					throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 				}
 
@@ -673,12 +667,6 @@ class MysqliDriver extends DatabaseDriver
 			}
 
 			// The server was not disconnected.
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}; Failed query: {sql}',
-				['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-			);
-
 			throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 		}
 
@@ -940,12 +928,6 @@ class MysqliDriver extends DatabaseDriver
 				catch (ConnectionFailureException $e)
 				// If connect fails, ignore that exception and throw the normal exception.
 				{
-					$this->log(
-						Log\LogLevel::ERROR,
-						'Database query failed (error #{code}): {message}; Failed query: {sql}',
-						['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-					);
-
 					throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 				}
 
@@ -954,12 +936,6 @@ class MysqliDriver extends DatabaseDriver
 			}
 
 			// The server was not disconnected.
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}; Failed query: {sql}',
-				['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-			);
-
 			throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 		}
 

--- a/src/Oracle/OracleDriver.php
+++ b/src/Oracle/OracleDriver.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Database\Oracle;
 
+use Joomla\Database\DatabaseEvents;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Pdo\PdoDriver;
 
 /**
@@ -121,6 +123,8 @@ class OracleDriver extends PdoDriver
 		// Close the connection.
 		$this->freeResult();
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -392,15 +392,10 @@ abstract class PdoDriver extends DatabaseDriver
 		// Increment the query counter.
 		$this->count++;
 
-		// If debugging is enabled then let's log the query.
-		if ($this->debug)
+		// If there is a monitor registered, let it know we are starting this query
+		if ($this->monitor)
 		{
-			// Add the query to the object queue.
-			$this->log(
-				Log\LogLevel::DEBUG,
-				'{sql}',
-				['sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace()]
-			);
+			$this->monitor->startQuery($sql);
 		}
 
 		// Reset the error values.
@@ -424,6 +419,12 @@ abstract class PdoDriver extends DatabaseDriver
 			}
 
 			$this->executed = $this->prepared->execute();
+		}
+
+		// If there is a monitor registered, let it know we have finished this query
+		if ($this->monitor)
+		{
+			$this->monitor->stopQuery();
 		}
 
 		// If an error occurred handle it.

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -16,7 +16,6 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
-use Psr\Log;
 
 /**
  * Joomla Framework PDO Database Driver Class
@@ -315,11 +314,7 @@ abstract class PdoDriver extends DatabaseDriver
 		}
 		catch (\PDOException $e)
 		{
-			$message = 'Could not connect to PDO: ' . $e->getMessage();
-
-			$this->log(Log\LogLevel::ERROR, $message);
-
-			throw new ConnectionFailureException($message, $e->getCode(), $e);
+			throw new ConnectionFailureException('Could not connect to PDO: ' . $e->getMessage(), $e->getCode(), $e);
 		}
 
 		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
@@ -450,12 +445,6 @@ abstract class PdoDriver extends DatabaseDriver
 					$this->errorNum = (int) $this->connection->errorCode();
 					$this->errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
 
-					$this->log(
-						Log\LogLevel::ERROR,
-						'Database query failed (error #{code}): {message}; Failed query: {sql}',
-						['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-					);
-
 					throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 				}
 
@@ -468,12 +457,6 @@ abstract class PdoDriver extends DatabaseDriver
 			$this->errorMsg = $errorMsg;
 
 			// Throw the normal query exception.
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}; Failed query: {sql}',
-				['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-			);
-
 			throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 		}
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -8,13 +8,15 @@
 
 namespace Joomla\Database\Pdo;
 
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseEvents;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
-use Psr\Log;
-use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
+use Psr\Log;
 
 /**
  * Joomla Framework PDO Database Driver Class
@@ -319,6 +321,8 @@ abstract class PdoDriver extends DatabaseDriver
 
 			throw new ConnectionFailureException($message, $e->getCode(), $e);
 		}
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
 	}
 
 	/**
@@ -333,6 +337,8 @@ abstract class PdoDriver extends DatabaseDriver
 		$this->freeResult();
 
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -9,7 +9,6 @@
 namespace Joomla\Database\Pgsql;
 
 use Joomla\Database\Pdo\PdoDriver;
-use Psr\Log;
 
 /**
  * PostgreSQL PDO Database Driver

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -680,15 +680,10 @@ class PostgresqlDriver extends DatabaseDriver
 		// Increment the query counter.
 		$this->count++;
 
-		// If debugging is enabled then let's log the query.
-		if ($this->debug)
+		// If there is a monitor registered, let it know we are starting this query
+		if ($this->monitor)
 		{
-			// Add the query to the object queue.
-			$this->log(
-				Log\LogLevel::DEBUG,
-				'{sql}',
-				['sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace()]
-			);
+			$this->monitor->startQuery($sql);
 		}
 
 		// Reset the error values.
@@ -715,6 +710,12 @@ class PostgresqlDriver extends DatabaseDriver
 		{
 			// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 			$this->cursor = @pg_query($this->connection, $sql);
+		}
+
+		// If there is a monitor registered, let it know we have finished this query
+		if ($this->monitor)
+		{
+			$this->monitor->stopQuery();
 		}
 
 		// If an error occurred handle it.

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -17,7 +17,6 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
-use Psr\Log;
 
 /**
  * PostgreSQL Database Driver
@@ -186,8 +185,6 @@ class PostgresqlDriver extends DatabaseDriver
 		// Attempt to connect to the server.
 		if (!($this->connection = @pg_connect($dsn)))
 		{
-			$this->log(Log\LogLevel::ERROR, 'Error connecting to PGSQL database.');
-
 			throw new ConnectionFailureException('Error connecting to PGSQL database.');
 		}
 
@@ -743,12 +740,6 @@ class PostgresqlDriver extends DatabaseDriver
 					}
 
 					// Throw the normal query exception.
-					$this->log(
-						Log\LogLevel::ERROR,
-						'Database query failed (error #{code}): {message}; Failed query: {sql}',
-						['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-					);
-
 					throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 				}
 
@@ -761,12 +752,6 @@ class PostgresqlDriver extends DatabaseDriver
 			$this->errorMsg = pg_last_error($this->connection);
 
 			// Throw the normal query exception.
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}; Failed query: {sql}',
-				['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-			);
-
 			throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 		}
 

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -9,7 +9,9 @@
 namespace Joomla\Database\Postgresql;
 
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseEvents;
 use Joomla\Database\DatabaseQuery;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
@@ -192,6 +194,8 @@ class PostgresqlDriver extends DatabaseDriver
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
 		pg_query($this->connection, 'SET standard_conforming_strings=off');
 		pg_query($this->connection, 'SET escape_string_warning=off');
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
 	}
 
 	/**
@@ -210,6 +214,8 @@ class PostgresqlDriver extends DatabaseDriver
 		}
 
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**

--- a/src/QueryMonitorInterface.php
+++ b/src/QueryMonitorInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database;
+
+/**
+ * Interface defining a query monitor.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface QueryMonitorInterface
+{
+	/**
+	 * Act on a query being started.
+	 *
+	 * @param   string  $sql  The SQL to be executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function startQuery($sql);
+
+	/**
+	 * Act on a query being stopped.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopQuery();
+}

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Database\Sqlite;
 
+use Joomla\Database\DatabaseEvents;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Pdo\PdoDriver;
 
 /**
@@ -58,6 +60,8 @@ class SqliteDriver extends PdoDriver
 	{
 		$this->freeResult();
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -577,15 +577,10 @@ class SqlsrvDriver extends DatabaseDriver
 		// Increment the query counter.
 		$this->count++;
 
-		// If debugging is enabled then let's log the query.
-		if ($this->debug)
+		// If there is a monitor registered, let it know we are starting this query
+		if ($this->monitor)
 		{
-			// Add the query to the object queue.
-			$this->log(
-				Log\LogLevel::DEBUG,
-				'{sql}',
-				['sql' => $sql, 'category' => 'databasequery', 'trace' => debug_backtrace()]
-			);
+			$this->monitor->startQuery($sql);
 		}
 
 		// Reset the error values.
@@ -619,6 +614,12 @@ class SqlsrvDriver extends DatabaseDriver
 
 		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 		$this->cursor = @sqlsrv_query($this->connection, $sql, $params, $options);
+
+		// If there is a monitor registered, let it know we have finished this query
+		if ($this->monitor)
+		{
+			$this->monitor->stopQuery();
+		}
 
 		// If an error occurred handle it.
 		if (!$this->cursor)

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -17,7 +17,6 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
-use Psr\Log;
 
 /**
  * SQL Server Database Driver
@@ -137,8 +136,6 @@ class SqlsrvDriver extends DatabaseDriver
 		// Attempt to connect to the server.
 		if (!($this->connection = @ sqlsrv_connect($this->options['host'], $config)))
 		{
-			$this->log(Log\LogLevel::ERROR, 'Could not connect to SQL Server', ['errors' => sqlsrv_errors()]);
-
 			throw new ConnectionFailureException('Could not connect to SQL Server');
 		}
 
@@ -642,12 +639,6 @@ class SqlsrvDriver extends DatabaseDriver
 					$this->errorMsg = $errors[0]['message'];
 
 					// Throw the normal query exception.
-					$this->log(
-						Log\LogLevel::ERROR,
-						'Database query failed (error #{code}): {message}; Failed query: {sql}',
-						['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-					);
-
 					throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 				}
 
@@ -661,12 +652,6 @@ class SqlsrvDriver extends DatabaseDriver
 			$this->errorMsg = $errors[0]['message'];
 
 			// Throw the normal query exception.
-			$this->log(
-				Log\LogLevel::ERROR,
-				'Database query failed (error #{code}): {message}; Failed query: {sql}',
-				['code' => $this->errorNum, 'message' => $this->errorMsg, 'sql' => $sql]
-			);
-
 			throw new ExecutionFailureException($sql, $this->errorMsg, $this->errorNum);
 		}
 

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -8,14 +8,16 @@
 
 namespace Joomla\Database\Sqlsrv;
 
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseEvents;
 use Joomla\Database\DatabaseQuery;
+use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
 use Psr\Log;
-use Joomla\Database\DatabaseDriver;
 
 /**
  * SQL Server Database Driver
@@ -148,6 +150,8 @@ class SqlsrvDriver extends DatabaseDriver
 		{
 			$this->select($this->options['database']);
 		}
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
 	}
 
 	/**
@@ -166,6 +170,8 @@ class SqlsrvDriver extends DatabaseDriver
 		}
 
 		$this->connection = null;
+
+		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_DISCONNECT, $this));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

- Adds event dispatching for post-connect and post-disconnect actions
- Adds a `QueryMonitorInterface` (roughly based on Doctrine's `SQLLogger` interface) which can be used as a means for monitoring queries (logging, profiling, etc.)
- Removes the debug attribute from the driver, it was only used to toggle whether queries should be logged
- The driver no longer implements PSR-3, queries should be logged through a monitor

### Documentation Changes Required

- Need proper deprecation for removed functionality
- Document new integration points