### PR TITLE
[2.0] Refactor SqlsrvQuery::processList method

### DIFF
--- a/Tests/Sqlsrv/SqlsrvIteratorTest.php
+++ b/Tests/Sqlsrv/SqlsrvIteratorTest.php
@@ -66,8 +66,8 @@ class SqlsrvIteratorTest extends SqlsrvCase
 				20,
 				2,
 				array(
-					(object) array('title' => 'Testing3', 'RowNumber' => '3'),
-					(object) array('title' => 'Testing4', 'RowNumber' => '4')
+					(object) array('title' => 'Testing3'),
+					(object) array('title' => 'Testing4')
 				),
 				null
 			),

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -1133,5 +1133,53 @@ class SqlsrvQueryTest extends TestCase
 			PHP_EOL . 'OFFSET 3 ROWS',
 			$q->processLimit((string) $q, 0, 3)
 		);
+
+		// Test if ORDER BY is correctly recognised in query 1
+		$q->clear('where')->where('id IN (select id from b order by 1)');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id IN (select id from b order by 1)' .
+			PHP_EOL . 'ORDER BY (SELECT 0)' .
+			PHP_EOL . 'OFFSET 3 ROWS',
+			$q->processLimit((string) $q, 0, 3)
+		);
+
+		// Test if ORDER BY is correctly recognised in query 2
+		$q->order('id DESC');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id IN (select id from b order by 1)' .
+			PHP_EOL . 'ORDER BY id DESC' .
+			PHP_EOL . 'OFFSET 3 ROWS',
+			$q->processLimit((string) $q, 0, 3)
+		);
+
+		// Test if ORDER BY is correctly recognised in query 3
+		$q->clear('where')->where('id IN (SELECT id FROM b /*ORDER BY (SELECT 0)*/)');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id IN (SELECT id FROM b /*ORDER BY (SELECT 0)*/)' .
+			PHP_EOL . 'ORDER BY id DESC' .
+			PHP_EOL . 'OFFSET 3 ROWS',
+			$q->processLimit((string) $q, 0, 3)
+		);
+
+		// Test if ORDER BY is correctly recognised in query 4
+		$q->clear('order');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id IN (SELECT id FROM b /*ORDER BY (SELECT 0)*/)' .
+			PHP_EOL . 'ORDER BY (SELECT 0)' .
+			PHP_EOL . 'OFFSET 3 ROWS',
+			$q->processLimit((string) $q, 0, 3)
+		);
 	}
 }

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -208,7 +208,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT YEAR("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT YEAR("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -227,7 +231,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT MONTH("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT MONTH("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -246,7 +254,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT DAY("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT DAY("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -265,7 +277,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT HOUR("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT HOUR("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -284,7 +300,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT MINUTE("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT MINUTE("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -303,7 +323,11 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'SELECT SECOND("col") AS "columnAlias0"' . PHP_EOL . 'FROM table')
+			$this->equalTo(
+				PHP_EOL . 'SELECT SECOND("col") AS "columnAlias0"' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
 		);
 	}
 
@@ -324,7 +348,14 @@ class SqlsrvQueryTest extends TestCase
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo(PHP_EOL . 'INSERT INTO table' . PHP_EOL . '(col)VALUES ' . PHP_EOL . '(' . PHP_EOL . 'SELECT col2' . PHP_EOL . 'WHERE a=1)')
+			$this->equalTo(
+				PHP_EOL . 'INSERT INTO table' .
+				PHP_EOL . '(col)VALUES ' .
+				PHP_EOL . '(' .
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'WHERE a=1' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/)'
+			)
 		);
 
 		$q->clear();
@@ -1071,27 +1102,36 @@ class SqlsrvQueryTest extends TestCase
 		$this->assertEquals(
 			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
 			PHP_EOL . 'FROM a' .
-			PHP_EOL . 'WHERE id = 1',
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . '/*ORDER BY (SELECT 0)*/',
 			$q->processLimit((string) $q, 0)
 		);
 
 		$this->assertEquals(
 			PHP_EOL . 'SELECT TOP 30 id,COUNT(*) AS count' .
 			PHP_EOL . 'FROM a' .
-			PHP_EOL . 'WHERE id = 1',
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . '/*ORDER BY (SELECT 0)*/',
 			$q->processLimit((string) $q, 30)
 		);
 
 		$this->assertEquals(
-			PHP_EOL . 'SELECT * FROM (' .
-			PHP_EOL . 'SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber' .
-			PHP_EOL . 'FROM (' .
-			PHP_EOL . 'SELECT TOP 4 id,COUNT(*) AS count' .
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
 			PHP_EOL . 'FROM a' .
-			PHP_EOL . 'WHERE id = 1) AS A' .
-			PHP_EOL . ') AS A' .
-			PHP_EOL . 'WHERE RowNumber > 3',
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . 'ORDER BY (SELECT 0)' .
+			PHP_EOL . 'OFFSET 3 ROWS' .
+			PHP_EOL . 'FETCH NEXT 1 ROWS ONLY',
 			$q->processLimit((string) $q, 1, 3)
+		);
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . 'ORDER BY (SELECT 0)' .
+			PHP_EOL . 'OFFSET 3 ROWS',
+			$q->processLimit((string) $q, 0, 3)
 		);
 	}
 }

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -127,6 +127,10 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 				{
 					$query .= (string) $this->order;
 				}
+				else
+				{
+					$query .= PHP_EOL . '/*ORDER BY (SELECT 0)*/';
+				}
 
 				if ($this->limit > 0 || $this->offset > 0)
 				{
@@ -1199,34 +1203,39 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
-		if ($limit)
+		if ($offset > 0)
 		{
-			$total = $offset + $limit;
+			$position = strrpos($query, '/*ORDER BY (SELECT 0)*/');
 
+			if ($position !== false)
+			{
+				// We can not use OFFSET without ORDER BY
+				$query = substr_replace($query, 'ORDER BY (SELECT 0)', $position, 23);
+			}
+
+			$query .= PHP_EOL . 'OFFSET ' . (int) $offset . ' ROWS';
+
+			if ($limit > 0)
+			{
+				$query .= PHP_EOL . 'FETCH NEXT ' . (int) $limit . ' ROWS ONLY';
+			}
+		}
+		elseif ($limit > 0)
+		{
 			$position = stripos($query, 'SELECT');
 			$distinct = stripos($query, 'SELECT DISTINCT');
 
 			if ($position === $distinct)
 			{
-				$query = substr_replace($query, 'SELECT DISTINCT TOP ' . (int) $total, $position, 15);
+				$query = substr_replace($query, 'SELECT DISTINCT TOP ' . (int) $limit, $position, 15);
 			}
 			else
 			{
-				$query = substr_replace($query, 'SELECT TOP ' . (int) $total, $position, 6);
+				$query = substr_replace($query, 'SELECT TOP ' . (int) $limit, $position, 6);
 			}
 		}
 
-		if (!$offset)
-		{
-			return $query;
-		}
-
-		return PHP_EOL
-			. 'SELECT * FROM ('
-			. PHP_EOL . 'SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber'
-			. PHP_EOL . 'FROM (' . $query . ') AS A'
-			. PHP_EOL . ') AS A'
-			. PHP_EOL . 'WHERE RowNumber > ' . (int) $offset;
+		return $query;
 	}
 
 	/**

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -1205,12 +1205,14 @@ class SqlsrvQuery extends DatabaseQuery implements LimitableInterface
 	{
 		if ($offset > 0)
 		{
-			$position = strrpos($query, '/*ORDER BY (SELECT 0)*/');
+			// Find a position of the last comment
+			$commentPos = strrpos($query, '/*ORDER BY (SELECT 0)*/');
 
-			if ($position !== false)
+			// If the last comment belongs to this query, not previous subquery
+			if ($commentPos !== false && $commentPos + 2 === strripos($query, 'ORDER BY', $commentPos + 2))
 			{
 				// We can not use OFFSET without ORDER BY
-				$query = substr_replace($query, 'ORDER BY (SELECT 0)', $position, 23);
+				$query = substr_replace($query, 'ORDER BY (SELECT 0)', $commentPos, 23);
 			}
 
 			$query .= PHP_EOL . 'OFFSET ' . (int) $offset . ' ROWS';


### PR DESCRIPTION
### Summary of Changes

Simpler OFFSET/LIMIT clause for sql server.
This PR requires SQL Server 2012.

Because `OFSET/FETCH` has to follow by `ORDER BY` I added a comment `/*ORDER BY (SELECT 0)*/` if ORDER BY clause does not exists in query. 

Later I can easy uncomment it if  `OFFSET/FETCH` is added.

### Testing Instructions
Code review.
It would be good to do a real test.

```php
require 'vendor/autoload.php';
$db = Joomla\Database\DatabaseDriver::getInstance(['driver' => 'sqlsrv', 'database' => '', 'user' => '', 'password' => '', 'prefix' => 'j38_']);
print_r($db->setQuery($db->getQuery(1)->select('id')->from('j38_modules'), 0, 3)->loadAssocList());
print_r($db->setQuery($db->getQuery(1)->select('id')->from('j38_modules'), 1, 3)->loadAssocList());
print_r($db->setQuery($db->getQuery(1)->select('id')->from('j38_modules'), 1)->loadAssocList());
print_r($db->setQuery($db->getQuery(1)->select('id')->from('j38_modules'))->loadAssocList());
```

### Documentation Changes Required
**Known issue:**
When you use one of `SELECT DISTINCT` or `GROUP BY` and you want to use `OFFSET` or `OFFSET/LIMIT` then you have to add `ORDER BY` clause.

To workaround that I may replace `/*ORDER BY (SELECT 0)*/` by `ORDER BY 1` but IMO this trick should not be added.

See https://stackoverflow.com/questions/34765786/nhibernate-order-by-current-timestamp 