### PR TITLE
Deprecate query interfaces

### DIFF
--- a/Tests/Stubs/nosqldriver.php
+++ b/Tests/Stubs/nosqldriver.php
@@ -11,7 +11,6 @@ use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Exception\PrepareStatementFailureException;
 use Joomla\Database\FetchOrientation;
 use Joomla\Database\ParameterType;
-use Joomla\Database\Query\PreparableInterface;
 use Joomla\Database\StatementInterface;
 
 /**

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -26,6 +26,12 @@ Support for PDO Oracle and native PostgreSQL has been removed.  PDO PostgreSQL i
 
 `Joomla\Database\QueryInterface` has been added to the package. All query objects must now implement this interface.
 
+### Query feature interfaces deprecated
+
+As `Joomla\Database\QueryInterface` is now extending `Joomla\Database\Query\LimitableInterface` and `Joomla\Database\Query\PreparableInterface`, these
+feature interfaces are no longer required and are deprecated. All query objects must implement `Joomla\Database\QueryInterface` and as of 3.0 the
+methods defined in the deprecated interfaces will be moved into `Joomla\Database\QueryInterface`.
+
 ### Support for parameterized queries required
 
 `Joomla\Database\QueryInterface` extends `Joomla\Database\Query\PrepareableInterface`, which is the interface defining that

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -12,7 +12,6 @@ use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Database\Exception\ConnectionFailureException;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Exception\PrepareStatementFailureException;
-use Joomla\Database\Query\LimitableInterface;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\EventInterface;
@@ -1757,21 +1756,18 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 			);
 		}
 
-		if ($query instanceof LimitableInterface)
+		// Check for values set on the query object and use those if there is a zero value passed here
+		if ($limit === 0 && $query->limit > 0)
 		{
-			// Check for values set on the query object and use those if there is a zero value passed here
-			if ($limit === 0 && $query->limit > 0)
-			{
-				$limit = $query->limit;
-			}
-
-			if ($offset === 0 && $query->offset > 0)
-			{
-				$offset = $query->offset;
-			}
-
-			$query->setLimit($limit, $offset);
+			$limit = $query->get;
 		}
+
+		if ($offset === 0 && $query->offset > 0)
+		{
+			$offset = $query->offset;
+		}
+
+		$query->setLimit($limit, $offset);
 
 		$sql = $this->replacePrefix((string) $query);
 

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -232,12 +232,7 @@ abstract class DatabaseQuery implements QueryInterface
 
 		if ($this->sql)
 		{
-			if ($this instanceof Query\LimitableInterface)
-			{
-				return $this->processLimit($this->sql, $this->limit, $this->offset);
-			}
-
-			return $this->sql;
+			return $this->processLimit($this->sql, $this->limit, $this->offset);
 		}
 
 		switch ($this->type)
@@ -296,7 +291,7 @@ abstract class DatabaseQuery implements QueryInterface
 			case 'querySet':
 				$query = $this->querySet;
 
-				if ($query->order || ($query instanceof Query\LimitableInterface && ($query->limit || $query->offset)))
+				if ($query->order || ($query->limit || $query->offset))
 				{
 					// If ORDER BY or LIMIT statement exist then parentheses is required for the first query
 					$query = "($query)";
@@ -396,12 +391,7 @@ abstract class DatabaseQuery implements QueryInterface
 				break;
 		}
 
-		if ($this instanceof Query\LimitableInterface)
-		{
-			$query = $this->processLimit($query, $this->limit, $this->offset);
-		}
-
-		return $query;
+		return $this->processLimit($query, $this->limit, $this->offset);
 	}
 
 	/**

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -10,7 +10,6 @@ namespace Joomla\Database\Mysqli;
 
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
-use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\MysqlQueryBuilder;
 
 /**

--- a/src/Pdo/PdoQuery.php
+++ b/src/Pdo/PdoQuery.php
@@ -10,7 +10,6 @@ namespace Joomla\Database\Pdo;
 
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
-use Joomla\Database\Query\LimitableInterface;
 
 /**
  * PDO Query Building Class.

--- a/src/Query/LimitableInterface.php
+++ b/src/Query/LimitableInterface.php
@@ -8,10 +8,22 @@
 
 namespace Joomla\Database\Query;
 
+use Joomla\Database\QueryInterface;
+
+@trigger_error(
+	sprintf(
+		'%1$s is deprecated and will be removed in 3.0, all query objects should implement %2$s instead.',
+		LimitableInterface::class,
+		QueryInterface::class
+	),
+	E_USER_DEPRECATED
+);
+
 /**
  * Joomla Database Query LimitableInterface.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  3.0  Capabilities will be required in Joomla\Database\QueryInterface
  */
 interface LimitableInterface
 {

--- a/src/Query/PostgresqlQueryBuilder.php
+++ b/src/Query/PostgresqlQueryBuilder.php
@@ -202,12 +202,7 @@ trait PostgresqlQueryBuilder
 				break;
 		}
 
-		if ($this instanceof LimitableInterface)
-		{
-			$query = $this->processLimit($query, $this->limit, $this->offset);
-		}
-
-		return $query;
+		return $this->processLimit($query, $this->limit, $this->offset);
 	}
 
 	/**

--- a/src/Query/PreparableInterface.php
+++ b/src/Query/PreparableInterface.php
@@ -9,13 +9,24 @@
 namespace Joomla\Database\Query;
 
 use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
+
+@trigger_error(
+	sprintf(
+		'%1$s is deprecated and will be removed in 3.0, all query objects should implement %2$s instead.',
+		PreparableInterface::class,
+		QueryInterface::class
+	),
+	E_USER_DEPRECATED
+);
 
 /**
  * Joomla Database Query Preparable Interface.
  *
  * Adds bind/unbind methods as well as a getBounded() method to retrieve the stored bounded variables on demand prior to query execution.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  3.0  Capabilities will be required in Joomla\Database\QueryInterface
  */
 interface PreparableInterface
 {

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -11,7 +11,6 @@ namespace Joomla\Database\Sqlsrv;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
-use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\QueryElement;
 
 /**


### PR DESCRIPTION
### Summary of Changes

With `Joomla\Database\QueryInterface` now extending `Joomla\Database\Query\LimitableInterface` and `Joomla\Database\Query\PreparableInterface`, there is no longer a requirement to have these feature interfaces in the API.  They are therefore deprecated as of 2.0 scheduled to be removed in 3.0.

Additionally, feature checks reliant upon these deprecated interfaces are removed as the API now documents and/or typehints that a `Joomla\Database\QueryInterface` object must always be used therefore we can safely assume these features are always available.

### Testing Instructions

Code review

### Documentation Changes Required

Deprecations added to upgrade guide (done)