### PR TITLE
Add a new method `alias()` to DatabaseQuery

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -136,7 +136,7 @@ class DatabaseQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = clone $this->instance;
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$this->instance->select('col2')->from($subq->alias('alias'));
 
@@ -147,7 +147,7 @@ class DatabaseQueryTest extends TestCase
 				PHP_EOL . 'FROM (' .
 				PHP_EOL . 'SELECT col AS col2' .
 				PHP_EOL . 'FROM table' .
-				PHP_EOL . 'WHERE a=1) AS alias'
+				PHP_EOL . 'WHERE a=1 LIMIT 1) AS alias'
 			)
 		);
 	}

--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -135,16 +135,19 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function test__toStringFrom_subquery()
 	{
-		$subq = $this->dbo->getQuery(true);
-		$subq->select('col2')->from('table')->where('a=1');
+		$subq = clone $this->instance;
+		$subq->select('col AS col2')->from('table')->where('a=1');
 
-		$this->instance->select('col')->from($subq, 'alias');
+		$this->instance->select('col2')->from($subq->alias('alias'));
 
 		$this->assertThat(
 			(string) $this->instance,
 			$this->equalTo(
-				PHP_EOL . 'SELECT col' . PHP_EOL .
-				'FROM ( ' . PHP_EOL . 'SELECT col2' . PHP_EOL . 'FROM table' . PHP_EOL . 'WHERE a=1 ) AS `alias`'
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1) AS alias'
 			)
 		);
 	}

--- a/Tests/Mock/Query.php
+++ b/Tests/Mock/Query.php
@@ -128,6 +128,16 @@ class Query extends \Joomla\Database\DatabaseQuery
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
+		if ($limit > 0)
+		{
+			$query .= ' LIMIT ' . $limit;
+		}
+
+		if ($offset > 0)
+		{
+			$query .= ' OFFSET ' . $offset;
+		}
+
 		return $query;
 	}
 }

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -336,7 +336,7 @@ class MysqlQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = new MysqlQuery($this->dbo);
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$q = new MysqlQuery($this->dbo);
 		$q->select('col2')->from($subq->alias('alias'));
@@ -348,7 +348,7 @@ class MysqlQueryTest extends TestCase
 				PHP_EOL . 'FROM (' .
 				PHP_EOL . 'SELECT col AS col2' .
 				PHP_EOL . 'FROM table' .
-				PHP_EOL . 'WHERE a=1) AS alias'
+				PHP_EOL . 'WHERE a=1 LIMIT 1) AS alias'
 			)
 		);
 	}

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -327,6 +327,33 @@ class MysqlQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$subq = new MysqlQuery($this->dbo);
+		$subq->select('col AS col2')->from('table')->where('a=1');
+
+		$q = new MysqlQuery($this->dbo);
+		$q->select('col2')->from($subq->alias('alias'));
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1) AS alias'
+			)
+		);
+	}
+
+	/**
 	 * Test for INSERT INTO clause with subquery.
 	 *
 	 * @return  void

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -354,6 +354,33 @@ class MysqliQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$subq = new MysqliQuery($this->dbo);
+		$subq->select('col AS col2')->from('table')->where('a=1');
+
+		$q = new MysqliQuery($this->dbo);
+		$q->select('col2')->from($subq->alias('alias'));
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1) AS alias'
+			)
+		);
+	}
+
+	/**
 	 * Test for INSERT INTO clause with subquery.
 	 *
 	 * @return  void

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -363,7 +363,7 @@ class MysqliQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = new MysqliQuery($this->dbo);
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$q = new MysqliQuery($this->dbo);
 		$q->select('col2')->from($subq->alias('alias'));
@@ -375,7 +375,7 @@ class MysqliQueryTest extends TestCase
 				PHP_EOL . 'FROM (' .
 				PHP_EOL . 'SELECT col AS col2' .
 				PHP_EOL . 'FROM table' .
-				PHP_EOL . 'WHERE a=1) AS alias'
+				PHP_EOL . 'WHERE a=1 LIMIT 1) AS alias'
 			)
 		);
 	}

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -327,6 +327,33 @@ class PgsqlQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$subq = new PgsqlQuery($this->dbo);
+		$subq->select('col AS col2')->from('table')->where('a=1');
+
+		$q = new PgsqlQuery($this->dbo);
+		$q->select('col2')->from($subq->alias('alias'));
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1) AS alias'
+			)
+		);
+	}
+
+	/**
 	 * Test for INSERT INTO clause with subquery.
 	 *
 	 * @return  void

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -336,7 +336,7 @@ class PgsqlQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = new PgsqlQuery($this->dbo);
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$q = new PgsqlQuery($this->dbo);
 		$q->select('col2')->from($subq->alias('alias'));
@@ -348,7 +348,7 @@ class PgsqlQueryTest extends TestCase
 				PHP_EOL . 'FROM (' .
 				PHP_EOL . 'SELECT col AS col2' .
 				PHP_EOL . 'FROM table' .
-				PHP_EOL . 'WHERE a=1) AS alias'
+				PHP_EOL . 'WHERE a=1 LIMIT 1) AS alias'
 			)
 		);
 	}

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -521,6 +521,33 @@ class SqliteQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$subq = new SqliteQuery($this->dbo);
+		$subq->select('col AS col2')->from('table')->where('a=1');
+
+		$q = new SqliteQuery($this->dbo);
+		$q->select('col2')->from($subq->alias('alias'));
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1) AS alias'
+			)
+		);
+	}
+
+	/**
 	 * Test for INSERT INTO clause with subquery.
 	 *
 	 * @return  void

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -530,7 +530,7 @@ class SqliteQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = new SqliteQuery($this->dbo);
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$q = new SqliteQuery($this->dbo);
 		$q->select('col2')->from($subq->alias('alias'));
@@ -542,7 +542,7 @@ class SqliteQueryTest extends TestCase
 				PHP_EOL . 'FROM (' .
 				PHP_EOL . 'SELECT col AS col2' .
 				PHP_EOL . 'FROM table' .
-				PHP_EOL . 'WHERE a=1) AS alias'
+				PHP_EOL . 'WHERE a=1 LIMIT 0, 1) AS alias'
 			)
 		);
 	}

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -554,7 +554,7 @@ class SqlsrvQueryTest extends TestCase
 	public function test__toStringFrom_subquery()
 	{
 		$subq = new SqlsrvQuery($this->dbo);
-		$subq->select('col AS col2')->from('table')->where('a=1');
+		$subq->select('col AS col2')->from('table')->where('a=1')->setLimit(1);
 
 		$q = new SqlsrvQuery($this->dbo);
 		$q->select('col2')->from($subq->alias('alias'));
@@ -564,7 +564,7 @@ class SqlsrvQueryTest extends TestCase
 			$this->equalTo(
 				PHP_EOL . 'SELECT col2' .
 				PHP_EOL . 'FROM (' .
-				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'SELECT TOP 1 col AS col2' .
 				PHP_EOL . 'FROM table' .
 				PHP_EOL . 'WHERE a=1' .
 				PHP_EOL . '/*ORDER BY (SELECT 0)*/) AS alias' .

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -545,6 +545,35 @@ class SqlsrvQueryTest extends TestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$subq = new SqlsrvQuery($this->dbo);
+		$subq->select('col AS col2')->from('table')->where('a=1');
+
+		$q = new SqlsrvQuery($this->dbo);
+		$q->select('col2')->from($subq->alias('alias'));
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . 'SELECT col2' .
+				PHP_EOL . 'FROM (' .
+				PHP_EOL . 'SELECT col AS col2' .
+				PHP_EOL . 'FROM table' .
+				PHP_EOL . 'WHERE a=1' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/) AS alias' .
+				PHP_EOL . '/*ORDER BY (SELECT 0)*/'
+			)
+		);
+	}
+
+	/**
 	 * Test for INSERT INTO clause with subquery.
 	 *
 	 * @return  void

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -100,3 +100,11 @@ The last argument `$conditions` has been split into two arguments: $table and $c
 Instead of `$query->join('INNER', 'b ON b.id = a.id)` use `$query->join('INNER', 'b', 'b.id = a.id)`.
 
 Although the old syntax still works in many cases, it will not work on PostgreSQL update query.
+
+#### Changes in the `from()` method
+
+The first argument, `$table`, stops accepting the array. Only `DatabaseQuery` object or string.
+
+- Argument `$subQueryAlias` has been removed.
+
+Instead of `$query->from($subquery, 'alias')` use `$query->from($subquery->alias('alias'))`.

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -250,12 +250,12 @@ abstract class DatabaseQuery implements QueryInterface
 	 */
 	public function __toString()
 	{
-		$query = '';
-
 		if ($this->sql)
 		{
 			return $this->processLimit($this->sql, $this->limit, $this->offset);
 		}
+
+		$query = '';
 
 		switch ($this->type)
 		{
@@ -416,18 +416,14 @@ abstract class DatabaseQuery implements QueryInterface
 				break;
 		}
 
-		switch ($this->type)
-		{
-			case 'select':
-				if ($this->alias)
-				{
-					$query = '(' . $query . ') AS ' . $this->alias;
-				}
+		$query = $this->processLimit($query, $this->limit, $this->offset);
 
-				break;
+		if ($this->type === 'select' && $this->alias !== null)
+		{
+			$query = '(' . $query . ') AS ' . $this->alias;
 		}
 
-		return $this->processLimit($query, $this->limit, $this->offset);
+		return $query;
 	}
 
 	/**

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -181,6 +181,15 @@ class PgsqlQuery extends PdoQuery
 
 			default:
 				$query = parent::__toString();
+		}
+
+		switch ($this->type)
+		{
+			case 'select':
+				if ($this->alias)
+				{
+					$query = '(' . $query . ') AS ' . $this->alias;
+				}
 
 				break;
 		}

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -183,18 +183,14 @@ class PgsqlQuery extends PdoQuery
 				$query = parent::__toString();
 		}
 
-		switch ($this->type)
-		{
-			case 'select':
-				if ($this->alias)
-				{
-					$query = '(' . $query . ') AS ' . $this->alias;
-				}
+		$query = $this->processLimit($query, $this->limit, $this->offset);
 
-				break;
+		if ($this->type === 'select' && $this->alias !== null)
+		{
+			$query = '(' . $query . ') AS ' . $this->alias;
 		}
 
-		return $this->processLimit($query, $this->limit, $this->offset);
+		return $query;
 	}
 
 	/**

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -182,20 +182,31 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a table to the FROM clause of the query.
 	 *
-	 * Note that while an array of tables can be provided, it is recommended you use explicit joins.
-	 *
 	 * Usage:
 	 * $query->select('*')->from('#__a');
+	 * $query->select('*')->from($subquery->alias('a'));
 	 *
-	 * @param   array|string  $tables         A string or array of table names.  This can be a QueryInterface object (or a child of it) when used
-	 *                                        as a subquery in FROM clause along with a value for $subQueryAlias.
-	 * @param   string        $subQueryAlias  Alias used when $tables is a QueryInterface.
+	 * @param   string|QueryInterface  $table  The name of the table or a QueryInterface object (or a child of it) with alias set.
 	 *
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function from($tables, $subQueryAlias = null);
+	public function from($table);
+
+	/**
+	 * Add alias for current query.
+	 *
+	 * Usage:
+	 * $query->select('*')->from('#__a')->alias('subquery');
+	 *
+	 * @param   string  $alias  Alias used for a JDatabaseQuery.
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function alias($alias);
 
 	/**
 	 * Used to get a string to extract year from date column.

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -132,12 +132,12 @@ class SqlsrvQuery extends DatabaseQuery
 					$query .= PHP_EOL . '/*ORDER BY (SELECT 0)*/';
 				}
 
-				if ($this->alias)
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
+				if ($this->alias !== null)
 				{
 					$query = '(' . $query . ') AS ' . $this->alias;
 				}
-
-				$query = $this->processLimit($query, $this->limit, $this->offset);
 
 				break;
 

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -132,6 +132,11 @@ class SqlsrvQuery extends DatabaseQuery
 					$query .= PHP_EOL . '/*ORDER BY (SELECT 0)*/';
 				}
 
+				if ($this->alias)
+				{
+					$query = '(' . $query . ') AS ' . $this->alias;
+				}
+
 				$query = $this->processLimit($query, $this->limit, $this->offset);
 
 				break;


### PR DESCRIPTION
### Summary of Changes

Add a new method `$query->alias('alias')` to help you to generate the query string as `(SELECT ... FROM ...) AS alias`.

Note: `$query->alias()` does not call `$db->quoteName()` `implicitly.

### Example
```php
$sub = $db->getQuery(true);
$sub->select('col AS col2')->from('table')->where('a=1');
$query = $db->getQuery(true)->select('col2')->from($sub->alias('alias'));
```

### Testing Instructions
Code review.
Unit tests should pass.

This PR requires https://github.com/joomla-framework/database/pull/141 to work properly.

### Documentation Changes Required
Yes.

- New method `alias($alias)`.
- Changes in method `from($table)`.
