### PR TITLE
Keep order for set operators such as UNION / UNION ALL

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -428,11 +428,9 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function test__toStringUnion()
 	{
-		$this->markTestIncomplete('This test does not work!');
-		$this->instance->select('*')
-			->union('SELECT id FROM a');
+		$this->instance->union('SELECT id FROM a');
 
-		$this->assertEquals('UNION (SELECT id FROM a)', trim($this->instance));
+		$this->assertEquals(PHP_EOL . 'UNION (SELECT id FROM a)', $this->instance);
 	}
 
 	/**
@@ -1881,11 +1879,12 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnion()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->union('SELECT name FROM foo');
-		$teststring = (string) current(TestHelper::getValue($this->instance, 'merge'));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION (SELECT name FROM foo)'),
 			'Tests rendered query with union.'
 		);
@@ -1901,11 +1900,12 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnionDistinctFalse()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->union('SELECT name FROM foo', false);
-		$teststring = (string) current(TestHelper::getValue($this->instance, 'merge'));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION ALL (SELECT name FROM foo)'),
 			'Tests rendered query with union distinct false.'
 		);
@@ -1921,11 +1921,12 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnionAll()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->unionAll('SELECT name FROM foo');
-		$teststring = (string) current(TestHelper::getValue($this->instance, 'merge'));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION ALL (SELECT name FROM foo)'),
 			'Tests rendered query with union all.'
 		);
@@ -1941,12 +1942,13 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnionTwo()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->union('SELECT name FROM foo');
 		$this->instance->union('SELECT name FROM bar');
-		$teststring = implode('', array_map('strval', TestHelper::getValue($this->instance, 'merge')));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION (SELECT name FROM foo)' . PHP_EOL . 'UNION (SELECT name FROM bar)'),
 			'Tests rendered query with two unions sequentially.'
 		);
@@ -1962,12 +1964,13 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnionsOrdering()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->unionAll('SELECT name FROM foo');
 		$this->instance->union('SELECT name FROM bar');
-		$teststring = implode('', array_map('strval', TestHelper::getValue($this->instance, 'merge')));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION ALL (SELECT name FROM foo)' . PHP_EOL . 'UNION (SELECT name FROM bar)'),
 			'Tests rendered query with two different unions sequentially.'
 		);
@@ -1983,12 +1986,13 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testUnionsOrdering2()
 	{
-		TestHelper::setValue($this->instance, 'merge', null);
 		$this->instance->union('SELECT name FROM foo');
 		$this->instance->unionAll('SELECT name FROM bar');
-		$teststring = implode('', array_map('strval', TestHelper::getValue($this->instance, 'merge')));
+
+		$string = implode('', $this->instance->merge);
+
 		$this->assertThat(
-			$teststring,
+			$string,
 			$this->equalTo(PHP_EOL . 'UNION (SELECT name FROM foo)' . PHP_EOL . 'UNION ALL (SELECT name FROM bar)'),
 			'Tests rendered query with two different unions sequentially.'
 		);

--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -340,7 +340,7 @@ class DatabaseQueryTest extends TestCase
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
 					PHP_EOL . 'WHERE b.id = 1' .
-					PHP_EOL . 'UNION (' .
+				PHP_EOL . 'UNION (' .
 					PHP_EOL . 'SELECT a.id' .
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
@@ -381,12 +381,12 @@ class DatabaseQueryTest extends TestCase
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
 					PHP_EOL . 'WHERE b.id = 1' .
-					PHP_EOL . 'UNION (' .
+				PHP_EOL . 'UNION (' .
 					PHP_EOL . 'SELECT a.id' .
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
 					PHP_EOL . 'WHERE b.name = \'_name_\')' .
-					PHP_EOL . 'ORDER BY b.name'
+				PHP_EOL . 'ORDER BY b.name'
 			),
 			'Tests for correct rendering unions with order by.'
 		);
@@ -1987,27 +1987,6 @@ class DatabaseQueryTest extends TestCase
 			$string,
 			$this->equalTo(PHP_EOL . 'UNION (SELECT name FROM foo)'),
 			'Tests rendered query with union.'
-		);
-	}
-
-	/**
-	 * Tests the \Joomla\Database\DatabaseQuery::union method.
-	 *
-	 * @return  void
-	 *
-	 * @covers  \Joomla\Database\DatabaseQuery::union
-	 * @since   1.0
-	 */
-	public function testUnionDistinctFalse()
-	{
-		$this->instance->union('SELECT name FROM foo', false);
-
-		$string = implode('', $this->instance->merge);
-
-		$this->assertThat(
-			$string,
-			$this->equalTo(PHP_EOL . 'UNION ALL (SELECT name FROM foo)'),
-			'Tests rendered query with union distinct false.'
 		);
 	}
 

--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -393,6 +393,105 @@ class DatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for the \Joomla\Database\DatabaseQuery::__string method for a 'querySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy()
+	{
+		$query = new Mock\Query($this->dbo);
+
+		$query->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new Mock\Query($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+
+		$this->instance->querySet($query)
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $this->instance,
+			$this->equalTo(
+				'(' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'UNION (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\DatabaseQuery::__string method for a 'toQuerySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy2()
+	{
+		$this->instance->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new Mock\Query($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+		$query = $this->instance->toQuerySet()
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $query,
+			$this->equalTo(
+				'(' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'UNION (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
 	 * Test for the \Joomla\Database\DatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void
@@ -633,6 +732,7 @@ class DatabaseQueryTest extends TestCase
 			'delete',
 			'update',
 			'insert',
+			'querySet',
 		);
 
 		$clauses = array(

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -1076,4 +1076,74 @@ class PgsqlDriverTest extends PgsqlCase
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
+
+	/**
+	 * Test querySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testQuerySetWithUnionAll()
+	{
+		$query  = self::$driver->getQuery(true);
+		$union1 = self::$driver->getQuery(true);
+		$union2 = self::$driver->getQuery(true);
+
+		$union1->select('id, title')->from('dbtest')->where('id = 4')->setLimit(1);
+
+		$union2->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union2->setLimit(2, 1);
+
+		$query->querySet($union1)->unionAll($union2)->order('id');
+
+		$result = self::$driver->setQuery($query, 0, 3)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test toQuerySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testSelectToQuerySetWithUnionAll()
+	{
+		$query = self::$driver->getQuery(true);
+		$union = self::$driver->getQuery(true);
+
+		$query->select('id, title')->from('dbtest')->where('id = 4');
+		$query = $query->setLimit(1)->toQuerySet();
+
+		$union->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union->setLimit(2, 1);
+
+		$query->unionAll($union)->order('id');
+
+		$result = self::$driver->setQuery($query)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
 }

--- a/Tests/Sqlite/SqliteDriverTest.php
+++ b/Tests/Sqlite/SqliteDriverTest.php
@@ -729,4 +729,74 @@ class SqliteDriverTest extends SqliteCase
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
+
+	/**
+	 * Test querySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testQuerySetWithUnionAll()
+	{
+		$query  = self::$driver->getQuery(true);
+		$union1 = self::$driver->getQuery(true);
+		$union2 = self::$driver->getQuery(true);
+
+		$union1->select('id, title')->from('dbtest')->where('id = 4')->setLimit(1);
+
+		$union2->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union2->setLimit(2, 1);
+
+		$query->querySet($union1)->unionAll($union2)->order('id');
+
+		$result = self::$driver->setQuery($query, 0, 3)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test toQuerySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testSelectToQuerySetWithUnionAll()
+	{
+		$query = self::$driver->getQuery(true);
+		$union = self::$driver->getQuery(true);
+
+		$query->select('id, title')->from('dbtest')->where('id = 4');
+		$query = $query->setLimit(1)->toQuerySet();
+
+		$union->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union->setLimit(2, 1);
+
+		$query->unionAll($union)->order('id');
+
+		$result = self::$driver->setQuery($query)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
 }

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -163,7 +163,7 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
-	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'select' case.
+	 * Test for the \Joomla\Database\Sqlite\SqliteQuery::__string method for a 'select' case.
 	 *
 	 * @return  void
 	 *
@@ -205,7 +205,7 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
-	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'select' case.
+	 * Test for the \Joomla\Database\Sqlite\SqliteQuery::__string method for a 'select' case.
 	 *
 	 * @return  void
 	 *
@@ -249,7 +249,7 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
-	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'querySet' case.
+	 * Test for the \Joomla\Database\Sqlite\SqliteQuery::__string method for a 'querySet' case.
 	 *
 	 * @return  void
 	 *
@@ -301,7 +301,7 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
-	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'toQuerySet' case.
+	 * Test for the \Joomla\Database\Sqlite\SqliteQuery::__string method for a 'toQuerySet' case.
 	 *
 	 * @return  void
 	 *
@@ -1288,7 +1288,7 @@ class SqliteQueryTest extends TestCase
 		);
 	}
 
-		/**
+	/**
 	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
 	 *
 	 * @return  void

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -163,6 +163,194 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectWithUnion()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1');
+
+		$union = new SqliteQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'));
+
+		$thisQuery->union($union);
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\')'
+			),
+			'Tests for correct rendering unions.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectWithUnionAndOrderBy()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('b.name');
+
+		$union = new SqliteQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'));
+
+		$thisQuery->union($union);
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\')' .
+					PHP_EOL . 'ORDER BY b.name'
+			),
+			'Tests for correct rendering unions with order by.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'querySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy()
+	{
+		$query = new SqliteQuery($this->dbo);
+
+		$query->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new SqliteQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->querySet($query)
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Postgresql\SqliteQuery::__string method for a 'toQuerySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy2()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new SqliteQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+		$query = $thisQuery->toQuerySet()
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $query,
+			$this->equalTo(
+				PHP_EOL . 'SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id)' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
 	 * Test for the SqliteQuery::__string method for a 'update' case.
 	 *
 	 * @return  void
@@ -1097,6 +1285,152 @@ class SqliteQueryTest extends TestCase
 			trim($q->processLimit('SELECT foo FROM bar', 5, 10)),
 			$this->equalTo('SELECT foo FROM bar LIMIT 10, 5'),
 			'Tests rendered value.'
+		);
+	}
+
+		/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionChain()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$this->assertThat(
+			$thisQuery->union($thisQuery),
+			$this->identicalTo($thisQuery),
+			'Tests chaining.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnion()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)'),
+			'Tests rendered query with union.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::unionAll method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::unionAll
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionAll()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->unionAll('SELECT name FROM foo');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM foo)'),
+			'Tests rendered query with union all.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionTwo()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+		$thisQuery->union('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two unions sequentially.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionsOrdering()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->unionAll('SELECT name FROM foo');
+		$thisQuery->union('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two different unions sequentially.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlite\SqliteQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlite\SqliteQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionsOrdering2()
+	{
+		$thisQuery = new SqliteQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+		$thisQuery->unionAll('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two different unions sequentially.'
 		);
 	}
 }

--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -590,4 +590,74 @@ class SqlsrvDriverTest extends SqlsrvCase
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
+
+	/**
+	 * Test querySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testQuerySetWithUnionAll()
+	{
+		$query  = self::$driver->getQuery(true);
+		$union1 = self::$driver->getQuery(true);
+		$union2 = self::$driver->getQuery(true);
+
+		$union1->select('id, title')->from('dbtest')->where('id = 4')->setLimit(1);
+
+		$union2->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union2->setLimit(2, 1);
+
+		$query->querySet($union1)->unionAll($union2)->order('id');
+
+		$result = self::$driver->setQuery($query, 0, 3)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
+
+	/**
+	 * Test toQuerySet method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testSelectToQuerySetWithUnionAll()
+	{
+		$query = self::$driver->getQuery(true);
+		$union = self::$driver->getQuery(true);
+
+		$query->select('id, title')->from('dbtest')->where('id = 4');
+		$query = $query->setLimit(1)->toQuerySet();
+
+		$union->select('id, title')->from('dbtest')->where('id < 4')->order('id DESC');
+		$union->setLimit(2, 1);
+
+		$query->unionAll($union)->order('id');
+
+		$result = self::$driver->setQuery($query)->loadAssocList();
+
+		$this->assertThat(
+			$result,
+			$this->equalTo(
+				array(
+					array('id' => '1', 'title' => 'Testing'),
+					array('id' => '2', 'title' => 'Testing2'),
+					array('id' => '4', 'title' => 'Testing4'),
+				)
+			),
+			__LINE__
+		);
+	}
 }

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -165,6 +165,198 @@ class SqlsrvQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for the \Joomla\Database\Sqlsrv\SqlsrvQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectWithUnion()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1');
+
+		$union = new SqlsrvQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'));
+
+		$thisQuery->union($union);
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\') AS merge_1'
+			),
+			'Tests for correct rendering unions.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Sqlsrv\SqlsrvQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectWithUnionAndOrderBy()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('b.name');
+
+		$union = new SqlsrvQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'));
+
+		$thisQuery->union($union);
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\') AS merge_1' .
+					PHP_EOL . 'ORDER BY b.name'
+			),
+			'Tests for correct rendering unions with order by.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Sqlsrv\SqlsrvQuery::__string method for a 'querySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy()
+	{
+		$query = new SqlsrvQuery($this->dbo);
+
+		$query->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new SqlsrvQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->querySet($query)
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $thisQuery,
+			$this->equalTo(
+				PHP_EOL . 'SELECT * FROM (' .
+					PHP_EOL . 'SELECT * FROM (' .
+						PHP_EOL . 'SELECT a.id' .
+						PHP_EOL . 'FROM a' .
+						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+						PHP_EOL . 'WHERE b.id = 1' .
+						PHP_EOL . 'ORDER BY a.id) AS merge_0' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+						PHP_EOL . 'SELECT a.id' .
+						PHP_EOL . 'FROM a' .
+						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+						PHP_EOL . 'WHERE b.name = \'_name_\'' .
+						PHP_EOL . 'ORDER BY a.id) AS merge_1' .
+					PHP_EOL . ') AS merges' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
+	 * Test for the \Joomla\Database\Sqlsrv\SqlsrvQuery::__string method for a 'toQuerySet' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringQuerySetWithIndividualOrderBy2()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->order('a.id');
+
+		$union = new SqlsrvQuery($this->dbo);
+
+		$union->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.name = ' . $union->quote('name'))
+			->order('a.id');
+
+		$query = $thisQuery->toQuerySet()
+			->union($union)
+			->order('id');
+
+		$this->assertThat(
+			(string) $query,
+			$this->equalTo(
+				PHP_EOL . 'SELECT * FROM (' .
+					PHP_EOL . 'SELECT * FROM (' .
+						PHP_EOL . 'SELECT a.id' .
+						PHP_EOL . 'FROM a' .
+						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+						PHP_EOL . 'WHERE b.id = 1' .
+						PHP_EOL . 'ORDER BY a.id) AS merge_0' .
+					PHP_EOL . 'UNION SELECT * FROM (' .
+						PHP_EOL . 'SELECT a.id' .
+						PHP_EOL . 'FROM a' .
+						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+						PHP_EOL . 'WHERE b.name = \'_name_\'' .
+						PHP_EOL . 'ORDER BY a.id) AS merge_1' .
+					PHP_EOL . ') AS merges' .
+				PHP_EOL . 'ORDER BY id'
+			),
+			'Tests for correct rendering querySet with global order by.'
+		);
+	}
+
+	/**
 	 * Test for the SqlsrvQuery::__string method for a 'update' case.
 	 *
 	 * @return  void
@@ -1082,16 +1274,164 @@ class SqlsrvQueryTest extends TestCase
 			$q->processLimit((string) $q, 30)
 		);
 
+		$aliasForRowNumer = 'RowNumber_' . md5(spl_object_hash($q));
+
 		$this->assertEquals(
 			PHP_EOL . 'SELECT * FROM (' .
-			PHP_EOL . 'SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber' .
+			PHP_EOL . 'SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS ' . $aliasForRowNumer .
 			PHP_EOL . 'FROM (' .
 			PHP_EOL . 'SELECT TOP 4 id,COUNT(*) AS count' .
 			PHP_EOL . 'FROM a' .
 			PHP_EOL . 'WHERE id = 1) AS A' .
 			PHP_EOL . ') AS A' .
-			PHP_EOL . 'WHERE RowNumber > 3',
+			PHP_EOL . 'WHERE ' . $aliasForRowNumer . ' > 3',
 			$q->processLimit((string) $q, 1, 3)
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionChain()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$this->assertThat(
+			$thisQuery->union($thisQuery),
+			$this->identicalTo($thisQuery),
+			'Tests chaining.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnion()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)'),
+			'Tests rendered query with union.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::unionAll method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::unionAll
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionAll()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->unionAll('SELECT name FROM foo');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM foo)'),
+			'Tests rendered query with union all.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionTwo()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+		$thisQuery->union('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two unions sequentially.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionsOrdering()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->unionAll('SELECT name FROM foo');
+		$thisQuery->union('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two different unions sequentially.'
+		);
+	}
+
+	/**
+	 * Tests the \Joomla\Database\Sqlsrv\SqlsrvQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  \Joomla\Database\Sqlsrv\SqlsrvQuery::union
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testUnionsOrdering2()
+	{
+		$thisQuery = new SqlsrvQuery($this->dbo);
+
+		$thisQuery->union('SELECT name FROM foo');
+		$thisQuery->unionAll('SELECT name FROM bar');
+
+		$string = implode('', $thisQuery->merge);
+
+		$this->assertThat(
+			$string,
+			$this->equalTo(
+				PHP_EOL . 'UNION SELECT * FROM (SELECT name FROM foo)' .
+				PHP_EOL . 'UNION ALL SELECT * FROM (SELECT name FROM bar)'
+			),
+			'Tests rendered query with two different unions sequentially.'
 		);
 	}
 }

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -288,19 +288,17 @@ class SqlsrvQueryTest extends TestCase
 			(string) $thisQuery,
 			$this->equalTo(
 				PHP_EOL . 'SELECT * FROM (' .
-					PHP_EOL . 'SELECT * FROM (' .
-						PHP_EOL . 'SELECT a.id' .
-						PHP_EOL . 'FROM a' .
-						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-						PHP_EOL . 'WHERE b.id = 1' .
-						PHP_EOL . 'ORDER BY a.id) AS merge_0' .
-					PHP_EOL . 'UNION SELECT * FROM (' .
-						PHP_EOL . 'SELECT a.id' .
-						PHP_EOL . 'FROM a' .
-						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-						PHP_EOL . 'WHERE b.name = \'_name_\'' .
-						PHP_EOL . 'ORDER BY a.id) AS merge_1' .
-					PHP_EOL . ') AS merges' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id) AS merge_0' .
+				PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id) AS merge_1' .
 				PHP_EOL . 'ORDER BY id'
 			),
 			'Tests for correct rendering querySet with global order by.'
@@ -340,19 +338,17 @@ class SqlsrvQueryTest extends TestCase
 			(string) $query,
 			$this->equalTo(
 				PHP_EOL . 'SELECT * FROM (' .
-					PHP_EOL . 'SELECT * FROM (' .
-						PHP_EOL . 'SELECT a.id' .
-						PHP_EOL . 'FROM a' .
-						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-						PHP_EOL . 'WHERE b.id = 1' .
-						PHP_EOL . 'ORDER BY a.id) AS merge_0' .
-					PHP_EOL . 'UNION SELECT * FROM (' .
-						PHP_EOL . 'SELECT a.id' .
-						PHP_EOL . 'FROM a' .
-						PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-						PHP_EOL . 'WHERE b.name = \'_name_\'' .
-						PHP_EOL . 'ORDER BY a.id) AS merge_1' .
-					PHP_EOL . ') AS merges' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.id = 1' .
+					PHP_EOL . 'ORDER BY a.id) AS merge_0' .
+				PHP_EOL . 'UNION SELECT * FROM (' .
+					PHP_EOL . 'SELECT a.id' .
+					PHP_EOL . 'FROM a' .
+					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . 'ORDER BY a.id) AS merge_1' .
 				PHP_EOL . 'ORDER BY id'
 			),
 			'Tests for correct rendering querySet with global order by.'

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -200,7 +200,9 @@ class SqlsrvQueryTest extends TestCase
 					PHP_EOL . 'SELECT a.id' .
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-					PHP_EOL . 'WHERE b.name = \'_name_\') AS merge_1'
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . '/*ORDER BY (SELECT 0)*/) AS merge_1' .
+					PHP_EOL . '/*ORDER BY (SELECT 0)*/'
 			),
 			'Tests for correct rendering unions.'
 		);
@@ -243,7 +245,8 @@ class SqlsrvQueryTest extends TestCase
 					PHP_EOL . 'SELECT a.id' .
 					PHP_EOL . 'FROM a' .
 					PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
-					PHP_EOL . 'WHERE b.name = \'_name_\') AS merge_1' .
+					PHP_EOL . 'WHERE b.name = \'_name_\'' .
+					PHP_EOL . '/*ORDER BY (SELECT 0)*/) AS merge_1' .
 					PHP_EOL . 'ORDER BY b.name'
 			),
 			'Tests for correct rendering unions with order by.'

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -58,3 +58,20 @@ Database drivers now support dispatching read-only events when a connection to t
 
 `Joomla\Database\DatabaseDriver::getInstance()` has been deprecated and will be removed in 3.0. Applications which require support for singleton object
 storage should extend `Joomla\Database\DatabaseFactory::getDriver()` implementing their additional logic.
+
+### `Joomla\Database\DatabaseQuery` general changes
+
+#### Changes in methods `union()`, `unionAll()` and `unionDistinct()`
+
+- Method `unionDistinct()` has been removed. Use `union()` instead.
+- Argument `$query` stops accepting the array. Only `DatabaseQuery` object or string.
+- Argument `$distinct` has been removed from `unionAll`.
+- Argument `$glue` has been removed from both.
+
+Method `union()` by default has `$distinct = true`.
+If `$distinct` is `false` then generates `UNION ALL` sql statement.
+
+Class variables `$union` and `$unionAll` has been merged into one variable `$merge`.
+The new variable represents an ordered array of individual elements.
+
+Stop supporting `$type = 'union'` in method `__toString()`.

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -75,3 +75,10 @@ Class variables `$union` and `$unionAll` have been merged into one variable `$me
 The new variable represents an ordered array of individual elements.
 
 Stop supporting `$type = 'union'` in method `__toString()`.
+
+New methods:
+- `querySet($query)` changes object type to querySet and set a query in query set.
+- `toQuerySet()` from current object creates DatabaseQuery of type querySet.
+
+The DatabaseQuery object of type querySet can be used to generate a union query
+where the first SELECT statement has own ORDER BY and LIMIT.

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -71,7 +71,7 @@ storage should extend `Joomla\Database\DatabaseFactory::getDriver()` implementin
 Method `union()` by default has `$distinct = true`.
 If `$distinct` is `false` then generates `UNION ALL` sql statement.
 
-Class variables `$union` and `$unionAll` has been merged into one variable `$merge`.
+Class variables `$union` and `$unionAll` have been merged into one variable `$merge`.
 The new variable represents an ordered array of individual elements.
 
 Stop supporting `$type = 'union'` in method `__toString()`.

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -90,7 +90,7 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * The join element.
 	 *
-	 * @var    Query\QueryElement
+	 * @var    Query\QueryElement[]
 	 * @since  1.0
 	 */
 	protected $join = null;
@@ -176,7 +176,7 @@ abstract class DatabaseQuery implements QueryInterface
 	protected $exec = null;
 
 	/**
-	 * The merge element may include UNION, UNION ALL, EXCEPT and INTERSECT.
+	 * The list of query elements, which may include UNION, UNION ALL, EXCEPT and INTERSECT.
 	 *
 	 * @var    Query\QueryElement[]
 	 * @since  __DEPLOY_VERSION__
@@ -263,9 +263,9 @@ abstract class DatabaseQuery implements QueryInterface
 					if ($this->merge)
 					{
 						// Special case for merge
-						foreach ($this->merge as $merge)
+						foreach ($this->merge as $element)
 						{
-							$query .= (string) $merge;
+							$query .= (string) $element;
 						}
 					}
 				}
@@ -519,6 +519,10 @@ abstract class DatabaseQuery implements QueryInterface
 				$this->having = null;
 				break;
 
+			case 'merge':
+				$this->merge = null;
+				break;
+
 			case 'order':
 				$this->order = null;
 				break;
@@ -550,10 +554,6 @@ abstract class DatabaseQuery implements QueryInterface
 				$this->offset = 0;
 				break;
 
-			case 'merge':
-				$this->merge = null;
-				break;
-
 			default:
 				$this->type               = null;
 				$this->select             = null;
@@ -567,13 +567,13 @@ abstract class DatabaseQuery implements QueryInterface
 				$this->where              = null;
 				$this->group              = null;
 				$this->having             = null;
+				$this->merge              = null;
 				$this->order              = null;
 				$this->columns            = null;
 				$this->values             = null;
 				$this->autoIncrementField = null;
 				$this->exec               = null;
 				$this->call               = null;
-				$this->merge              = null;
 				$this->offset             = 0;
 				$this->limit              = 0;
 				break;
@@ -1599,10 +1599,10 @@ abstract class DatabaseQuery implements QueryInterface
 
 	/**
 	 * Combine a select statement to the current query by one of the set operators.
-	 * Example operators: UNION, UNION ALL, EXCEPT or INTERSECT.
+	 * Operators: UNION, UNION ALL, EXCEPT or INTERSECT.
 	 *
-	 * @param   string                $name   The name of the operator with parentheses.
 	 * @param   DatabaseQuery|string  $query  The DatabaseQuery object or string.
+	 * @param   string                $name   The name of the set operator with parentheses.
 	 *
 	 * @return  $this
 	 *
@@ -1610,6 +1610,8 @@ abstract class DatabaseQuery implements QueryInterface
 	 */
 	protected function merge($name, $query)
 	{
+		$this->type = $this->type ?: 'select';
+
 		$this->merge[] = new Query\QueryElement($name, $query);
 
 		return $this;

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1704,7 +1704,7 @@ abstract class DatabaseQuery implements QueryInterface
 	 *       ->order('name')
 	 *       ->setLimit(1)
 	 *
-	 * @param   DatabaseQuery|string  $query  The DatabaseQuery object or string.
+	 * @param   DatabaseQuery  $query  The DatabaseQuery object or string.
 	 *
 	 * @return  $this
 	 *
@@ -1724,7 +1724,7 @@ abstract class DatabaseQuery implements QueryInterface
 	 *
 	 * Usage:
 	 * $query->select('name')->from('#__foo')->order('id DESC')->setLimit(1)
-	 *       ->toQuerySets()
+	 *       ->toQuerySet()
 	 *       ->unionAll($query2->select('name')->from('#__foo')->order('id')->setLimit(1))
 	 *       ->order('name')
 	 *       ->setLimit(1)

--- a/src/Exception/PrepareStatementFailureException.php
+++ b/src/Exception/PrepareStatementFailureException.php
@@ -15,4 +15,18 @@ namespace Joomla\Database\Exception;
  */
 class PrepareStatementFailureException extends \RuntimeException
 {
+	/**
+	 * Construct the exception
+	 *
+	 * @param   string     $message   The Exception message to throw. [optional]
+	 * @param   integer    $code      The Exception code. [optional]
+	 * @param   Exception  $previous  The previous exception used for the exception chaining. [optional]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($message = '', $code = 0, \Exception $previous = null)
+	{
+		// PDOException redefines $code as a string and now we have to cast it again to an integer.
+		parent::__construct($message, (int) $code, $previous);
+	}
 }

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -681,7 +681,7 @@ abstract class PdoDriver extends DatabaseDriver
 		}
 		catch (\PDOException $exception)
 		{
-			throw new PrepareStatementFailureException($exception->getMessage(), (int) $exception->getCode(), $exception);
+			throw new PrepareStatementFailureException($exception->getMessage(), $exception->getCode(), $exception);
 		}
 	}
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -681,7 +681,7 @@ abstract class PdoDriver extends DatabaseDriver
 		}
 		catch (\PDOException $exception)
 		{
-			throw new PrepareStatementFailureException($exception->getMessage(), $exception->getCode(), $exception);
+			throw new PrepareStatementFailureException($exception->getMessage() . $query, (int) $exception->getCode(), $exception);
 		}
 	}
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -681,7 +681,7 @@ abstract class PdoDriver extends DatabaseDriver
 		}
 		catch (\PDOException $exception)
 		{
-			throw new PrepareStatementFailureException($exception->getMessage() . $query, (int) $exception->getCode(), $exception);
+			throw new PrepareStatementFailureException($exception->getMessage(), (int) $exception->getCode(), $exception);
 		}
 	}
 

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -71,6 +71,15 @@ class PgsqlQuery extends PdoQuery
 					$query .= (string) $this->having;
 				}
 
+				if ($this->merge)
+				{
+					// Special case for merge
+					foreach ($this->merge as $element)
+					{
+						$query .= (string) $element;
+					}
+				}
+
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
@@ -213,12 +222,14 @@ class PgsqlQuery extends PdoQuery
 			case 'update':
 			case 'delete':
 			case 'insert':
+			case 'querySet':
 			case 'from':
 			case 'join':
 			case 'set':
 			case 'where':
 			case 'group':
 			case 'having':
+			case 'merge':
 			case 'order':
 			case 'columns':
 			case 'values':

--- a/src/Postgresql/PostgresqlQuery.php
+++ b/src/Postgresql/PostgresqlQuery.php
@@ -147,6 +147,15 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 					$query .= (string) $this->having;
 				}
 
+				if ($this->merge)
+				{
+					// Special case for merge
+					foreach ($this->merge as $element)
+					{
+						$query .= (string) $element;
+					}
+				}
+
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
@@ -289,12 +298,14 @@ class PostgresqlQuery extends DatabaseQuery implements LimitableInterface
 			case 'update':
 			case 'delete':
 			case 'insert':
+			case 'querySet':
 			case 'from':
 			case 'join':
 			case 'set':
 			case 'where':
 			case 'group':
 			case 'having':
+			case 'merge':
 			case 'order':
 			case 'columns':
 			case 'values':

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -567,4 +567,38 @@ interface QueryInterface extends PreparableInterface
 	 * @since   1.5.0
 	 */
 	public function unionAll($query);
+
+	/**
+	 * Set a single query to the query set.
+	 * On this type of DatabaseQuery you can use union(), unioAll(), order() and setLimit()
+	 *
+	 * Usage:
+	 * $query->querySet($query2->select('name')->from('#__foo')->order('id DESC')->setLimit(1))
+	 *       ->unionAll($query3->select('name')->from('#__foo')->order('id')->setLimit(1))
+	 *       ->order('name')
+	 *       ->setLimit(1)
+	 *
+	 * @param   DatabaseQuery|string  $query  The DatabaseQuery object or string.
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function querySet($query);
+
+	/**
+	 * Create a DatabaseQuery object of type querySet from current query.
+	 *
+	 * Usage:
+	 * $query->select('name')->from('#__foo')->order('id DESC')->setLimit(1)
+	 *       ->toQuerySets()
+	 *       ->unionAll($query2->select('name')->from('#__foo')->order('id')->setLimit(1))
+	 *       ->order('name')
+	 *       ->setLimit(1)
+	 *
+	 * @return  DatabaseQuery  A new object of the DatabaseQuery.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function toQuerySet();
 }

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -554,7 +554,7 @@ interface QueryInterface extends PreparableInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function union($query, $distinct = false, $glue = '');
+	public function union($query, $distinct = false);
 
 	/**
 	 * Add a query to UNION ALL with the current query.
@@ -573,5 +573,5 @@ interface QueryInterface extends PreparableInterface
 	 * @see     union
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function unionAll($query, $distinct = false, $glue = '');
+	public function unionAll($query);
 }

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -591,7 +591,7 @@ interface QueryInterface extends PreparableInterface
 	 *
 	 * Usage:
 	 * $query->select('name')->from('#__foo')->order('id DESC')->setLimit(1)
-	 *       ->toQuerySets()
+	 *       ->toQuerySet()
 	 *       ->unionAll($query2->select('name')->from('#__foo')->order('id')->setLimit(1))
 	 *       ->order('name')
 	 *       ->setLimit(1)

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -539,39 +539,32 @@ interface QueryInterface extends PreparableInterface
 
 	/**
 	 * Add a query to UNION with the current query.
-	 * Multiple unions each require separate statements and create an array of unions.
 	 *
 	 * Usage:
 	 * $query->union('SELECT name FROM  #__foo')
-	 * $query->union('SELECT name FROM  #__foo','distinct')
-	 * $query->union(array('SELECT name FROM  #__foo', 'SELECT name FROM  #__bar'))
+	 * $query->union('SELECT name FROM  #__foo', true)
 	 *
-	 * @param   QueryInterface|string  $query     The QueryInterface object or string to union.
-	 * @param   boolean                $distinct  True to only return distinct rows from the union.
-	 * @param   string                 $glue      The glue by which to join the conditions.
+	 * @param   DatabaseQuery|string  $query     The DatabaseQuery object or string to union.
+	 * @param   boolean               $distinct  True to only return distinct rows from the union.
 	 *
 	 * @return  $this
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.0
 	 */
-	public function union($query, $distinct = false);
+	public function union($query, $distinct = true);
 
 	/**
 	 * Add a query to UNION ALL with the current query.
-	 * Multiple unions each require separate statements and create an array of unions.
 	 *
 	 * Usage:
-	 * $query->union('SELECT name FROM  #__foo')
-	 * $query->union(array('SELECT name FROM  #__foo','SELECT name FROM  #__bar'))
+	 * $query->unionAll('SELECT name FROM  #__foo')
 	 *
-	 * @param   DatabaseQuery|string  $query     The DatabaseQuery object or string to union.
-	 * @param   boolean               $distinct  Not used - ignored.
-	 * @param   string                $glue      The glue by which to join the conditions.
+	 * @param   DatabaseQuery|string  $query  The DatabaseQuery object or string to union.
 	 *
 	 * @return  $this
 	 *
 	 * @see     union
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.5.0
 	 */
 	public function unionAll($query);
 }

--- a/src/Sqlite/SqliteQuery.php
+++ b/src/Sqlite/SqliteQuery.php
@@ -73,7 +73,7 @@ class SqliteQuery extends PdoQuery
 			case 'querySet':
 				$query = $this->querySet;
 
-				if ($query->order || ($query instanceof Query\LimitableInterface && ($query->limit || $query->offset)))
+				if ($query->order || $query->limit || $query->offset)
 				{
 					// If ORDER BY or LIMIT statement exist then parentheses is required for the first query
 					$query = PHP_EOL . "SELECT * FROM ($query)";

--- a/src/Sqlite/SqliteQuery.php
+++ b/src/Sqlite/SqliteQuery.php
@@ -70,6 +70,31 @@ class SqliteQuery extends PdoQuery
 
 				break;
 
+			case 'querySet':
+				$query = $this->querySet;
+
+				if ($query->order || ($query instanceof Query\LimitableInterface && ($query->limit || $query->offset)))
+				{
+					// If ORDER BY or LIMIT statement exist then parentheses is required for the first query
+					$query = PHP_EOL . "SELECT * FROM ($query)";
+				}
+
+				if ($this->merge)
+				{
+					// Special case for merge
+					foreach ($this->merge as $element)
+					{
+						$query .= (string) $element;
+					}
+				}
+
+				if ($this->order)
+				{
+					$query .= (string) $this->order;
+				}
+
+				return $query;
+
 			case 'update':
 				if ($this->join)
 				{
@@ -210,5 +235,25 @@ class SqliteQuery extends PdoQuery
 		$this->validateRowNumber($orderBy, $orderColumnAlias);
 
 		return $this;
+	}
+
+	/**
+	 * Add a query to UNION with the current query.
+	 *
+	 * Usage:
+	 * $query->union('SELECT name FROM  #__foo')
+	 * $query->union('SELECT name FROM  #__foo', true)
+	 *
+	 * @param   DatabaseQuery|string  $query     The DatabaseQuery object or string to union.
+	 * @param   boolean               $distinct  True to only return distinct rows from the union.
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.0
+	 */
+	public function union($query, $distinct = true)
+	{
+		// Set up the name with parentheses, the DISTINCT flag is redundant
+		return $this->merge($distinct ? 'UNION SELECT * FROM ()' : 'UNION ALL SELECT * FROM ()', $query);
 	}
 }

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -166,12 +166,6 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 					}
 				}
 
-				if ($this->order || $this->limit || $this->offset)
-				{
-					// Merge sets has to be wrapped
-					$query = PHP_EOL . 'SELECT * FROM (' . $query . PHP_EOL . ') AS merges';
-				}
-
 				if ($this->order)
 				{
 					$query .= (string) $this->order;

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -121,6 +121,15 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 					{
 						$query .= (string) $this->having;
 					}
+
+					if ($this->merge)
+					{
+						// Special case for merge
+						foreach ($this->merge as $element)
+						{
+							$query .= (string) $element;
+						}
+					}
 				}
 
 				if ($this->order)

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -141,10 +141,7 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 					$query .= PHP_EOL . '/*ORDER BY (SELECT 0)*/';
 				}
 
-				if ($this->limit > 0 || $this->offset > 0)
-				{
-					$query = $this->processLimit($query, $this->limit, $this->offset);
-				}
+				$query = $this->processLimit($query, $this->limit, $this->offset);
 
 				break;
 

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -148,7 +148,7 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 			case 'querySet':
 				$query = $this->querySet;
 
-				if ($query->order || ($query instanceof Query\LimitableInterface && ($query->limit || $query->offset)))
+				if ($query->order || $query->limit || $query->offset)
 				{
 					// If ORDER BY or LIMIT statement exist then parentheses is required for the first query
 					$query = PHP_EOL . "SELECT * FROM ($query) AS merge_0";


### PR DESCRIPTION
Pull Request for Issue #115

### Summary of Changes
1. Fix UNION/UNION ALL
2. Allow to mix UNION with UNION ALL and preserve the order.
3. Allow to support (in the future) more set operators like `EXCEPT` and `INTERSECT`
4. A few B/C breaks
    - Method `unionDistinct()` - removed, use `union()` instead.
    - Protected variables `$union` and `$unionAll` replaced by variable `$merge` (array) to preserve the order.
    - Array is not accepted in the $query parameter of `union()` and `unionAll()` methods.
4. New methods `DatabaseQuery::querySet($query)` and `DatabaseQuery::toQuerySet()`, see https://github.com/joomla-framework/database/pull/116#issuecomment-385015308
### Testing Instructions

1. Go to `database/src` folder.
2. Run `php -a` or create a short script like below and execute it. Replace dots `...`.

```php
require '../vendor/autoload.php';
$db = Joomla\Database\DatabaseDriver::getInstance(['driver' => 'mysqli', 'host' => 'localhost', 'user' => '...', 'password' => '...', 'database' => '...', 'prefix' => '...']);
print_r($db->setQuery($db->getQuery(true)->select('1')->union($db->getQuery(true)->select('2'))->unionAll($db->getQuery(true)->select('3')))->loadColumn());
Array
(
    [0] => 1
    [1] => 2
    [2] => 3
)
print_r($db->setQuery($db->getQuery(true)->select('2')->union($db->getQuery(true)->select('1'))->unionAll($db->getQuery(true)->select('1')))->loadColumn());
Array
(
    [0] => 2
    [1] => 1
    [2] => 1
)
print_r($db->setQuery($db->getQuery(true)->select('2')->unionAll($db->getQuery(true)->select('1'))->union($db->getQuery(true)->select('1')))->loadColumn());
Array
(
    [0] => 2
    [1] => 1
)
```

### Documentation Changes Required

#### `Joomla\Database\DatabaseQuery` general changes

##### Changes in methods `union()`, `unionAll()` and `unionDistinct()`

- Method `unionDistinct()` has been removed. Use `union()` instead.
- Argument `$query` stops accepting the array. Only `DatabaseQuery` object or string.
- Argument `$distinct` has been removed from `unionAll`.
- Argument `$glue` has been removed from both.

Method `union()` by default has `$distinct = true`.
If `$distinct` is `false` then generates `UNION ALL` sql statement.

Class variables `$union` and `$unionAll` has been merged into one variable `$merge`.
The new variable represents an ordered array of individual elements.

Stop supporting `$type = 'union'` in method `__toString()`.

### Mix of union types
```sql
SELECT 1 UNION SELECT 2 UNION ALL SELECT 1 -- > return 3 rows

SELECT 1 UNION ALL SELECT 2 UNION SELECT 1 -- > return 2 rows
```

> You can combine multiple queries using the set operators UNION, UNION ALL, INTERSECT, and MINUS. All set operators have equal precedence. If a SQL statement contains multiple set operators, then Oracle Database evaluates them from the left to right unless parentheses explicitly specify another order.

Source https://docs.oracle.com/cd/B19306_01/server.102/b14200/queries004.htm