### PR TITLE
[RFC mysql] - set proper nullDate  depending on SQL_MODE

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -409,7 +409,7 @@ class MysqliDriver extends DatabaseDriver
 	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
-	*/
+	 */
 	public function getNullDate()
 	{
 		$this->connect();

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -408,7 +408,7 @@ class MysqliDriver extends DatabaseDriver
 	 *
 	 * @return  string
 	 *
-	 * @since    __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	*/
 	public function getNullDate()
 	{
@@ -418,7 +418,7 @@ class MysqliDriver extends DatabaseDriver
 
 		if (strpos($mode, 'NO_ZERO_DATE') !== false)
 		{
-			$this->nullDate='1000-01-01 00:00:00';
+			$this->nullDate = '1000-01-01 00:00:00';
 		}
 
 		return $this->nullDate;

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -404,6 +404,27 @@ class MysqliDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Get the null or zero representation of a timestamp for the database driver.
+	 *
+	 * @return  string
+	 *
+	 * @since    __DEPLOY_VERSION__
+	*/
+	public function getNullDate()
+	{
+		$this->connect();
+
+		$mode = $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult();
+
+		if (strpos($mode, 'NO_ZERO_DATE') !== false)
+		{
+			$this->nullDate='1000-01-01 00:00:00';
+		}
+
+		return $this->nullDate;
+	}
+
+	/**
 	 * Get the number of returned rows for the previous executed SQL statement.
 	 *
 	 * @param   resource  $cursor  An optional database cursor resource to extract the row count from.


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16788

### Summary of Changes
trivial check for null date

set `$this->nullDate='1000-01-01 00:00:00'; `
if `NO_ZERO_DATE` sql_mode enabled