### PR TITLE
Escaping float value should be non-locale aware

### DIFF
--- a/Tests/DatabaseDriverTest.php
+++ b/Tests/DatabaseDriverTest.php
@@ -354,7 +354,7 @@ SQL
 	 */
 	public function testQuoteFloat()
 	{
-		// This also call `escape()` method from nosqldriver which is locate aware
+		// This call `escape()` method from nosqldriver, which is locale aware
 		$this->assertSame(
 			// Below line may generate "'-3.14-'" or "'-3,14-'"
 			"'-" . 3.14 . "-'",

--- a/Tests/DatabaseDriverTest.php
+++ b/Tests/DatabaseDriverTest.php
@@ -354,8 +354,10 @@ SQL
 	 */
 	public function testQuoteFloat()
 	{
+		// This also call `escape()` method from nosqldriver which is locate aware
 		$this->assertSame(
-			"'-3.14-'",
+			// Below line may generate "'-3.14-'" or "'-3,14-'"
+			"'-" . 3.14 . "-'",
 			$this->instance->quote(3.14)
 		);
 	}

--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -27,7 +27,9 @@ class MysqlDriverTest extends MysqlCase
 	{
 		return array(
 			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
+			array("'%_abc123", true, '\\\'\\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -112,6 +114,39 @@ class MysqlDriverTest extends MysqlCase
 			$expected,
 			self::$driver->escape($text, $extra)
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -27,7 +27,9 @@ class MysqliDriverTest extends MysqliCase
 	{
 		return array(
 			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
+			array("'%_abc123", true, '\\\'\\%\_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -102,6 +104,39 @@ class MysqliDriverTest extends MysqliCase
 			$this->equalTo($expected),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -30,23 +30,10 @@ class PgsqlDriverTest extends PgsqlCase
 			array("'%_abc123", true, '\'\'%_abc123'),
 			/* ' and \ will be escaped: the first become '', the latter \\ */
 			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
-			array("\'%_abc123", true, '\\\\\'\'%_abc123'));
-	}
-
-	/**
-	 * Data for the testGetEscaped test, proxies of escape, so same data test.
-	 *
-	 * @return  array
-	 *
-	 * @since   1.0
-	 */
-	public function dataTestGetEscaped()
-	{
-		return array(
-			/* ' will be escaped and become '' */
-			array("'%_abc123", false), array("'%_abc123", true),
-			/* ' and \ will be escaped: the first become '', the latter \\ */
-			array("\'%_abc123", false), array("\'%_abc123", true));
+			array("\'%_abc123", true, '\\\\\'\'%_abc123'),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
+		);
 	}
 
 	/**
@@ -193,6 +180,39 @@ class PgsqlDriverTest extends PgsqlCase
 			$this->equalTo($result),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/Tests/Sqlite/SqliteDriverTest.php
+++ b/Tests/Sqlite/SqliteDriverTest.php
@@ -27,7 +27,8 @@ class SqliteDriverTest extends SqliteCase
 		return array(
 			array("'%_abc123", false, "''%_abc123"),
 			array("'%_abc123", true, "''%_abc123"),
-			array(3, false, 3)
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -102,6 +103,39 @@ class SqliteDriverTest extends SqliteCase
 			$this->equalTo($expected),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -29,6 +29,8 @@ class SqlsrvDriverTest extends SqlsrvCase
 			array("'%_abc123[]", false, "''%_abc123[]"),
 			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
 			array("binary\000data", false, "binary' + CHAR(0) + N'data"),
+			array(3, false, 3),
+			array(3.14, false, '3.14'),
 		);
 	}
 
@@ -95,6 +97,39 @@ class SqlsrvDriverTest extends SqlsrvCase
 			$this->equalTo($expected),
 			'The string was not escaped properly'
 		);
+	}
+
+	/**
+	 * Tests the escape method 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscapeNonLocaleAware()
+	{
+		$origin = setLocale(LC_NUMERIC, 0);
+
+		// Test with decimal_point equals to comma
+		setLocale(LC_NUMERIC, 'pl_PL');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Test with C locale
+		setLocale(LC_NUMERIC, 'C');
+
+		$this->assertThat(
+			self::$driver->escape(3.14),
+			$this->equalTo('3.14'),
+			'The string was not escaped properly'
+		);
+
+		// Revert to origin locale
+		setLocale(LC_NUMERIC, $origin);
 	}
 
 	/**

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -496,12 +496,18 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	 */
 	public function escape($text, $extra = false)
 	{
-		$this->connect();
-
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
 		}
+
+		if (is_float($text))
+		{
+			// Format %F is for non-locale aware
+			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+		}
+
+		$this->connect();
 
 		$result = substr($this->connection->quote($text), 1, -1);
 

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -503,8 +503,8 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 
 		if (is_float($text))
 		{
-			// Format %F is for non-locale aware
-			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		$this->connect();

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -299,6 +299,17 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Format %F is for non-locale aware
+			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+		}
+
 		$this->connect();
 
 		$result = $this->connection->real_escape_string($text);

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -306,8 +306,8 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
 		if (is_float($text))
 		{
-			// Format %F is for non-locale aware
-			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		$this->connect();

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -336,8 +336,8 @@ abstract class PdoDriver extends DatabaseDriver
 
 		if (is_float($text))
 		{
-			// Format %F is for non-locale aware
-			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		$text = str_replace("'", "''", $text);

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -329,9 +329,15 @@ abstract class PdoDriver extends DatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Format %F is for non-locale aware
+			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
 		}
 
 		$text = str_replace("'", "''", $text);

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -139,8 +139,9 @@ class SqliteDriver extends PdoDriver
 
 		if (is_float($text))
 		{
-			// Format %F is for non-locale aware
-			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
+
 		}
 
 		return \SQLite3::escapeString($text);

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -132,9 +132,15 @@ class SqliteDriver extends PdoDriver
 	 */
 	public function escape($text, $extra = false)
 	{
-		if (is_int($text) || is_float($text))
+		if (is_int($text))
 		{
 			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Format %F is for non-locale aware
+			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
 		}
 
 		return \SQLite3::escapeString($text);

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -221,6 +221,17 @@ class SqlsrvDriver extends DatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
+		if (is_int($text))
+		{
+			return $text;
+		}
+
+		if (is_float($text))
+		{
+			// Format %F is for non-locale aware
+			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+		}
+
 		$result = str_replace("'", "''", $text);
 
 		// SQL Server does not accept NULL byte in query string

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -228,8 +228,8 @@ class SqlsrvDriver extends DatabaseDriver
 
 		if (is_float($text))
 		{
-			// Format %F is for non-locale aware
-			return rtrim(rtrim(sprintf('%F', $text), '0'), '.');
+			// Force the dot as a decimal point.
+			return str_replace(',', '.', $text);
 		}
 
 		$result = str_replace("'", "''", $text);


### PR DESCRIPTION
### Summary of Changes

When I run unit tests locally the result always failed because of my locale (pl_PL).
In Polish, numbers are displayed with the comma as a decimal point.

If I use `$query->where('column = ' . $db->quote(3.14)); // <- input a float value`
then the query instead of displays `... WHERE column = 3.14` shows `... WHERE column = 3,14` which is incorrect.

See https://github.com/matomo-org/matomo/issues/6435

### Testing Instructions
Code review.
Unit tests pass.

### Documentation Changes Required
No