### PR TITLE
Add support for database expression

### DIFF
--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -831,7 +831,30 @@ class MysqliDriverTest extends MysqliCase
 	 */
 	public function testUpdateObject()
 	{
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$exprValue = "CASE WHEN start_date < UTC_TIMESTAMP() THEN '2018-01-01 00:00:00' ELSE start_date END";
+
+		$row = (object) [
+			'id' => 4,
+			'title' => 'New title',
+			'start_date' => new \Joomla\Database\Expression($exprValue),
+			'description' => null,
+			'_ignoreMe' => 'ignoreMe',
+			'object' => (object) 'ignoreMe',
+			'array' => ['ignoreMe'],
+		];
+
+		self::$driver->updateObject('#__dbtest', $row, 'id');
+
+		$query = self::$driver->getQuery(true)
+			->select('*')
+			->from('#__dbtest')
+			->where('id = 4');
+
+		$result = self::$driver->setQuery($query)->loadRow();
+
+		$expected = ['4', 'New title', '2018-01-01 00:00:00', 'four'];
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1100,7 +1100,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 			}
 
 			// Only process non-null scalars.
-			if (\is_array($v) || \is_object($v) || $v === null)
+			if (\is_array($v) || (\is_object($v) && !$v instanceOf Expression) || $v === null)
 			{
 				continue;
 			}
@@ -1476,6 +1476,11 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	 */
 	public function quote($text, $escape = true)
 	{
+		if ($text instanceOf Expression)
+		{
+			return (string) $text;
+		}
+
 		if (\is_array($text))
 		{
 			foreach ($text as $k => $v)
@@ -1851,7 +1856,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 			}
 
 			// Only process scalars that are not internal fields.
-			if (\is_array($v) || \is_object($v) || $k[0] === '_')
+			if (\is_array($v) || (\is_object($v) && !$v instanceOf Expression) || $k[0] === '_')
 			{
 				continue;
 			}

--- a/src/Expression.php
+++ b/src/Expression.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database;
+
+/**
+ * Expression represents a database expression that does not need quoting.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Expression
+{
+	/**
+	 * The value of the expression.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $value;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $value  The database expression.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(string $value)
+	{
+		$this->value = $value;
+	}
+
+	/**
+	 * String magic method.
+	 *
+	 * @return  string  The database expression.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __toString()
+	{
+		return $this->value;
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
In order to not quote a special string we can use instance of class with method `__toString()`.

When we use `$db->updateObject()` we can set something like:

```
if (!$this->publish_up)
{
	$this->publish_up = new Expression('NOW()');
}

if (!$this->publish_down)
{
	$this->publish_down = new Expression('NULL');
}
```

Then `$this->publish_down` won't be quoted by `$db->quote($this->publish_down)` and still return "NULL" instead of "'NULL'".

### Testing Instructions
Unit tests missing


### Documentation Changes Required
TODO