### PR TITLE
[2.0] Deprecate DatabaseDriver::getInstance() and singleton storage

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -165,6 +165,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	 *
 	 * @var    DatabaseDriver[]
 	 * @since  1.0
+	 * @deprecated  3.0  Singleton storage will no longer be supported.
 	 */
 	protected static $instances = [];
 
@@ -266,9 +267,19 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	 *
 	 * @since   1.0
 	 * @throws  \RuntimeException
+	 * @deprecated  3.0  Use DatabaseFactory::getDriver() instead
 	 */
 	public static function getInstance(array $options = [])
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::getDriver() instead.',
+				__METHOD__,
+				DatabaseFactory::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		// Sanitize the database connector options.
 		$options['driver']   = isset($options['driver']) ? preg_replace('/[^A-Z0-9_\.-]/i', '', $options['driver']) : 'mysqli';
 		$options['database'] = isset($options['database']) ? $options['database'] : null;


### PR DESCRIPTION
### Summary of Changes

Singleton storage is really an application level responsibility, at this level I would suggest there is no longer a need to maintain support for singleton drivers.  This PR deprecates that in favor of using the `DatabaseFactory` (which, an application may subclass to retain this functionality if needed).

### Testing Instructions

Code review

### Documentation Changes Required

N/A, docs not started for package yet