### PR TITLE
[2.0] Have the base QueryInterface extend PrepareableInterface, require prepared statement support always

### DIFF
--- a/Tests/Mock/Query.php
+++ b/Tests/Mock/Query.php
@@ -13,4 +13,104 @@ namespace Joomla\Database\Tests\Mock;
  */
 class Query extends \Joomla\Database\DatabaseQuery
 {
+	/**
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bounded = [];
+
+	/**
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
+	 *
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           $value          The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
+	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
+	 * @param   array           $driverOptions  Optional driver options to be used.
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function bind($key = null, &$value = null, $dataType = \PDO::PARAM_STR, $length = 0, $driverOptions = [])
+	{
+		// Case 1: Empty Key (reset $bounded array)
+		if (empty($key))
+		{
+			$this->bounded = [];
+
+			return $this;
+		}
+
+		// Case 2: Key Provided, null value (unset key from $bounded array)
+		if (is_null($value))
+		{
+			if (isset($this->bounded[$key]))
+			{
+				unset($this->bounded[$key]);
+			}
+
+			return $this;
+		}
+
+		$obj = new \stdClass;
+
+		$obj->value         = &$value;
+		$obj->dataType      = $dataType;
+		$obj->length        = $length;
+		$obj->driverOptions = $driverOptions;
+
+		// Case 3: Simply add the Key/Value into the bounded array
+		$this->bounded[$key] = $obj;
+
+		return $this;
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case null:
+				$this->bounded = array();
+				break;
+		}
+
+		return parent::clear($clause);
+	}
+
+	/**
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is returned.
+	 *
+	 * @param   mixed  $key  The bounded variable key to retrieve.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function &getBounded($key = null)
+	{
+		if (empty($key))
+		{
+			return $this->bounded;
+		}
+
+		if (isset($this->bounded[$key]))
+		{
+			return $this->bounded[$key];
+		}
+	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,2 @@
+* [Overview](overview.md)
+* [Updating from v1 to v2](v1-to-v2-update.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,4 @@
+## Overview
+
+The Database package provides an abstraction layer for cross-database compatibility in PHP applications.
+

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,0 +1,60 @@
+## Updating from v1 to v2
+
+The following changes were made to the Database package between v1 and v2.
+
+### Minimum supported PHP version raised
+
+All Framework packages now require PHP 7.0 or newer.
+
+### Minimum supported database versions raised
+
+The following are the minimum supported database versions:
+
+- MySQL: 5.5.3
+- PostgreSQL: 9.2.0
+
+### `Joomla\Database\DatabaseInterface` populated
+
+`Joomla\Database\DatabaseInterface` has been filled with most of the public methods of `Joomla\Database\DatabaseDatabase`.
+
+### `Joomla\Database\QueryInterface` added
+
+`Joomla\Database\QueryInterface` has been added to the package. All query objects must now implement this interface.
+
+### Support for parameterized queries required
+
+`Joomla\Database\QueryInterface` extends `Joomla\Database\Query\PrepareableInterface`, which is the interface defining that
+a query supports parameterized queries. This effectively mandates that all query objects support parameterized queries.
+
+### Abstraction layer for parameterized queries
+
+For drivers which support defining an argument's type, the method required passing a parameter specific to the driver's implementation.
+As of 2.0, there is now a `Joomla\Database\ParameterType` object defining supported data types in an abstract manner.
+`Joomla\Database\Query\PrepareableInterface` implementations should map this argument to the driver specific data type when applicable.
+
+### `Joomla\Database\DatabaseDriver` general changes
+
+The base `Joomla\Database\DatabaseDriver` class has undergone several underlying API changes to create a more flexible platform moving forward.
+Significant changes include:
+
+#### Debug mode removed
+
+The database driver's debug mode, and corresponding `setDebug` API and `$debug` property, have been removed
+
+#### Query monitors added
+
+Database drivers now support monitors via a `Joomla\Database\QueryMonitorInterface` implementation. This implementation is loosely modeled on the
+Doctrine SQLLogger interface.
+
+#### PSR-3 support removed
+
+Database drivers are no longer logger aware, logging should instead be performed in a query monitor if desired.
+
+#### Connection events added
+
+Database drivers now support dispatching read-only events when a connection to the database is opened or closed.
+
+#### Singleton storage deprecated
+
+`Joomla\Database\DatabaseDriver::getInstance()` has been deprecated and will be removed in 3.0. Applications which require support for singleton object
+storage should extend `Joomla\Database\DatabaseFactory::getDriver()` implementing their additional logic.

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -12,14 +12,13 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\MysqlQueryBuilder;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * MySQLi Query Building Class.
  *
  * @since  1.0
  */
-class MysqliQuery extends DatabaseQuery implements LimitableInterface, PreparableInterface
+class MysqliQuery extends DatabaseQuery implements LimitableInterface
 {
 	use MysqlQueryBuilder;
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -15,7 +15,6 @@ use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * Joomla Framework PDO Database Driver Class
@@ -402,15 +401,12 @@ abstract class PdoDriver extends DatabaseDriver
 
 		if ($this->prepared instanceof \PDOStatement)
 		{
-			// Bind the variables:
-			if ($this->sql instanceof PreparableInterface)
-			{
-				$bounded =& $this->sql->getBounded();
+			// Bind the variables
+			$bounded =& $this->sql->getBounded();
 
-				foreach ($bounded as $key => $obj)
-				{
-					$this->prepared->bindParam($key, $obj->value, $obj->dataType, $obj->length, $obj->driverOptions);
-				}
+			foreach ($bounded as $key => $obj)
+			{
+				$this->prepared->bindParam($key, $obj->value, $obj->dataType, $obj->length, $obj->driverOptions);
 			}
 
 			$this->executed = $this->prepared->execute();

--- a/src/Pdo/PdoQuery.php
+++ b/src/Pdo/PdoQuery.php
@@ -11,14 +11,13 @@ namespace Joomla\Database\Pdo;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Query\LimitableInterface;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * PDO Query Building Class.
  *
  * @since  1.0
  */
-abstract class PdoQuery extends DatabaseQuery implements LimitableInterface, PreparableInterface
+abstract class PdoQuery extends DatabaseQuery implements LimitableInterface
 {
 	/**
 	 * The offset for the result set.

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -16,7 +16,6 @@ use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * PostgreSQL Database Driver
@@ -682,20 +681,12 @@ class PostgresqlDriver extends DatabaseDriver
 		$this->errorMsg = '';
 
 		// Bind the variables
-		if ($this->sql instanceof PreparableInterface)
-		{
-			$bounded =& $this->sql->getBounded();
+		$bounded =& $this->sql->getBounded();
 
-			if (count($bounded))
-			{
-				// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
-				$this->cursor = @pg_execute($this->connection, $this->queryName . $count, array_values($bounded));
-			}
-			else
-			{
-				// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
-				$this->cursor = @pg_query($this->connection, $sql);
-			}
+		if (count($bounded))
+		{
+			// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
+			$this->cursor = @pg_execute($this->connection, $this->queryName . $count, array_values($bounded));
 		}
 		else
 		{

--- a/src/Postgresql/PostgresqlQuery.php
+++ b/src/Postgresql/PostgresqlQuery.php
@@ -12,14 +12,13 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PostgresqlQueryBuilder;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * PostgreSQL Query Building Class.
  *
  * @since  1.0
  */
-class PostgresqlQuery extends DatabaseQuery implements LimitableInterface, PreparableInterface
+class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 {
 	use PostgresqlQueryBuilder;
 

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -8,12 +8,14 @@
 
 namespace Joomla\Database;
 
+use Joomla\Database\Query\PreparableInterface;
+
 /**
  * Joomla Framework Query Building Interface.
  *
  * @since  __DEPLOY_VERSION__
  */
-interface QueryInterface
+interface QueryInterface extends PreparableInterface
 {
 	/**
 	 * Convert the query object to a string.

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -16,7 +16,6 @@ use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Query\LimitableInterface;
-use Joomla\Database\Query\PreparableInterface;
 
 /**
  * SQL Server Database Driver
@@ -609,18 +608,15 @@ class SqlsrvDriver extends DatabaseDriver
 
 		$params = [];
 
-		// Bind the variables:
-		if ($this->sql instanceof PreparableInterface)
-		{
-			$bounded =& $this->sql->getBounded();
+		// Bind the variables
+		$bounded =& $this->sql->getBounded();
 
-			if (count($bounded))
+		if (count($bounded))
+		{
+			foreach ($bounded as $key => $obj)
 			{
-				foreach ($bounded as $key => $obj)
-				{
-					// And add the value as an additional param
-					$params[] = $obj->value;
-				}
+				// And add the value as an additional param
+				$params[] = $obj->value;
 			}
 		}
 

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -12,7 +12,6 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Query\LimitableInterface;
-use Joomla\Database\Query\PreparableInterface;
 use Joomla\Database\Query\QueryElement;
 
 /**
@@ -20,7 +19,7 @@ use Joomla\Database\Query\QueryElement;
  *
  * @since  1.0
  */
-class SqlsrvQuery extends DatabaseQuery implements PreparableInterface
+class SqlsrvQuery extends DatabaseQuery
 {
 	/**
 	 * The character(s) used to quote SQL statement names such as table names or field names, etc.


### PR DESCRIPTION
### Summary of Changes

We're now at a point where all drivers support prepared statements.  However, this is still an optional feature and it is possible for query classes to be built without the support.  We should discourage that behavior, therefore I suggest that we have our QueryInterface extend the PrepareableInterface and in effect mandate that Query objects (and drivers) support prepared statements.

### Testing Instructions

N/A, no API changes

### Documentation Changes Required

Note interface requirements