### PR TITLE
Add support for binary data

### DIFF
--- a/Tests/DatabaseSqliteCase.php
+++ b/Tests/DatabaseSqliteCase.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Sqlite\SqliteDriver;
+use Joomla\Test\TestDatabase;
+
+/**
+ * Abstract test case class for MySQLi database testing.
+ *
+ * @since  1.0
+ */
+abstract class DatabaseSqliteCase extends TestDatabase
+{
+	/**
+	 * @var    array  The database driver options for the connection.
+	 * @since  1.0
+	 */
+	private static $options = array('driver' => 'sqlite');
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public static function setUpBeforeClass()
+	{
+		if (!class_exists('\\Joomla\\Database\\DatabaseDriver'))
+		{
+			static::markTestSkipped('The joomla/database package is not installed, cannot use this test case.');
+		}
+
+		// Make sure the driver is supported
+		if (!SqliteDriver::isSupported())
+		{
+			static::markTestSkipped('The SQLite driver is not supported on this platform.');
+		}
+
+		// We always want the default database test case to use an SQLite memory database.
+		$options = array(
+			'driver'   => 'sqlite',
+			'database' => ':memory:',
+			'prefix'   => 'jos_',
+		);
+
+		try
+		{
+			// Attempt to instantiate the driver.
+			static::$driver = DatabaseDriver::getInstance($options);
+			static::$driver->connect();
+
+			// Get the PDO instance for an SQLite memory database and load the test schema into it.
+			static::$driver->getConnection()->exec(file_get_contents(__DIR__ . '/Stubs/ddl.sql'));
+		}
+		catch (\RuntimeException $e)
+		{
+			static::$driver = null;
+		}
+	}
+
+	/**
+	 * This method is called after the last test of this test class is run.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public static function tearDownAfterClass()
+	{
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
+	}
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  \PHPUnit_Extensions_Database_DataSet_XmlDataSet
+	 *
+	 * @since   1.0
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/Stubs/database.xml');
+	}
+
+	/**
+	 * Returns the default database connection for running the tests.
+	 *
+	 * @return  \PHPUnit_Extensions_Database_DB_IDatabaseConnection
+	 *
+	 * @since   1.0
+	 */
+	protected function getConnection()
+	{
+		if (!is_null(static::$driver))
+		{
+			return $this->createDefaultDBConnection(static::$driver->getConnection(), ':memory:');
+		}
+
+		return null;
+	}
+}

--- a/Tests/DatabaseSqlsrvCase.php
+++ b/Tests/DatabaseSqlsrvCase.php
@@ -140,7 +140,17 @@ abstract class DatabaseSqlsrvCase extends TestDatabase
 
 		// Create the PDO object from the DSN and options.
 		$pdo = new \PDO($dsn, self::$options['user'], self::$options['password']);
-		$pdo->exec('create table [jos_dbtest]([id] [int] IDENTITY(1,1) NOT NULL, [title] [nvarchar](50) NOT NULL, [start_date] [datetime] NOT NULL, [description] [nvarchar](max) NOT NULL, CONSTRAINT [PK_jos_dbtest_id] PRIMARY KEY CLUSTERED ([id] ASC) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF))');
+		$pdo->exec("
+			IF OBJECT_ID('jos_dbtest', 'U') IS NOT NULL DROP TABLE [jos_dbtest];
+			CREATE TABLE [jos_dbtest] (
+				[id] [int] IDENTITY(1,1) NOT NULL,
+				[title] nvarchar(50) NOT NULL,
+				[start_date] datetime NOT NULL,
+				[description] nvarchar(max) NOT NULL,
+				[data] varbinary(max),
+				CONSTRAINT [PK_jos_dbtest_id] PRIMARY KEY CLUSTERED ([id] ASC) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF)
+			);"
+		);
 
 		return $this->createDefaultDBConnection($pdo, self::$options['database']);
 	}

--- a/Tests/DriverMysqlTest.php
+++ b/Tests/DriverMysqlTest.php
@@ -29,6 +29,22 @@ class DriverMysqlTest extends DatabaseMysqlCase
 	}
 
 	/**
+	 * Data for the testQuoteBinary test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestQuoteBinary()
+	{
+		return array(
+			array('DATA', "X'" . bin2hex('DATA') . "'"),
+			array("\x00\x01\x02\xff", "X'000102ff'"),
+			array("\x01\x01\x02\xff", "X'010102ff'"),
+		);
+	}
+
+	/**
 	 * Data for the testQuoteName test.
 	 *
 	 * @return  array
@@ -125,6 +141,25 @@ class DriverMysqlTest extends DatabaseMysqlCase
 			self::$driver->escape($text, $extra),
 			$this->equalTo($expected),
 			'The string was not escaped properly'
+		);
+	}
+
+	/**
+	 * Test the quoteBinary method.
+	 *
+	 * @param   string  $data  The binary quoted input string.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  dataTestQuoteBinary
+	 * @since         __DEPLOY_VERSION__
+	 */
+	public function testQuoteBinary($data, $expected)
+	{
+		$this->assertThat(
+			self::$driver->quoteBinary($data),
+			$this->equalTo($expected),
+			'The binary data was not quoted properly'
 		);
 	}
 
@@ -261,7 +296,13 @@ class DriverMysqlTest extends DatabaseMysqlCase
 	 */
 	public function testGetTableColumns()
 	{
-		$tableCol = array('id' => 'int unsigned', 'title' => 'varchar', 'start_date' => 'datetime', 'description' => 'text');
+		$tableCol = array(
+			'id' => 'int unsigned',
+			'title' => 'varchar',
+			'start_date' => 'datetime',
+			'description' => 'text',
+			'data' => 'blob',
+		);
 
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest'),
@@ -314,6 +355,17 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$description->Privileges = 'select,insert,update,references';
 		$description->Comment    = '';
 
+		$data = new \stdClass;
+		$data->Default    = null;
+		$data->Field      = 'data';
+		$data->Type       = 'blob';
+		$data->Null       = 'YES';
+		$data->Key        = '';
+		$data->Collation  = null;
+		$data->Extra      = '';
+		$data->Privileges = 'select,insert,update,references';
+		$data->Comment    = '';
+
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest', false),
 			$this->equalTo(
@@ -321,7 +373,8 @@ class DriverMysqlTest extends DatabaseMysqlCase
 					'id' => $id,
 					'title' => $title,
 					'start_date' => $start_date,
-					'description' => $description
+					'description' => $description,
+					'data' => $data,
 				)
 			),
 			__LINE__
@@ -474,6 +527,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$this->assertThat($result, $this->equalTo($objCompare), __LINE__);
 	}
@@ -501,6 +555,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$objCompare->title = 'Testing';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -509,6 +564,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$objCompare->title = 'Testing2';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -517,6 +573,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -525,6 +582,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$objCompare->title = 'Testing4';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'four';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -567,7 +625,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -588,8 +646,101 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+		$expected = array(
+			array(1, 'Testing', '1980-04-18 00:00:00', 'one', null),
+			array(2, 'Testing2', '1980-04-18 00:00:00', 'one', null)
+		);
 
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test quoteBinary and decodeBinary methods
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLoadBinary()
+	{
+		// Add binary data with null byte
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"))
+			->where('id = 3');
+
+		self::$driver->setQuery($query)->execute();
+
+		// Add binary data with invalid UTF-8
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x01\x01\x02\xff"))
+			->where('id = 4');
+
+		self::$driver->setQuery($query)->execute();
+
+		$selectRow3 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"));
+
+		$selectRow4 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = '. self::$driver->quoteBinary("\x01\x01\x02\xff"));
+
+		$result = self::$driver->setQuery($selectRow3)->loadResult();
+		$this->assertThat($result, $this->equalTo(3), __LINE__);
+
+		$result = self::$driver->setQuery($selectRow4)->loadResult();
+		$this->assertThat($result, $this->equalTo(4), __LINE__);
+
+		$selectRows = self::$driver->getQuery(true)
+			->select('data')
+			->from('jos_dbtest')
+			->order('id');
+
+		// Test loadColumn
+		$result = self::$driver->setQuery($selectRows)->loadColumn();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i] = self::$driver->decodeBinary($v);
+		}
+
+		$expected = array(null, null, "\x00\x01\x02\xff", "\x01\x01\x02\xff");
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadAssocList
+		$result = self::$driver->setQuery($selectRows)->loadAssocList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]['data'] = self::$driver->decodeBinary($v['data']);
+		}
+
+		$expected = array(
+			array('data' => null),
+			array('data' => null),
+			array('data' => "\x00\x01\x02\xff"),
+			array('data' => "\x01\x01\x02\xff"),
+		);
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadObjectList
+		$result = self::$driver->setQuery($selectRows)->loadObjectList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]->data = self::$driver->decodeBinary($v->data);
+		}
+
+		$expected = array(
+			(object) array('data' => null),
+			(object) array('data' => null),
+			(object) array('data' => "\x00\x01\x02\xff"),
+			(object) array('data' => "\x01\x01\x02\xff"),
+		);
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
@@ -683,7 +834,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -29,6 +29,22 @@ class DriverMysqliTest extends DatabaseMysqliCase
 	}
 
 	/**
+	 * Data for the testQuoteBinary test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestQuoteBinary()
+	{
+		return array(
+			array('DATA', "X'" . bin2hex('DATA') . "'"),
+			array("\x00\x01\x02\xff", "X'000102ff'"),
+			array("\x01\x01\x02\xff", "X'010102ff'"),
+		);
+	}
+
+	/**
 	 * Data for the testQuoteName test.
 	 *
 	 * @return  array
@@ -114,6 +130,25 @@ class DriverMysqliTest extends DatabaseMysqliCase
 			self::$driver->escape($text, $extra),
 			$this->equalTo($expected),
 			'The string was not escaped properly'
+		);
+	}
+
+	/**
+	 * Test the quoteBinary method.
+	 *
+	 * @param   string  $data  The binary quoted input string.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  dataTestQuoteBinary
+	 * @since         __DEPLOY_VERSION__
+	 */
+	public function testQuoteBinary($data, $expected)
+	{
+		$this->assertThat(
+			self::$driver->quoteBinary($data),
+			$this->equalTo($expected),
+			'The binary data was not quoted properly'
 		);
 	}
 
@@ -250,7 +285,13 @@ class DriverMysqliTest extends DatabaseMysqliCase
 	 */
 	public function testGetTableColumns()
 	{
-		$tableCol = array('id' => 'int unsigned', 'title' => 'varchar', 'start_date' => 'datetime', 'description' => 'text');
+		$tableCol = array(
+			'id'          => 'int unsigned',
+			'title'       => 'varchar',
+			'start_date'  => 'datetime',
+			'description' => 'text',
+			'data'        => 'blob',
+		);
 
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest'),
@@ -303,6 +344,17 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$description->Privileges = 'select,insert,update,references';
 		$description->Comment    = '';
 
+		$data = new \stdClass;
+		$data->Default    = null;
+		$data->Field      = 'data';
+		$data->Type       = 'blob';
+		$data->Null       = 'YES';
+		$data->Key        = '';
+		$data->Collation  = null;
+		$data->Extra      = '';
+		$data->Privileges = 'select,insert,update,references';
+		$data->Comment    = '';
+
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest', false),
 			$this->equalTo(
@@ -310,7 +362,8 @@ class DriverMysqliTest extends DatabaseMysqliCase
 					'id' => $id,
 					'title' => $title,
 					'start_date' => $start_date,
-					'description' => $description
+					'description' => $description,
+					'data' => $data,
 				)
 			),
 			__LINE__
@@ -475,6 +528,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$this->assertThat($result, $this->equalTo($objCompare), __LINE__);
 	}
@@ -502,6 +556,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$objCompare->title = 'Testing';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -510,6 +565,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$objCompare->title = 'Testing2';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -518,6 +574,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -526,6 +583,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$objCompare->title = 'Testing4';
 		$objCompare->start_date = '1980-04-18 00:00:00';
 		$objCompare->description = 'four';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -568,7 +626,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -589,8 +647,101 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+		$expected = array(
+			array(1, 'Testing', '1980-04-18 00:00:00', 'one', null),
+			array(2, 'Testing2', '1980-04-18 00:00:00', 'one', null)
+		);
 
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test quoteBinary and decodeBinary methods
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLoadBinary()
+	{
+		// Add binary data with null byte
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"))
+			->where('id = 3');
+
+		self::$driver->setQuery($query)->execute();
+
+		// Add binary data with invalid UTF-8
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x01\x01\x02\xff"))
+			->where('id = 4');
+
+		self::$driver->setQuery($query)->execute();
+
+		$selectRow3 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"));
+
+		$selectRow4 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = '. self::$driver->quoteBinary("\x01\x01\x02\xff"));
+
+		$result = self::$driver->setQuery($selectRow3)->loadResult();
+		$this->assertThat($result, $this->equalTo(3), __LINE__);
+
+		$result = self::$driver->setQuery($selectRow4)->loadResult();
+		$this->assertThat($result, $this->equalTo(4), __LINE__);
+
+		$selectRows = self::$driver->getQuery(true)
+			->select('data')
+			->from('jos_dbtest')
+			->order('id');
+
+		// Test loadColumn
+		$result = self::$driver->setQuery($selectRows)->loadColumn();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i] = self::$driver->decodeBinary($v);
+		}
+
+		$expected = array(null, null, "\x00\x01\x02\xff", "\x01\x01\x02\xff");
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadAssocList
+		$result = self::$driver->setQuery($selectRows)->loadAssocList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]['data'] = self::$driver->decodeBinary($v['data']);
+		}
+
+		$expected = array(
+			array('data' => null),
+			array('data' => null),
+			array('data' => "\x00\x01\x02\xff"),
+			array('data' => "\x01\x01\x02\xff"),
+		);
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadObjectList
+		$result = self::$driver->setQuery($selectRows)->loadObjectList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]->data = self::$driver->decodeBinary($v->data);
+		}
+
+		$expected = array(
+			(object) array('data' => null),
+			(object) array('data' => null),
+			(object) array('data' => "\x00\x01\x02\xff"),
+			(object) array('data' => "\x01\x01\x02\xff"),
+		);
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
@@ -715,7 +866,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}

--- a/Tests/DriverSqlsrvTest.php
+++ b/Tests/DriverSqlsrvTest.php
@@ -31,6 +31,22 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 	}
 
 	/**
+	 * Data for the testQuoteBinary test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestQuoteBinary()
+	{
+		return array(
+			array('DATA', "0x" . bin2hex('DATA')),
+			array("\x00\x01\x02\xff", "0x000102ff"),
+			array("\x01\x01\x02\xff", "0x010102ff"),
+		);
+	}
+
+	/**
 	 * Data for the testQuoteName test.
 	 *
 	 * @return  array
@@ -108,6 +124,25 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 			self::$driver->escape($text, $extra),
 			$this->equalTo($expected),
 			'The string was not escaped properly'
+		);
+	}
+
+	/**
+	 * Test the quoteBinary method.
+	 *
+	 * @param   string  $data  The binary quoted input string.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  dataTestQuoteBinary
+	 * @since         __DEPLOY_VERSION__
+	 */
+	public function testQuoteBinary($data, $expected)
+	{
+		$this->assertThat(
+			self::$driver->quoteBinary($data),
+			$this->equalTo($expected),
+			'The binary data was not quoted properly'
 		);
 	}
 
@@ -386,6 +421,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00.000';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$this->assertThat($result, $this->equalTo($objCompare), __LINE__);
 	}
@@ -413,6 +449,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		$objCompare->title = 'Testing';
 		$objCompare->start_date = '1980-04-18 00:00:00.000';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -421,6 +458,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		$objCompare->title = 'Testing2';
 		$objCompare->start_date = '1980-04-18 00:00:00.000';
 		$objCompare->description = 'one';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -429,6 +467,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00.000';
 		$objCompare->description = 'three';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -437,6 +476,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		$objCompare->title = 'Testing4';
 		$objCompare->start_date = '1980-04-18 00:00:00.000';
 		$objCompare->description = 'four';
+		$objCompare->data = null;
 
 		$expected[] = clone $objCompare;
 
@@ -479,7 +519,7 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00.000', 'three');
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00.000', 'three', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -500,8 +540,101 @@ class DriverSqlsrvTest extends DatabaseSqlsrvCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00.000', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00.000', 'one'));
+		$expected = array(
+			array(1, 'Testing', '1980-04-18 00:00:00.000', 'one', null),
+			array(2, 'Testing2', '1980-04-18 00:00:00.000', 'one', null)
+		);
 
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test quoteBinary and decodeBinary methods
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLoadBinary()
+	{
+		// Add binary data with null byte
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"))
+			->where('id = 3');
+
+		self::$driver->setQuery($query)->execute();
+
+		// Add binary data with invalid UTF-8
+		$query = self::$driver->getQuery(true)
+			->update('jos_dbtest')
+			->set('data = ' . self::$driver->quoteBinary("\x01\x01\x02\xff"))
+			->where('id = 4');
+
+		self::$driver->setQuery($query)->execute();
+
+		$selectRow3 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = ' . self::$driver->quoteBinary("\x00\x01\x02\xff"));
+
+		$selectRow4 = self::$driver->getQuery(true)
+			->select('id')
+			->from('jos_dbtest')
+			->where('data = '. self::$driver->quoteBinary("\x01\x01\x02\xff"));
+
+		$result = self::$driver->setQuery($selectRow3)->loadResult();
+		$this->assertThat($result, $this->equalTo(3), __LINE__);
+
+		$result = self::$driver->setQuery($selectRow4)->loadResult();
+		$this->assertThat($result, $this->equalTo(4), __LINE__);
+
+		$selectRows = self::$driver->getQuery(true)
+			->select('data')
+			->from('jos_dbtest')
+			->order('id');
+
+		// Test loadColumn
+		$result = self::$driver->setQuery($selectRows)->loadColumn();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i] = self::$driver->decodeBinary($v);
+		}
+
+		$expected = array(null, null, "\x00\x01\x02\xff", "\x01\x01\x02\xff");
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadAssocList
+		$result = self::$driver->setQuery($selectRows)->loadAssocList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]['data'] = self::$driver->decodeBinary($v['data']);
+		}
+
+		$expected = array(
+			array('data' => null),
+			array('data' => null),
+			array('data' => "\x00\x01\x02\xff"),
+			array('data' => "\x01\x01\x02\xff"),
+		);
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+
+		// Test loadObjectList
+		$result = self::$driver->setQuery($selectRows)->loadObjectList();
+
+		foreach ($result as $i => $v)
+		{
+			$result[$i]->data = self::$driver->decodeBinary($v->data);
+		}
+
+		$expected = array(
+			(object) array('data' => null),
+			(object) array('data' => null),
+			(object) array('data' => "\x00\x01\x02\xff"),
+			(object) array('data' => "\x01\x01\x02\xff"),
+		);
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 

--- a/Tests/DriverTest.php
+++ b/Tests/DriverTest.php
@@ -581,6 +581,28 @@ SQL
 	}
 
 	/**
+	 * Tests the Joomla\Database\DatabaseDriver::quoteBinary method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testQuoteBinary()
+	{
+		$this->assertThat(
+			$this->instance->quoteBinary('DATA'),
+			$this->equalTo("X'" . bin2hex('DATA') . "'"),
+			'Tests the binary data 1.'
+		);
+
+		$this->assertThat(
+			$this->instance->quoteBinary("\x00\x01\x02\xff"),
+			$this->equalTo("X'000102ff'"),
+			'Tests the binary data 2.'
+		);
+	}
+
+	/**
 	 * Tests the Joomla\Database\DatabaseDriver::quoteName method.
 	 *
 	 * @return  void

--- a/Tests/Mock/Driver.php
+++ b/Tests/Mock/Driver.php
@@ -77,6 +77,7 @@ class Driver
 			'lockTable',
 			'query',
 			'quote',
+			'quoteBinary',
 			'quoteName',
 			'renameTable',
 			'replacePrefix',

--- a/Tests/Stubs/ddl.sql
+++ b/Tests/Stubs/ddl.sql
@@ -484,7 +484,8 @@ CREATE TABLE `jos_dbtest` (
   `id` INTEGER PRIMARY KEY AUTOINCREMENT,
   `title` TEXT NOT NULL DEFAULT '',
   `start_date` TEXT NOT NULL DEFAULT '',
-  `description` TEXT NOT NULL DEFAULT ''
+  `description` TEXT NOT NULL DEFAULT '',
+  `data` BLOB
 );
 
 

--- a/Tests/Stubs/mysql.sql
+++ b/Tests/Stubs/mysql.sql
@@ -20,6 +20,7 @@ CREATE TABLE `jos_dbtest` (
   `title` varchar(50) NOT NULL,
   `start_date` datetime NOT NULL,
   `description` text NOT NULL,
+  `data` blob,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/Tests/Stubs/postgresql.sql
+++ b/Tests/Stubs/postgresql.sql
@@ -559,6 +559,7 @@ CREATE TABLE "jos_dbtest" (
   "title" character varying(50) NOT NULL,
   "start_date" timestamp without time zone NOT NULL,
   "description" text NOT NULL,
+  "data" bytea,
   PRIMARY KEY ("id")
 );
 

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1458,6 +1458,35 @@ abstract class DatabaseDriver implements DatabaseInterface, Log\LoggerAwareInter
 	}
 
 	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   string  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		// SQL standard syntax for hexadecimal literals
+		return "X'" . bin2hex($data) . "'";
+	}
+
+	/**
+	 * Replace special placeholder representing binary field with the original string.
+	 *
+	 * @param   string|resource  $data  Encoded string or resource.
+	 *
+	 * @return  string  The original string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function decodeBinary($data)
+	{
+		return $data;
+	}
+
+	/**
 	 * Wrap an SQL statement identifier name such as column, table or database names in quotes to prevent injection
 	 * risks and reserved word conflicts.
 	 *

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -23,4 +23,26 @@ interface DatabaseInterface
 	 * @since   1.0
 	 */
 	public static function isSupported();
+
+	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   string  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data);
+
+	/**
+	 * Replace special placeholder representing binary field with the original string.
+	 *
+	 * @param   string|resource  $data  Encoded string or resource.
+	 *
+	 * @return  string  The original string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function decodeBinary($data);
 }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -23,26 +23,4 @@ interface DatabaseInterface
 	 * @since   1.0
 	 */
 	public static function isSupported();
-
-	/**
-	 * Quotes a binary string to database requirements for use in database queries.
-	 *
-	 * @param   string  $data  A binary string to quote.
-	 *
-	 * @return  string  The binary quoted input string.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function quoteBinary($data);
-
-	/**
-	 * Replace special placeholder representing binary field with the original string.
-	 *
-	 * @param   string|resource  $data  Encoded string or resource.
-	 *
-	 * @return  string  The original string.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function decodeBinary($data);
 }

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -981,4 +981,37 @@ class PgsqlDriver extends PdoDriver
 
 		return $this->execute();
 	}
+
+	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   string  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		return "decode('" . bin2hex($data) . "', 'hex')";
+	}
+
+	/**
+	 * Replace special placeholder representing binary field with the original string.
+	 *
+	 * @param   string|resource  $data  Encoded string or resource.
+	 *
+	 * @return  string  The original string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function decodeBinary($data)
+	{
+		if (is_resource($data))
+		{
+			return stream_get_contents($data);
+		}
+
+		return $data;
+	}
 }

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -1603,4 +1603,37 @@ class PostgresqlDriver extends DatabaseDriver
 
 		return $this->execute();
 	}
+
+	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   string  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		return "decode('" . bin2hex($data) . "', 'hex')";
+	}
+
+	/**
+	 * Replace special placeholder representing binary field with the original string.
+	 *
+	 * @param   string|resource  $data  Encoded string or resource.
+	 *
+	 * @return  string  The original string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function decodeBinary($data)
+	{
+		if (is_string($data))
+		{
+			return pg_unescape_bytea($data);
+		}
+
+		return $data;
+	}
 }

--- a/src/Postgresql/PostgresqlDriver.php
+++ b/src/Postgresql/PostgresqlDriver.php
@@ -202,6 +202,7 @@ class PostgresqlDriver extends DatabaseDriver
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
 		pg_query($this->connection, 'SET standard_conforming_strings=off');
 		pg_query($this->connection, 'SET escape_string_warning=off');
+		pg_query($this->connection, 'SET bytea_output=escape');
 	}
 
 	/**

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -273,6 +273,21 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Quotes a binary string to database requirements for use in database queries.
+	 *
+	 * @param   string  $data  A binary string to quote.
+	 *
+	 * @return  string  The binary quoted input string.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function quoteBinary($data)
+	{
+		// ODBC syntax for hexadecimal literals
+		return '0x' . bin2hex($data);
+	}
+
+	/**
 	 * Determines if the connection to the server is active.
 	 *
 	 * @return  boolean  True if connected to the database engine.


### PR DESCRIPTION
### Summary of Changes

Add two new methods:
- `$db->quoteBinary()` - required by ms sql server (to explicitly cast a value on INSERT query)
- `$db->decodeBinary()` - required by Postgresql/Pgsql drivers to get the original binary string.

Add a missing class `DatabaseSqliteCase` in order to load `./Stubs/ddl.sql` file and the same `./Stubs/database.xml` file as on other drivers. 
Previously, phpunit loaded SQL/XML data from the additional package 'Joomla\Test'.

### Testing Instructions
Code review.
Unit tests should pass

### Documentation Changes Required

To work properly with a binary string, we have to quote it using `quoteBinary()`. This method replaces the binary string with hexadecimal text wrapped in the specified format depending on the database driver.

When we want to get value of `BLOB/VARBINARY` then Postgresql/Pgsql database API returns an equivalent of binary string. 

Postgresql (>= 9.0) by default returns hexdecimal text or (<9.0) escaped string.
I changed SQL variable `buffer_output` to always return escaped string and then use `pg_unescape_string` to get the original binary string.

PgSQL returns a stream instead of string. To get the original binary string we have to use `stream_get_contents()`. 

Other databases do not require this additional conversion. For the code to work properly regardless of the database driver, we will use  `$db->decodeBinary($value)`. 

