### PR TITLE
Replace serialize/unserialize with simple cloning

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -1987,6 +1987,32 @@ class DatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the \Joomla\Database\DatabaseQuery::__clone method properly clones nested objects.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__clone_nested_query()
+	{
+		/**
+		 * Add a custom closure to test the cloning of nested objects.
+		 *
+		 * DatabaseQuery->QueryElement->DatabaseQuery
+		 * $query       ->merge[0]    ->elements[0]
+		 */
+		$this->dbo->func = function() {};
+
+		$query = $this->instance->select('id')->from('#__content');
+		$query->union(clone $query);
+
+		// Real test for exception: Serialization of 'Closure' is not allowed
+		$query2 = clone $query;
+
+		$this->assertFalse($query->merge[0]->getElements()[0] === $query2->merge[0]->getElements()[0]);
+	}
+
+	/**
 	 * Tests the \Joomla\Database\DatabaseQuery::union method.
 	 *
 	 * @return  void

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1737,9 +1737,19 @@ abstract class DatabaseQuery implements QueryInterface
 				continue;
 			}
 
-			if (\is_object($v) || \is_array($v))
+			if (\is_object($v))
 			{
-				$this->{$k} = unserialize(serialize($v));
+				$this->{$k} = clone $v;
+			}
+			elseif (\is_array($v))
+			{
+				foreach ($v as $i => $element)
+				{
+					if (\is_object($element))
+					{
+						$this->{$k}[$i] = clone $element;
+					}
+				}
 			}
 		}
 	}

--- a/src/Query/QueryElement.php
+++ b/src/Query/QueryElement.php
@@ -137,9 +137,19 @@ class QueryElement
 	{
 		foreach ($this as $k => $v)
 		{
-			if (\is_object($v) || \is_array($v))
+			if (\is_object($v))
 			{
-				$this->{$k} = unserialize(serialize($v));
+				$this->{$k} = clone $v;
+			}
+			elseif (\is_array($v))
+			{
+				foreach ($v as $i => $element)
+				{
+					if (\is_object($element))
+					{
+						$this->{$k}[$i] = clone $element;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/22685

### Summary of Changes
Use object cloning instead of serialization.

### Testing Instructions
See unit test.

### Note
`DatabaseQuery/QueryElement` object should not have any multidimensional array with objects.
Each member of the `DatabaseQuery/QueryElement` object should take care of its own `__clone()` method, (except `DatabaseQuery::db`).
