### PR TITLE
Simplify the quoteName method

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1474,17 +1474,14 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	{
 		if (\is_string($name))
 		{
-			$quotedName = $this->quoteNameStr(explode('.', $name));
-
-			$quotedAs = '';
+			$name = $this->quoteNameString($name);
 
 			if ($as !== null)
 			{
-				$as       = (array) $as;
-				$quotedAs .= ' AS ' . $this->quoteNameStr($as);
+				$name .= ' AS ' . $this->quoteNameString($as);
 			}
 
-			return $quotedName . $quotedAs;
+			return $name;
 		}
 
 		$fin = array();
@@ -1510,6 +1507,22 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	}
 
 	/**
+	 * Quote string coming from quoteName call.
+	 *
+	 * @param   string  $name  Array of strings coming from quoteName dot-explosion.
+	 *
+	 * @return  string  Dot-imploded string of quoted parts.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function quoteNameString($name)
+	{
+		$q = $this->nameQuote . $this->nameQuote;
+
+		return $q[0] . str_replace('.', "$q[1].$q[0]", $name) . $q[1];
+	}
+
+	/**
 	 * Quote strings coming from quoteName call.
 	 *
 	 * @param   array  $strArr  Array of strings coming from quoteName dot-explosion.
@@ -1517,6 +1530,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	 * @return  string  Dot-imploded string of quoted parts.
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  Use quoteNameString instead
 	 */
 	protected function quoteNameStr($strArr)
 	{


### PR DESCRIPTION
### Summary of Changes
Simplify the `quoteName` code.
Replace `explode() / implode()` by `str_replace()`.

Introduce a new method `DatabaseDriver::quoteNameString()` as a replacement for `DatabaseDriver::quoteNameStr()`. The new method takes a string instead of an array.

### Testing Instructions
Unit tests should pass

### Documentation Changes Required
Deprecate `DatabaseDriver::quoteNameStr()`.
