### PR TITLE
Add strict sql_modes to MySQL drivers.

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -72,9 +72,23 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	 */
 	public function __construct(array $options)
 	{
+		/**
+		 * sql_mode to MySql 5.7.8+ default strict mode.
+		 *
+		 * @see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-8.html#mysqld-5-7-8-sql-mode
+		 */
+		$sqlModes = [
+			'ONLY_FULL_GROUP_BY',
+			'STRICT_TRANS_TABLES',
+			'ERROR_FOR_DIVISION_BY_ZERO',
+			'NO_AUTO_CREATE_USER',
+			'NO_ENGINE_SUBSTITUTION',
+		];
+
 		// Get some basic values from the options.
-		$options['driver']	= 'mysql';
-		$options['charset'] = (isset($options['charset'])) ? $options['charset'] : 'utf8';
+		$options['driver']   = 'mysql';
+		$options['charset']  = isset($options['charset']) ? $options['charset'] : 'utf8';
+		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
 		$this->charset = $options['charset'];
 
@@ -140,6 +154,12 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 				$this->options['charset'] = 'utf8';
 				parent::connect();
 			}
+		}
+
+		// If needed, set the sql modes.
+		if ($this->options['sqlModes'] !== [])
+		{
+			$this->connection->query('SET @@SESSION.sql_mode = \'' . implode(',', $this->options['sqlModes']) . '\';');
 		}
 
 		$this->connection->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -103,15 +103,29 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	 */
 	public function __construct(array $options)
 	{
+		/**
+		 * sql_mode to MySql 5.7.8+ default strict mode.
+		 *
+		 * @see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-8.html#mysqld-5-7-8-sql-mode
+		 */
+		$sqlModes = [
+			'ONLY_FULL_GROUP_BY',
+			'STRICT_TRANS_TABLES',
+			'ERROR_FOR_DIVISION_BY_ZERO',
+			'NO_AUTO_CREATE_USER',
+			'NO_ENGINE_SUBSTITUTION',
+		];
+
 		// Get some basic values from the options.
-		$options['host']     = (isset($options['host'])) ? $options['host'] : 'localhost';
-		$options['user']     = (isset($options['user'])) ? $options['user'] : 'root';
-		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
-		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
-		$options['select']   = (isset($options['select'])) ? (bool) $options['select'] : true;
-		$options['port']     = (isset($options['port'])) ? (int) $options['port'] : null;
-		$options['socket']   = (isset($options['socket'])) ? $options['socket'] : null;
-		$options['utf8mb4']  = (isset($options['utf8mb4'])) ? (bool) $options['utf8mb4'] : false;
+		$options['host']     = isset($options['host']) ? $options['host'] : 'localhost';
+		$options['user']     = isset($options['user']) ? $options['user'] : 'root';
+		$options['password'] = isset($options['password']) ? $options['password'] : '';
+		$options['database'] = isset($options['database']) ? $options['database'] : '';
+		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['port']     = isset($options['port']) ? (int) $options['port'] : null;
+		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
+		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
+		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
 		// Finalize initialisation.
 		parent::__construct($options);
@@ -226,6 +240,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 				'Could not connect to MySQL: ' . $this->connection->connect_error,
 				$this->connection->connect_errno
 			);
+		}
+
+		// If needed, set the sql modes.
+		if ($this->options['sqlModes'] !== [])
+		{
+			$this->connection->query('SET @@SESSION.sql_mode = \'' . implode(',', $this->options['sqlModes']) . '\';');
 		}
 
 		// If auto-select is enabled select the given database.


### PR DESCRIPTION
Pull Request for Improvement

### Summary of Changes

In 2.0 add strict `ONLY_FULL_GROUP_BY`, `STRICT_TRANS_TABLES`, `ERROR_FOR_DIVISION_BY_ZERO`, `NO_AUTO_CREATE_USER` and `NO_ENGINE_SUBSTITUTION` strict sql modes to MySQLi and PDO MySQL drivers.

Also add the hability to override this default sql_modes with sqlModes option.

### Testing Instructions

Confirm both drivers still work.

### Documentation Changes Required

None.

### Additional info

This are the same sql_modes that were adedd in https://github.com/joomla/joomla-cms/pull/12494/files and later removed when joomla stated using the database framework package