### PR TITLE
Add a new class DebugMonitor

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1732,7 +1732,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setMonitor($monitor)
+	public function setMonitor(QueryMonitorInterface $monitor = null)
 	{
 		$this->monitor = $monitor;
 

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1728,6 +1728,21 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	}
 
 	/**
+	 * Delete the query monitor.
+	 *
+	 * @return  QueryMonitorInterface|null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function delMonitor()
+	{
+		$monitor       = $this->monitor;
+		$this->monitor = null;
+
+		return $monitor;
+	}
+
+	/**
 	 * Sets the SQL statement string for later execution.
 	 *
 	 * @param   string|QueryInterface  $query   The SQL statement to set either as a Query object or a string.

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1728,13 +1728,13 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	}
 
 	/**
-	 * Delete the query monitor.
+	 * Remove the query monitor.
 	 *
-	 * @return  QueryMonitorInterface|null
+	 * @return  QueryMonitorInterface|null  The removed monitor or null if not set.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function delMonitor()
+	public function removeMonitor()
 	{
 		$monitor       = $this->monitor;
 		$this->monitor = null;

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1712,34 +1712,31 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	}
 
 	/**
+	 * Get the query monitor.
+	 *
+	 * @return  QueryMonitorInterface|null  The query monitor or null if not set.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMonitor()
+	{
+		return $this->monitor;
+	}
+
+	/**
 	 * Set a query monitor.
 	 *
-	 * @param   QueryMonitorInterface  $monitor  The query monitor.
+	 * @param   QueryMonitorInterface|null  $monitor  The query monitor.
 	 *
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setMonitor(QueryMonitorInterface $monitor)
+	public function setMonitor($monitor)
 	{
 		$this->monitor = $monitor;
 
 		return $this;
-	}
-
-	/**
-	 * Remove the query monitor.
-	 *
-	 * @return  QueryMonitorInterface|null  The removed monitor or null if not set.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function removeMonitor()
-	{
-		$monitor       = $this->monitor;
-		$this->monitor = null;
-
-		return $monitor;
 	}
 
 	/**

--- a/src/Monitor/DebugMonitor.php
+++ b/src/Monitor/DebugMonitor.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Monitor;
+
+use Joomla\Database\QueryMonitorInterface;
+
+/**
+ * Query monitor handling logging of queries.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class DebugMonitor implements QueryMonitorInterface
+{
+	/**
+	 * The log of executed SQL statements call stacks by the database driver.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $callStacks = [];
+
+	/**
+	 * The log of executed SQL statements by the database driver.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $logs = [];
+
+	/**
+	 * The log of executed SQL statements memory usage (start and stop memory_get_usage) by the database driver.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $memoryLogs = [];
+
+	/**
+	 * The log of executed SQL statements timings (start and stop microtimes) by the database driver.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $timings = [];
+
+	/**
+	 * Act on a query being started.
+	 *
+	 * @param   string  $sql  The SQL to be executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function startQuery(string $sql)
+	{
+		$this->logs[]       = $sql;
+		$this->callStacks[] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+		$this->memoryLogs[] = memory_get_usage();
+		$this->timings[]    = microtime(true);
+	}
+
+	/**
+	 * Act on a query being stopped.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function stopQuery()
+	{
+		$this->timings[]    = microtime(true);
+		$this->memoryLogs[] = memory_get_usage();
+	}
+
+	/**
+	 * Get the logged call stacks.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getCallStacks()
+	{
+		return $this->callStacks;
+	}
+
+	/**
+	 * Get the logged queries.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLogs()
+	{
+		return $this->logs;
+	}
+
+	/**
+	 * Get the logged memory logs.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMemoryLogs()
+	{
+		return $this->memoryLogs;
+	}
+
+	/**
+	 * Get the logged timings.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getTimings()
+	{
+		return $this->timings;
+	}
+}


### PR DESCRIPTION
### Summary of Changes

To help J4 to display all queries in logs when debug is ON.

The idea on J4 is to add a `DebugMonitor` object to DatabaseDriver instance when JDEBUG is ON.

```php
[...]
$options = [
        'driver'   => $dbtype,
        'host'     => $conf->get('host'),
        'user'     => $conf->get('user'),
        'password' => $conf->get('password'),
        'database' => $conf->get('db'),
        'prefix'   => $conf->get('dbprefix'),
];

if (defined('JDEBUG') && JDEBUG)
{
        $options['monitor'] = new \Joomla\Database\Monitor\DebugMonitor();
}

$db = DatabaseDriver::getInstance($options);
```

Joomla plugin will have an option to get/set debug monitor based on other configuration.

This is a copy/paste of `DebugMonitor` from https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/system/debug/DebugMonitor.php with a few changes.

I'm not sure about:
- use the `final` keyword in declaration of class or not
- use `private` or `protected` variables

At the moment there is a "final class". 
And "private" variables.

```php
// A way for J4 debug plugin
$monitor = $db->getMonitor();

if (!$log_queries) { 
    $db->setMonitor(null);
}
```

### Testing Instructions
Code review.

### Documentation Changes Required
No