### PR TITLE
Fix the quoteName method for an alias of the column containing a period

### DIFF
--- a/Tests/DriverTest.php
+++ b/Tests/DriverTest.php
@@ -602,6 +602,12 @@ SQL
 		);
 
 		$this->assertThat(
+			$this->instance->quoteName('a.test', 'a.test'),
+			$this->equalTo('[a].[test] AS [a.test]'),
+			'Tests the left-right quotes on a dotted string for column alias.'
+		);
+
+		$this->assertThat(
 			$this->instance->quoteName('a.te]st'),
 			$this->equalTo('[a].[te]]st]'),
 			'Tests the left-right quotes on a dotted string with reserved keyword.'

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1478,7 +1478,7 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 
 			if ($as !== null)
 			{
-				$name .= ' AS ' . $this->quoteNameString($as);
+				$name .= ' AS ' . $this->quoteNameString($as, true);
 			}
 
 			return $name;
@@ -1509,18 +1509,24 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	/**
 	 * Quote string coming from quoteName call.
 	 *
-	 * @param   string  $name  Identifier name to be quoted.
+	 * @param   string   $name          Identifier name to be quoted.
+	 * @param   boolean  $asSinglePart  Treat the name as a single part of the identifier.
 	 *
 	 * @return  string  Quoted identifier string.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function quoteNameString($name)
+	protected function quoteNameString($name, $asSinglePart = false)
 	{
 		$q = $this->nameQuote . $this->nameQuote;
 
 		// Double quote reserved keyword
 		$name = str_replace($q[1], $q[1] . $q[1], $name);
+
+		if ($asSinglePart)
+		{
+			return $q[0] . $name . $q[1];
+		}
 
 		return $q[0] . str_replace('.', "$q[1].$q[0]", $name) . $q[1];
 	}

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -42,7 +42,7 @@ class SqlsrvDriver extends DatabaseDriver
 	 * @var    string
 	 * @since  1.0
 	 */
-	protected $nameQuote;
+	protected $nameQuote = '[]';
 
 	/**
 	 * The null or zero representation of a timestamp for the database driver.  This should be


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/23293

### Summary of Changes
Allow alias to contain periods.

### Testing Instructions
Unit tests.
Code review

### Documentation Changes Required
No