### PR TITLE
Return type for magic method in DatabaseQuery is mixed

### DIFF
--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -201,7 +201,7 @@ abstract class DatabaseQuery
 	 * @param   string  $method  The called method.
 	 * @param   array   $args    The array of arguments passed to the method.
 	 *
-	 * @return  string  The aliased method's return value or null.
+	 * @return  mixed  The aliased method's return value or null.
 	 *
 	 * @since   1.0
 	 */


### PR DESCRIPTION
Pull Request for Issue #107 #108 

### Summary of Changes
Follow up to #108 same type of issue as in #107

Corrects Magic method docblock  return type to mixed

### Testing Instructions
code review

### Documentation Changes Required
none