### PR TITLE
[FEATURE] add whereNotIn function

### DIFF
--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1706,6 +1706,29 @@ abstract class DatabaseQuery implements QueryInterface
 	}
 
 	/**
+	 * Add a WHERE NOT IN statement to the query.
+	 *
+	 * Note that all values must be the same data type.
+	 *
+	 * Usage
+	 * $query->whereIn('id', [1, 2, 3]);
+	 *
+	 * @param   string  $keyName    Key name for the where clause
+	 * @param   array   $keyValues  Array of values to be matched
+	 * @param   string  $dataType   Type of the values to bind
+	 *
+	 * @return  $this
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function whereNotIn(string $keyName, array $keyValues, string $dataType = ParameterType::INTEGER)
+	{
+		return $this->where(
+			$keyName . ' NOT IN (' . implode(',', $this->bindArray($keyValues, $dataType)) . ')'
+		);
+	}
+
+	/**
 	 * Extend the WHERE clause with a single condition or an array of conditions, with a potentially
 	 * different logical operator from the one in the current WHERE clause.
 	 *

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1711,7 +1711,7 @@ abstract class DatabaseQuery implements QueryInterface
 	 * Note that all values must be the same data type.
 	 *
 	 * Usage
-	 * $query->whereIn('id', [1, 2, 3]);
+	 * $query->whereNotIn('id', [1, 2, 3]);
 	 *
 	 * @param   string  $keyName    Key name for the where clause
 	 * @param   array   $keyValues  Array of values to be matched


### PR DESCRIPTION
### Summary of Changes
Add function `whereNotIn`.

So now we can use prepared statements for `NOT IN` queries easier.

### Testing Instructions
using something like this:

```php
$groups = array("Editor", "Author");
$db = Factory::getDbo();
$query = $db->getQuery(true)
                                ->select($db->quoteName('title'))
                                ->from($db->quoteName('#__usergroups'))
                                ->whereNotIn($db->quoteName('title'), $currentGroups, ParameterType::STRING);$db->setQuery($query);

$result = $db->loadColumn()
```

`$result` should contain alls groups, except of `Editor` and `Author`