### PR TITLE
Add named prepared statements to sqlsrv

### DIFF
--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -691,13 +691,13 @@ class SqlsrvDriverTest extends SqlsrvCase
 	}
 
 	/**
-	 * Test the execute method with a prepared statement
+	 * Test the execute method with an unnamed prepared statement
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testExecutePreparedStatement()
+	public function testExecuteUnnamedPreparedStatement()
 	{
 		$title       = 'testTitle';
 		$startDate   = '2013-04-01 00:00:00.000';
@@ -711,6 +711,33 @@ class SqlsrvDriverTest extends SqlsrvCase
 		$query->bind(1, $title);
 		$query->bind(2, $startDate);
 		$query->bind(3, $description);
+
+		self::$driver->setQuery($query);
+
+		$this->assertNotEquals(self::$driver->execute(), false, __LINE__);
+	}
+
+	/**
+	 * Test the execute method with a named prepared statement
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testExecuteNamedPreparedStatement()
+	{
+		$title       = 'testTitleNamed';
+		$startDate   = '2013-04-01 00:00:00.000';
+		$description = 'NamedTesting';
+
+		/** @var \Joomla\Database\Sqlsrv\SqlsrvQuery $query */
+		$query = self::$driver->getQuery(true);
+		$query->insert('dbtest')
+					->columns('title,start_date,description')
+					->values(':title, :start_date, :description123');
+		$query->bind(":description123", $description);
+		$query->bind(":title", $title);
+		$query->bind(":start_date", $startDate);
 
 		self::$driver->setQuery($query);
 

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -93,7 +93,7 @@ class SqlsrvQuery extends DatabaseQuery
 			ParameterType::STRING       => SQLSRV_SQLTYPE_VARCHAR('max'),
 		];
 
-		return parrent::__construct($db);
+		return parent::__construct($db);
 	}
 
 	/**

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -12,11 +12,6 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Query\QueryElement;
-use function SQLSRV_SQLTYPE_BINARY;
-use const SQLSRV_SQLTYPE_BIT;
-use const SQLSRV_SQLTYPE_INT;
-use function SQLSRV_SQLTYPE_VARBINARY;
-use function SQLSRV_SQLTYPE_VARCHAR;
 
 /**
  * SQL Server Query Building Class.

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -81,11 +81,11 @@ class SqlsrvQuery extends DatabaseQuery
 		// Initial parameter types for prepared statements
 
 		$this->parameterMapping = [
-			ParameterType::BOOLEAN      => SQLSRV_SQLTYPE_BIT,
-			ParameterType::INTEGER      => SQLSRV_SQLTYPE_INT,
-			ParameterType::LARGE_OBJECT => SQLSRV_SQLTYPE_VARBINARY('max'),
-			ParameterType::NULL         => SQLSRV_SQLTYPE_VARCHAR(1),
-			ParameterType::STRING       => SQLSRV_SQLTYPE_VARCHAR('max'),
+			ParameterType::BOOLEAN      => SQLSRV_PHPTYPE_INT,
+			ParameterType::INTEGER      => SQLSRV_PHPTYPE_INT,
+			ParameterType::LARGE_OBJECT => SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY),
+			ParameterType::NULL         => SQLSRV_PHPTYPE_NULL,
+			ParameterType::STRING       => SQLSRV_PHPTYPE_STRING(SQLSRV_ENC_CHAR),
 		];
 
 		return parent::__construct($db);

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -486,54 +486,26 @@ class SqlsrvStatement implements StatementInterface
 	private function prepare()
 	{
 		$params = [];
-
-		if (!empty($this->parameterKeyMapping))
-		{
-			foreach ($this->bindedValues as $key => &$value)
-			{
-				$variable = [
-					&$value,
-					SQLSRV_PARAM_IN,
-					null,
-					$this->typesKeyMapping[$key]
-				];
-
-				if ($this->typesKeyMapping[$key] === SQLSRV_SQLTYPE_VARBINARY('max'))
-				{
-					$variable[2] = SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY);
-				}
-
-				$params[] = $variable;
-			}
-			unset($value);
-		}
-		else
-		{
-			foreach ($this->bindedValues as $key => &$value)
-			{
-				$params[]    =& $value;
-				$types[$key] = $this->typesKeyMapping[$key];
-
-				$variable = [
-					&$value,
-					SQLSRV_PARAM_IN,
-					null,
-					$this->typesKeyMapping[$key]
-				];
-
-				if ($this->typesKeyMapping[$key] === SQLSRV_SQLTYPE_VARBINARY('max'))
-				{
-					$variable[2] = SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY);
-				}
-
-				$params[] = $variable;
-			}
-			unset($value);
-		}
-
-		ksort($params);
-
 		$options = [];
+
+		foreach ($this->bindedValues as $key => &$value)
+		{
+			$variable = [
+				&$value,
+				SQLSRV_PARAM_IN
+			];
+
+			if ($this->typesKeyMapping[$key] === SQLSRV_SQLTYPE_VARBINARY('max'))
+			{
+				$variable[] = $this->typesKeyMapping[$key];
+				$variable[] = SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY);
+			}
+
+			$params[] = $variable;
+		}
+
+		// Cleanup referenced variable
+		unset($value);
 
 		// SQLSRV Function sqlsrv_num_rows requires a static or keyset cursor.
 		if (strncmp(strtoupper(ltrim($this->query)), 'SELECT', \strlen('SELECT')) === 0)

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -495,10 +495,10 @@ class SqlsrvStatement implements StatementInterface
 				SQLSRV_PARAM_IN
 			];
 
-			if ($this->typesKeyMapping[$key] === SQLSRV_SQLTYPE_VARBINARY('max'))
+			if ($this->typesKeyMapping[$key] === SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY))
 			{
 				$variable[] = $this->typesKeyMapping[$key];
-				$variable[] = SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY);
+				$variable[] = SQLSRV_SQLTYPE_VARBINARY('max');
 			}
 
 			if (isset($this->parameterKeyMapping[$key]))

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -501,7 +501,14 @@ class SqlsrvStatement implements StatementInterface
 				$variable[] = SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY);
 			}
 
-			$params[] = $variable;
+			if (isset($this->parameterKeyMapping[$key]))
+			{
+				$params[$this->parameterKeyMapping[$key]] = $variable;
+			}
+			else
+			{
+				$params[] = $variable;
+			}
 		}
 
 		// Cleanup referenced variable


### PR DESCRIPTION
Pull Request for Issue #112 and tries to bring named prepared statements to the sqlsrv driver.

### Summary of Changes
* bring sqlsrv driver more in sync with mysqli driver
* add named prepared statements
* fixed wrong docblocks

### Testing Instructions
* use (named) prepared statements with mssql server
