### PR TITLE
Add a new method QueryElement::getName()

### DIFF
--- a/src/Query/QueryElement.php
+++ b/src/Query/QueryElement.php
@@ -108,6 +108,18 @@ class QueryElement
 	}
 
 	/**
+	 * Gets the name of this element.
+	 *
+	 * @return  string  Name of the element.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
 	 * Sets the name of this element.
 	 *
 	 * @param   string  $name  Name of the element.


### PR DESCRIPTION
### Summary of Changes

Add a `QueryElement::getName()` to allow to manipulate query elements.

Example of removing `LEFT JOIN`:

```php
$joinList = $query->join;

// Remove JOINs
$query->clear('join')->clear('select')->clear('order')->clear('limit')->clear('offset')->select('COUNT(*)');

foreach ($joinList as $join)
{
	$name = explode(' ', $join->getName())[0];
	// Skip LEFT JOINs
	if ($name !== 'LEFT')
	{
		$query->join($name, $join->getElements());
	}
}
```

### Documentation Changes Required
A new method `QueryElement::getName()`