### PR TITLE
missed getConnectionCollation()

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1885,4 +1885,15 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 * @throws  \RuntimeException
 	 */
 	public abstract function unlockTables();
+
+	/**
+	 * Method to get the database connection collation, as reported by the driver. If the connector doesn't support
+	 * reporting this value please return an empty string.
+	 *
+	 * @return  string
+	 */
+	public function getConnectionCollation()
+	{
+		return '';
+	}
 }

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -249,6 +249,21 @@ class MysqlDriver extends PdoDriver
 	}
 
 	/**
+	 * Method to get the database connection collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database connection (string) or boolean false if not supported.
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionCollation()
+	{
+		$this->connect();
+
+		return $this->setQuery('SELECT @@collation_connection;')->loadResult();
+	}
+
+	/**
 	 * Shows the table CREATE statement that creates the given tables.
 	 *
 	 * @param   mixed  $tables  A table name or a list of table names.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -389,6 +389,22 @@ class MysqliDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Method to get the database connection collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database connection (string) or boolean false if not supported.
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionCollation()
+	{
+		$this->connect();
+
+		return $this->setQuery('SELECT @@collation_connection;')->loadResult();
+
+	}
+	
+	/**
 	 * Get the number of returned rows for the previous executed SQL statement.
 	 *
 	 * @param   resource  $cursor  An optional database cursor resource to extract the row count from.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -401,9 +401,8 @@ class MysqliDriver extends DatabaseDriver
 		$this->connect();
 
 		return $this->setQuery('SELECT @@collation_connection;')->loadResult();
-
 	}
-	
+
 	/**
 	 * Get the number of returned rows for the previous executed SQL statement.
 	 *


### PR DESCRIPTION
Pull Request for Issue #16789 .

### Summary of Changes
added the missed `getConnectionCollation()` method


### Testing Instructions
Access to System -> System Information


### Expected result
NO error


### Actual result
Call to undefined method Joomla\Database\Mysqli\MysqliDriver::getConnectionCollation()

