### PR TITLE
Bump to SQL Server 2012

### DIFF
--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -12,6 +12,7 @@ The following are the minimum supported database versions:
 
 - MySQL: 5.5.3
 - PostgreSQL: 9.2.0
+- MS SQL: 11.0.2100.60 (SQL Server 2012)
 
 ### `Joomla\Database\DatabaseInterface` populated
 

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -58,7 +58,7 @@ class SqlsrvDriver extends DatabaseDriver
 	 * @var    string
 	 * @since  1.0
 	 */
-	protected static $dbMinimum = '10.50.1600.1';
+	protected static $dbMinimum = '11.0.2100.60';
 
 	/**
 	 * Test to see if the SQLSRV connector is available.


### PR DESCRIPTION
### Summary of Changes

Bump to newer version SQL Server 2012.

It's time to use `OFFSET FETCH` instead of subqueries with` ROW_NUMBER () `as the equivalent for OFFSET WITH LIMIT.

See https://technet.microsoft.com/en-gb/library/gg699618(v=sql.110).aspx

### Documentation Changes Required
Yes.
