### PR TITLE
Add a method DatabaseQuery::isNullDatetime()

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -1297,6 +1297,23 @@ class DatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\DatabaseQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$this->assertThat(
+			$this->instance->isNullDatetime('publish_up'),
+			$this->equalTo('`publish_up` IS NULL'),
+			'Test isNullDatetime failed.'
+		);
+	}
+
+	/**
 	 * Tests the \Joomla\Database\DatabaseQuery::nullDate method for an expected exception.
 	 *
 	 * @return  void

--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -1308,7 +1308,7 @@ class DatabaseQueryTest extends TestCase
 	{
 		$this->assertThat(
 			$this->instance->isNullDatetime('publish_up'),
-			$this->equalTo('`publish_up` IS NULL'),
+			$this->equalTo('publish_up IS NULL'),
 			'Test isNullDatetime failed.'
 		);
 	}

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -41,6 +41,28 @@ class MysqlQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\Mysql\MysqlQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$query = new MysqlQuery($this->dbo);
+
+		$this->assertThat(
+			$query->isNullDatetime('publish_up'),
+			$this->equalTo(
+				'("publish_up" IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
+				' OR "publish_up" IS NULL)'
+			),
+			'Test isNullDatetime failed.'
+		);
+	}
+
+	/**
 	 * Data for the testNullDate test.
 	 *
 	 * @return  array

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -55,8 +55,8 @@ class MysqlQueryTest extends TestCase
 		$this->assertThat(
 			$query->isNullDatetime('publish_up'),
 			$this->equalTo(
-				'("publish_up" IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
-				' OR "publish_up" IS NULL)'
+				'(publish_up IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
+				' OR publish_up IS NULL)'
 			),
 			'Test isNullDatetime failed.'
 		);

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -55,8 +55,8 @@ class MysqliQueryTest extends TestCase
 		$this->assertThat(
 			$query->isNullDatetime('publish_up'),
 			$this->equalTo(
-				'("publish_up" IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
-				' OR "publish_up" IS NULL)'
+				'(publish_up IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
+				' OR publish_up IS NULL)'
 			),
 			'Test isNullDatetime failed.'
 		);

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -41,6 +41,28 @@ class MysqliQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\Mysqli\MysqliQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$query = new MysqliQuery($this->dbo);
+
+		$this->assertThat(
+			$query->isNullDatetime('publish_up'),
+			$this->equalTo(
+				'("publish_up" IN (\'_0000-00-00 00:00:00_\', \'_1000-01-01 00:00:00_\')' .
+				' OR "publish_up" IS NULL)'
+			),
+			'Test isNullDatetime failed.'
+		);
+	}
+
+	/**
 	 * Data for the testNullDate test.
 	 *
 	 * @return  array

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -55,8 +55,8 @@ class PgsqlQueryTest extends TestCase
 		$this->assertThat(
 			$query->isNullDatetime('publish_up'),
 			$this->equalTo(
-				'("publish_up" IN (\'_1970-01-01 00:00:00_\')' .
-				' OR "publish_up" IS NULL)'
+				'(publish_up IN (\'_1970-01-01 00:00:00_\')' .
+				' OR publish_up IS NULL)'
 			),
 			'Test isNullDatetime failed.'
 		);

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -41,6 +41,28 @@ class PgsqlQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\PgsqlQuery\PgsqlQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$query = new PgsqlQuery($this->dbo);
+
+		$this->assertThat(
+			$query->isNullDatetime('publish_up'),
+			$this->equalTo(
+				'("publish_up" IN (\'_1970-01-01 00:00:00_\')' .
+				' OR "publish_up" IS NULL)'
+			),
+			'Test isNullDatetime failed.'
+		);
+	}
+
+	/**
 	 * Data for the testNullDate test.
 	 *
 	 * @return  array

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -56,8 +56,8 @@ class SqliteQueryTest extends TestCase
 		$this->assertThat(
 			$query->isNullDatetime('publish_up'),
 			$this->equalTo(
-				'("publish_up" IN (\'_0000-00-00 00:00:00_\')' .
-				' OR "publish_up" IS NULL)'
+				'(publish_up IN (\'_0000-00-00 00:00:00_\')' .
+				' OR publish_up IS NULL)'
 			),
 			'Test isNullDatetime failed.'
 		);

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -40,6 +40,29 @@ class SqliteQueryTest extends TestCase
 		);
 	}
 
+
+	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\Sqlite\SqliteQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$query = new SqliteQuery($this->dbo);
+
+		$this->assertThat(
+			$query->isNullDatetime('publish_up'),
+			$this->equalTo(
+				'("publish_up" IN (\'_0000-00-00 00:00:00_\')' .
+				' OR "publish_up" IS NULL)'
+			),
+			'Test isNullDatetime failed.'
+		);
+	}
+
 	/**
 	 * Data for the testNullDate test.
 	 *

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -55,8 +55,8 @@ class SqlsrvQueryTest extends TestCase
 		$this->assertThat(
 			$query->isNullDatetime('publish_up'),
 			$this->equalTo(
-				'("publish_up" IN (\'_1900-01-01 00:00:00_\')' .
-				' OR "publish_up" IS NULL)'
+				'(publish_up IN (\'_1900-01-01 00:00:00_\')' .
+				' OR publish_up IS NULL)'
 			),
 			'Test isNullDatetime failed.'
 		);

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -41,6 +41,28 @@ class SqlsrvQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the isNullDatetime method.
+	 *
+	 * @return  void
+	 *
+	 * @covers     \Joomla\Database\Sqlsrv\SqlsrvQuery::isNullDatetime
+	 * @since      __DEPLOY_VERSION__
+	 */
+	public function testIsNullDatetime()
+	{
+		$query = new SqlsrvQuery($this->dbo);
+
+		$this->assertThat(
+			$query->isNullDatetime('publish_up'),
+			$this->equalTo(
+				'("publish_up" IN (\'_1900-01-01 00:00:00_\')' .
+				' OR "publish_up" IS NULL)'
+			),
+			'Test isNullDatetime failed.'
+		);
+	}
+
+	/**
 	 * Data for the testNullDate test.
 	 *
 	 * @return  array

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1228,7 +1228,7 @@ abstract class DatabaseQuery implements QueryInterface
 		if ($this->nullDatetimeList)
 		{
 			return "($column IN ("
-			. implode(',', $this->db->quote($this->nullDatetimeList))
+			. implode(', ', $this->db->quote($this->nullDatetimeList))
 			. ") OR $column IS NULL)";
 		}
 

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1223,8 +1223,6 @@ abstract class DatabaseQuery implements QueryInterface
 			throw new \RuntimeException(sprintf('A %s instance is not set to the query object.', DatabaseInterface::class));
 		}
 
-		$column = $this->db->quoteName($column);
-
 		if ($this->nullDatetimeList)
 		{
 			return "($column IN ("

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -200,6 +200,14 @@ abstract class DatabaseQuery implements QueryInterface
 	protected $selectRowNumber = null;
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = [];
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   DatabaseInterface  $db  The database driver.
@@ -1194,6 +1202,37 @@ abstract class DatabaseQuery implements QueryInterface
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Generate a SQL statement to check if column represents a zero or null datetime.
+	 *
+	 * Usage:
+	 * $query->where($query->isNullDatetime('modified_date'));
+	 *
+	 * @param   string  $column  A column name.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function isNullDatetime($column)
+	{
+		if (!$this->db instanceof DatabaseInterface)
+		{
+			throw new \RuntimeException(sprintf('A %s instance is not set to the query object.', DatabaseInterface::class));
+		}
+
+		$column = $this->db->quoteName($column);
+
+		if ($this->nullDatetimeList)
+		{
+			return "($column IN ("
+			. implode(',', $this->db->quote($this->nullDatetimeList))
+			. ") OR $column IS NULL)";
+		}
+
+		return "$column IS NULL";
 	}
 
 	/**

--- a/src/Mysql/MysqlQuery.php
+++ b/src/Mysql/MysqlQuery.php
@@ -21,6 +21,14 @@ class MysqlQuery extends PdoQuery
 	use MysqlQueryBuilder;
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = ['0000-00-00 00:00:00', '1000-01-01 00:00:00'];
+
+	/**
 	 * Magic function to convert the query to a string.
 	 *
 	 * @return  string  The completed query.

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -61,6 +61,14 @@ class MysqliQuery extends DatabaseQuery implements LimitableInterface
 	];
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = ['0000-00-00 00:00:00', '1000-01-01 00:00:00'];
+
+	/**
 	 * Magic function to convert the query to a string.
 	 *
 	 * @return  string  The completed query.

--- a/src/Pdo/PdoQuery.php
+++ b/src/Pdo/PdoQuery.php
@@ -58,6 +58,14 @@ abstract class PdoQuery extends DatabaseQuery implements LimitableInterface
 	];
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = ['0000-00-00 00:00:00'];
+
+	/**
 	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
 	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
 	 *

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -21,6 +21,14 @@ class PgsqlQuery extends PdoQuery
 	use PostgresqlQueryBuilder;
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = ['1970-01-01 00:00:00'];
+
+	/**
 	 * Magic function to convert the query to a string, only for PostgreSQL specific queries
 	 *
 	 * @return  string	The completed query.

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -378,6 +378,20 @@ interface QueryInterface extends PreparableInterface
 	public function nullDate($quoted = true);
 
 	/**
+	 * Generate a SQL statement to check if column represents a zero or null datetime.
+	 *
+	 * Usage:
+	 * $query->where($query->isNullDatetime('modified_date'));
+	 *
+	 * @param   string  $column  A column name.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function isNullDatetime($column);
+
+	/**
 	 * Add an ordering column to the ORDER clause of the query.
 	 *
 	 * Usage:

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -65,6 +65,14 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 	protected $limit;
 
 	/**
+	 * The list of zero or null representation of a datetime.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $nullDatetimeList = ['1900-01-01 00:00:00'];
+
+	/**
 	 * Magic function to convert the query to a string.
 	 *
 	 * @return  string  The completed query.


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16788

### Summary of Changes

Add a new method `DatabaseQuery::isNullDatetime($column)` to allow to compare column with more than one ZERO/NULL value.

Another ideas:
- add `9999-12-31 23:59:59` to nullDatetimes .
- add additional methods like `isNullOrLowerDatetime()` or `isNullOrHigherDatetime()`, maybe without text 'NullOr'.

An example for mysql:
```php
$db->getQuery(true)
    ->select('*')
    ->from($db->quoteName('#__content'))
    ->where('publish_up < ' . $db->quote('2017-01-01 00:00:00') 
        . ' OR ' . $query->isNullDatetime('publish_up'));
```
will be 

```sql
SELECT * 
FROM `#__content` 
WHERE publish_up < '2017-01-01 00:00:00' 
OR (publish_up IN ('0000-00-00 00:00:00', '1000-01-01 00:00:00') OR publish_up IS NULL)
```


### Testing Instructions
At now only code review.

### Note
~~Method `DatabaseQuery::isNullDatetime($column)` automatically calls `$db->quoteName($column)` inside.~~ - reverted.