### PR TITLE
Correctly escape NULL byte in sqlsrv driver

### DIFF
--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -28,6 +28,7 @@ class SqlsrvDriverTest extends SqlsrvCase
 		return array(
 			array("'%_abc123[]", false, "''%_abc123[]"),
 			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
+			array("binary\000data", false, "binary' + CHAR(0) + N'data"),
 		);
 	}
 

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -223,6 +223,9 @@ class SqlsrvDriver extends DatabaseDriver
 	{
 		$result = str_replace("'", "''", $text);
 
+		// SQL Server does not accept NULL byte in query string
+		$result = str_replace("\0", "' + CHAR(0) + N'", $result);
+
 		// Fix for SQL Sever escape sequence, see https://support.microsoft.com/en-us/kb/164291
 		$result = str_replace(
 			array("\\\n",     "\\\r",     "\\\\\r\r\n"),


### PR DESCRIPTION
### Summary of Changes

Apply changes from CMS
https://github.com/joomla/joomla-cms/pull/14077

### Testing Instructions

### Documentation Changes Required
