### PR TITLE
[2.0] Use Symfony's OptionsResolver for database options

### DIFF
--- a/Tests/Cases/PgsqlCase.php
+++ b/Tests/Cases/PgsqlCase.php
@@ -64,7 +64,7 @@ abstract class PgsqlCase extends AbstractDatabaseTestCase
 					static::$options['host'] = $v;
 					break;
 				case 'port':
-					static::$options['port'] = $v;
+					static::$options['port'] = (int) $v;
 					break;
 				case 'dbname':
 					static::$options['database'] = $v;

--- a/Tests/Cases/PostgresqlCase.php
+++ b/Tests/Cases/PostgresqlCase.php
@@ -68,7 +68,7 @@ abstract class PostgresqlCase extends AbstractDatabaseTestCase
 					static::$options['host'] = $v;
 					break;
 				case 'port':
-					static::$options['port'] = $v;
+					static::$options['port'] = (int) $v;
 					break;
 				case 'dbname':
 					static::$options['database'] = $v;

--- a/Tests/Service/DatabaseProviderTest.php
+++ b/Tests/Service/DatabaseProviderTest.php
@@ -39,7 +39,7 @@ class DatabaseProviderTest extends TestCase
 		$this->container = new Container;
 		$config = new Registry;
 		$config->set('database.driver', 'sqlite');
-		$config->set('database.name', ':memory:');
+		$config->set('database.database', ':memory:');
 		$config->set('database.prefix', 'jos_');
 		$this->container->set('config', $config);
 	}
@@ -51,7 +51,7 @@ class DatabaseProviderTest extends TestCase
 	 * @uses     Joomla\Database\DatabaseDriver
 	 * @uses     Joomla\Database\Pdo\PdoDriver
 	 */
-	public function testVerifyTheLanguageObjectIsRegisteredToTheContainer()
+	public function testVerifyTheDatabaseObjectIsRegisteredToTheContainer()
 	{
 		$this->container->registerServiceProvider(new DatabaseProvider);
 

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,9 @@
     "license": "GPL-2.0+",
     "require": {
         "php": "~7.0",
-        "joomla/event": "~2.0@dev",
-        "psr/log": "~1.0"
+        "joomla/event": "~2.0",
+        "psr/log": "~1.0",
+        "symfony/options-resolver": "~3.0|~4.0"
     },
     "require-dev": {
         "joomla/di": "~1.0|~2.0",

--- a/src/DatabaseFactory.php
+++ b/src/DatabaseFactory.php
@@ -32,9 +32,8 @@ class DatabaseFactory
 	public function getDriver($name = 'mysqli', array $options = [])
 	{
 		// Sanitize the database connector options.
-		$options['driver']   = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
-		$options['database'] = isset($options['database']) ? $options['database'] : null;
-		$options['select']   = isset($options['select']) ? $options['select'] : true;
+		$options['driver']  = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
+		$options['factory'] = $options['factory'] ?? $this;
 
 		// Derive the class name from the driver.
 		$class = __NAMESPACE__ . '\\' . ucfirst(strtolower($options['driver'])) . '\\' . ucfirst(strtolower($options['driver'])) . 'Driver';

--- a/src/Oracle/OracleDriver.php
+++ b/src/Oracle/OracleDriver.php
@@ -11,6 +11,7 @@ namespace Joomla\Database\Oracle;
 use Joomla\Database\DatabaseEvents;
 use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Pdo\PdoDriver;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Oracle Database Driver supporting PDO based connections
@@ -64,15 +65,12 @@ class OracleDriver extends PdoDriver
 	 */
 	public function __construct(array $options)
 	{
-		$options['driver']     = 'oci';
-		$options['charset']    = isset($options['charset']) ? $options['charset']   : 'AL32UTF8';
-		$options['dateformat'] = isset($options['dateformat']) ? $options['dateformat'] : 'RRRR-MM-DD HH24:MI:SS';
+		$options['driver'] = 'oci';
 
-		$this->charset    = $options['charset'];
-		$this->dateformat = $options['dateformat'];
-
-		// Finalize initialisation
 		parent::__construct($options);
+
+		$this->charset    = $this->options['charset'];
+		$this->dateformat = $this->options['dateformat'];
 	}
 
 	/**
@@ -83,6 +81,31 @@ class OracleDriver extends PdoDriver
 	public function __destruct()
 	{
 		$this->disconnect();
+	}
+
+	/**
+	 * Resolve the options for the database driver.
+	 *
+	 * @param   OptionsResolver  $resolver  The options resolver.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function configureOptions(OptionsResolver $resolver)
+	{
+		parent::configureOptions($resolver);
+
+		$resolver->setDefaults(
+			[
+				'charset'    => 'AL32UTF8',
+				'dateformat' => 'RRRR-MM-DD HH24:MI:SS',
+				'schema'     => '',
+			]
+		);
+
+		$resolver->setAllowedTypes('dateformat', ['string']);
+		$resolver->setAllowedTypes('schema', ['string']);
 	}
 
 	/**
@@ -102,7 +125,7 @@ class OracleDriver extends PdoDriver
 
 		parent::connect();
 
-		if (isset($this->options['schema']))
+		if ($this->options['schema'])
 		{
 			$this->setQuery('ALTER SESSION SET CURRENT_SCHEMA = ' . $this->quoteName($this->options['schema']))
 				->execute();

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -16,6 +16,7 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Joomla Framework PDO Database Driver Class
@@ -77,29 +78,6 @@ abstract class PdoDriver extends DatabaseDriver
 	protected $executed = false;
 
 	/**
-	 * Constructor.
-	 *
-	 * @param   array  $options  List of options used to configure the connection
-	 *
-	 * @since   1.0
-	 */
-	public function __construct(array $options)
-	{
-		// Get some basic values from the options.
-		$options['driver']        = isset($options['driver']) ? $options['driver'] : 'odbc';
-		$options['dsn']           = isset($options['dsn']) ? $options['dsn'] : '';
-		$options['host']          = isset($options['host']) ? $options['host'] : 'localhost';
-		$options['database']      = isset($options['database']) ? $options['database'] : '';
-		$options['user']          = isset($options['user']) ? $options['user'] : '';
-		$options['port']          = isset($options['port']) ? (int) $options['port'] : null;
-		$options['password']      = isset($options['password']) ? $options['password'] : '';
-		$options['driverOptions'] = isset($options['driverOptions']) ? $options['driverOptions'] : [];
-
-		// Finalize initialisation
-		parent::__construct($options);
-	}
-
-	/**
 	 * Destructor.
 	 *
 	 * @since   1.0
@@ -107,6 +85,34 @@ abstract class PdoDriver extends DatabaseDriver
 	public function __destruct()
 	{
 		$this->disconnect();
+	}
+
+	/**
+	 * Resolve the options for the database driver.
+	 *
+	 * @param   OptionsResolver  $resolver  The options resolver.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function configureOptions(OptionsResolver $resolver)
+	{
+		parent::configureOptions($resolver);
+
+		$resolver->setDefaults(
+			[
+				'driverOptions' => [],
+				'protocol'      => '',
+				'charset'       => '',
+				'version'       => null,
+			]
+		);
+
+		$resolver->setAllowedTypes('driverOptions', ['array']);
+		$resolver->setAllowedTypes('protocol', ['string']);
+		$resolver->setAllowedTypes('charset', ['string']);
+		$resolver->setAllowedTypes('version', ['null', 'int']);
 	}
 
 	/**
@@ -134,7 +140,7 @@ abstract class PdoDriver extends DatabaseDriver
 		switch ($this->options['driver'])
 		{
 			case 'cubrid':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 33000;
+				$this->options['port'] = $this->options['port'] ?: 33000;
 
 				$format = 'cubrid:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
 
@@ -144,7 +150,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'dblib':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 1433;
+				$this->options['port'] = $this->options['port'] ?: 1433;
 
 				$format = 'dblib:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
 
@@ -154,7 +160,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'firebird':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 3050;
+				$this->options['port'] = $this->options['port'] ?: 3050;
 
 				$format = 'firebird:dbname=#DBNAME#';
 
@@ -164,7 +170,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'ibm':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 56789;
+				$this->options['port'] = $this->options['port'] ?: 56789;
 
 				if (!empty($this->options['dsn']))
 				{
@@ -184,8 +190,8 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'informix':
-				$this->options['port']     = isset($this->options['port']) ? $this->options['port'] : 1526;
-				$this->options['protocol'] = isset($this->options['protocol']) ? $this->options['protocol'] : 'onsoctcp';
+				$this->options['port']     = $this->options['port'] ?: 1526;
+				$this->options['protocol'] = $this->options['protocol'] ?: 'onsoctcp';
 
 				if (!empty($this->options['dsn']))
 				{
@@ -211,7 +217,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'mssql':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 1433;
+				$this->options['port'] = $this->options['port'] ?: 1433;
 
 				$format = 'mssql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
 
@@ -221,7 +227,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'mysql':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 3306;
+				$this->options['port'] = $this->options['port'] ?: 3306;
 
 				$format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#;charset=#CHARSET#';
 
@@ -231,8 +237,8 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'oci':
-				$this->options['port']    = isset($this->options['port']) ? $this->options['port'] : 1521;
-				$this->options['charset'] = isset($this->options['charset']) ? $this->options['charset'] : 'AL32UTF8';
+				$this->options['port']    = $this->options['port'] ?: 1521;
+				$this->options['charset'] = $this->options['charset'] ?: 'AL32UTF8';
 
 				if (!empty($this->options['dsn']))
 				{
@@ -262,7 +268,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'pgsql':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 5432;
+				$this->options['port'] = $this->options['port'] ?: 5432;
 
 				$format = 'pgsql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
 
@@ -272,7 +278,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'sqlite':
-				if (isset($this->options['version']) && $this->options['version'] == 2)
+				if ($this->options['version'] === 2)
 				{
 					$format = 'sqlite2:#DBNAME#';
 				}
@@ -287,7 +293,7 @@ abstract class PdoDriver extends DatabaseDriver
 				break;
 
 			case 'sybase':
-				$this->options['port'] = isset($this->options['port']) ? $this->options['port'] : 1433;
+				$this->options['port'] = $this->options['port'] ?: 1433;
 
 				$format = 'mssql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
 

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -70,12 +70,7 @@ class PgsqlDriver extends PdoDriver
 	 */
 	public function __construct($options)
 	{
-		$options['driver']   = 'pgsql';
-		$options['host']     = isset($options['host']) ? $options['host'] : 'localhost';
-		$options['user']     = isset($options['user']) ? $options['user'] : '';
-		$options['password'] = isset($options['password']) ? $options['password'] : '';
-		$options['database'] = isset($options['database']) ? $options['database'] : '';
-		$options['port']     = isset($options['port']) ? $options['port'] : null;
+		$options['driver'] = 'pgsql';
 
 		// Finalize initialization
 		parent::__construct($options);

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -93,25 +93,6 @@ class PostgresqlDriver extends DatabaseDriver
 	protected $concat_operator = '||';
 
 	/**
-	 * Database object constructor
-	 *
-	 * @param   array  $options  List of options used to configure the connection
-	 *
-	 * @since	1.0
-	 */
-	public function __construct(array $options)
-	{
-		$options['host']     = isset($options['host']) ? $options['host'] : 'localhost';
-		$options['user']     = isset($options['user']) ? $options['user'] : '';
-		$options['password'] = isset($options['password']) ? $options['password'] : '';
-		$options['database'] = isset($options['database']) ? $options['database'] : '';
-		$options['port']     = isset($options['port']) ? $options['port'] : null;
-
-		// Finalize initialization
-		parent::__construct($options);
-	}
-
-	/**
 	 * Database object destructor
 	 *
 	 * @since   1.0

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -74,26 +74,6 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
-	 * Constructor.
-	 *
-	 * @param   array  $options  List of options used to configure the connection
-	 *
-	 * @since   1.0
-	 */
-	public function __construct(array $options)
-	{
-		// Get some basic values from the options.
-		$options['host']     = isset($options['host']) ? $options['host'] : 'localhost';
-		$options['user']     = isset($options['user']) ? $options['user'] : '';
-		$options['password'] = isset($options['password']) ? $options['password'] : '';
-		$options['database'] = isset($options['database']) ? $options['database'] : '';
-		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
-
-		// Finalize initialisation
-		parent::__construct($options);
-	}
-
-	/**
 	 * Destructor.
 	 *
 	 * @since   1.0


### PR DESCRIPTION
As a way to more explicitly be aware of and configure the various options used in the database drivers, we can simplify things down a bit and use Symfony's OptionsResolver component to define the various options, the allowed option types/values, and set default values.  This also removes the consistent need for `isset` checks as all options should be defined going forward.

The one catch here though is the resolver is by design a bit strict about what values it will accept, and this will make it so that you cannot inject options into the constructor that the resolver's definition does not know for a driver class.