### PR TITLE
Fix Appveyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,17 +38,26 @@ install:
     - ps: >-
         If ($env:PHP -eq "1") {
           If ($env:php_ver_target -eq "5.6") {
-            appveyor DownloadFile https://cdn.joomla.org/ci/php-sqlsrv.zip
+            $source = "https://cdn.joomla.org/ci/php-sqlsrv.zip"
+            $destination = "c:\tools\php\php-sqlsrv.zip"
+            Invoke-WebRequest $source -OutFile $destination
+            #appveyor-retry appveyor DownloadFile https://cdn.joomla.org/ci/php-sqlsrv.zip
             7z x php-sqlsrv.zip > $null
             copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
             copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll
             Remove-Item c:\tools\php\* -include .zip
             } Else {
-            $DLLVersion = "4.1.6.1"
+            $DLLVersion = "4.3.0"
             cd c:\tools\php\ext
-            appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
+            $source = "http://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip"
+            $destination = "c:\tools\php\ext\php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip"
+            Invoke-WebRequest $source -OutFile $destination
+            #appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
             7z x -y php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
-            appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
+            $source = "http://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip"
+            $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip"
+            Invoke-WebRequest $source -OutFile $destination
+            #appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
             7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
             Remove-Item c:\tools\php\ext* -include .zip
             cd c:\tools\php}}


### PR DESCRIPTION
Pull Request for Issue Appveyor builds are failing

### Summary of Changes
When you use appveyor command-line utility to download, its user-agent is empty, 
Some sites do not allow empty user-agents to download. 
Use powershell 'Invoke-WebRequest' Workaround until appveyor fixes their command-line utility to have a user agent

bump the SQLSVR dll version

### Testing Instructions
Appveyor now works

### Documentation Changes Required
none