### PR TITLE
DatabaseDriver function `__call()` docblock return is mixed

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -443,7 +443,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 * @param   string  $method  The called method.
 	 * @param   array   $args    The array of arguments passed to the method.
 	 *
-	 * @return  string  The aliased method's return value or null.
+	 * @return  mixed  The aliased method's return value or null.
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Pull Request for Issue #107 

### Summary of Changes
changes docblock return type to mixed for a magic method

### Testing Instructions
merge by code review
### Documentation Changes Required
I don't believe there are any documentation changes. 