### PR TITLE
Add ability to clear offset

### DIFF
--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -560,6 +560,10 @@ abstract class DatabaseQuery
 				$this->limit = 0;
 				break;
 
+			case 'offset':
+				$this->offset = 0;
+				break;
+
 			case 'union':
 				$this->union = null;
 				break;


### PR DESCRIPTION
### Summary of Changes
This fixes the failing CMS tests in https://github.com/joomla/joomla-cms/pull/16402

This was due to https://github.com/joomla/joomla-cms/commit/bff522ef80e22b568f7b5a3fc13efd600bce84b9 not being applied to the framework. As ListModel in the CMS then clears the offset (but this case doesn't exist) it falls back to default behaviour which is to clear the entire query object data.

### Testing Instructions
Unit tests on CMS pass

### Documentation Changes Required
None
