### PR TITLE
Fix sqlsrv syntax for query SELECT with DISTINCT and LIMIT

### DIFF
--- a/Tests/Sqlsrv/SqlsrvIteratorTest.php
+++ b/Tests/Sqlsrv/SqlsrvIteratorTest.php
@@ -51,8 +51,8 @@ class SqlsrvIteratorTest extends SqlsrvCase
 				2,
 				0,
 				array(
-					(object) array('title' => 'Testing', 'RowNumber' => '1'),
-					(object) array('title' => 'Testing2', 'RowNumber' => '2')
+					(object) array('title' => 'Testing'),
+					(object) array('title' => 'Testing2')
 				),
 				null
 			),


### PR DESCRIPTION
### Summary of Changes

This is changes applied in J3.8.2 from https://github.com/joomla/joomla-cms/pull/18315
I added new missing methods and variables to `SqlsrvQuery` class.

Ping @wilsonge 


Note:
I'm not sure, may be would be better to set for `$limit` default value `null` instead `0`?