### PR TITLE
mysql - null date from sql mode

### DIFF
--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -766,4 +766,25 @@ class MysqliDriverTest extends MysqliCase
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
+
+	/**
+	 * Test getNullDate method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testgetNullDate()
+	{
+		$query    = self::$driver->getQuery(true);
+		$result   = self::$driver->setQuery('SELECT @@SESSION.sql_mode;')->loadResult();
+		$expected = '0000-00-00 00:00:00';
+		
+		if (strpos($result, 'NO_ZERO_DATE') !== false)
+		{
+			$expected = '1000-01-01 00:00:00';
+		}
+
+		$this->assertThat($expected, $this->equalTo(self::$driver->getNullDate()), __LINE__);
+	}
 }


### PR DESCRIPTION
redo  of https://github.com/joomla-framework/database/pull/94
https://github.com/joomla/joomla-cms/issues/16788#issuecomment-385579869

### Summary of Changes
set $this->nullDate='1000-01-01 00:00:00';
depending on wich sql mode is enabled `NO_ZERO_DATE `

### Testing Instructions
change the current hard coded setting in https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php#L94

