### PR TITLE
Allow to add flags to the connection (ex: for encrypted SSL/TLS connection)

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -131,7 +131,6 @@ class MysqliDriver extends DatabaseDriver
 			$options['ssl']['cipher'] = isset($options['ssl']['cipher']) ? $options['ssl']['cipher'] : null;
 		}
 
-
 		// Finalize initialisation.
 		parent::__construct($options);
 	}

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -131,6 +131,7 @@ class MysqliDriver extends DatabaseDriver
 			$options['ssl']['cipher'] = isset($options['ssl']['cipher']) ? $options['ssl']['cipher'] : null;
 		}
 
+
 		// Finalize initialisation.
 		parent::__construct($options);
 	}

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -222,7 +222,13 @@ class MysqliDriver extends DatabaseDriver
 
 		// Attempt to connect to the server.
 		$connected = $this->connection->real_connect(
-			$this->options['host'], $this->options['user'], $this->options['password'], null, $this->options['port'], $this->options['socket'], $this->options['flags']
+			$this->options['host'],
+			$this->options['user'],
+			$this->options['password'],
+			null,
+			$this->options['port'],
+			$this->options['socket'],
+			$this->options['flags']
 		);
 
 		if (!$connected)

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -120,15 +120,15 @@ class MysqliDriver extends DatabaseDriver
 		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
 		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
 		$options['flags']    = isset($options['flags']) ? $options['flags'] : null;
-		$options['ssl']      = (isset($options['ssl'])) ? $options['ssl'] : null;
+		$options['ssl']      = isset($options['ssl']) ? $options['ssl'] : null;
 
 		if ($options['ssl'] !== null)
 		{
-			$options['ssl']['key']    = (isset($options['ssl']['key'])) ? $options['ssl']['key'] : null;
-			$options['ssl']['cert']   = (isset($options['ssl']['cert'])) ? $options['ssl']['cert'] : null;
-			$options['ssl']['ca']     = (isset($options['ssl']['ca'])) ? $options['ssl']['ca'] : null;
-			$options['ssl']['capath'] = (isset($options['ssl']['capath'])) ? $options['ssl']['capath'] : null;
-			$options['ssl']['cipher'] = (isset($options['ssl']['key'])) ? $options['ssl']['cipher'] : null;
+			$options['ssl']['key']    = isset($options['ssl']['key']) ? $options['ssl']['key'] : null;
+			$options['ssl']['cert']   = isset($options['ssl']['cert']) ? $options['ssl']['cert'] : null;
+			$options['ssl']['ca']     = isset($options['ssl']['ca']) ? $options['ssl']['ca'] : null;
+			$options['ssl']['capath'] = isset($options['ssl']['capath']) ? $options['ssl']['capath'] : null;
+			$options['ssl']['cipher'] = isset($options['ssl']['key']) ? $options['ssl']['cipher'] : null;
 		}
 
 		// Finalize initialisation.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -233,7 +233,13 @@ class MysqliDriver extends DatabaseDriver
 		// Add SSL/TLS options.
 		if ($this->options['ssl'] !== null)
 		{
-			$this->connection->ssl_set($this->options['ssl']['key'], $this->options['ssl']['cert'], $this->options['ssl']['ca'], $this->options['ssl']['capath'], $this->options['ssl']['cipher']);
+			$this->connection->ssl_set(
+				$this->options['ssl']['key'],
+				$this->options['ssl']['cert'],
+				$this->options['ssl']['ca'],
+				$this->options['ssl']['capath'],
+				$this->options['ssl']['cipher']
+			);
 		}
 
 		// Attempt to connect to the server.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -119,6 +119,7 @@ class MysqliDriver extends DatabaseDriver
 		$options['port']     = isset($options['port']) ? (int) $options['port'] : null;
 		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
 		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
+		$options['flags']    = isset($options['flags']) ? $options['flags'] : null;
 
 		// Finalize initialisation.
 		parent::__construct($options);
@@ -221,7 +222,7 @@ class MysqliDriver extends DatabaseDriver
 
 		// Attempt to connect to the server.
 		$connected = $this->connection->real_connect(
-			$this->options['host'], $this->options['user'], $this->options['password'], null, $this->options['port'], $this->options['socket']
+			$this->options['host'], $this->options['user'], $this->options['password'], null, $this->options['port'], $this->options['socket'], $this->options['flags']
 		);
 
 		if (!$connected)

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -120,6 +120,16 @@ class MysqliDriver extends DatabaseDriver
 		$options['socket']   = isset($options['socket']) ? $options['socket'] : null;
 		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
 		$options['flags']    = isset($options['flags']) ? $options['flags'] : null;
+		$options['ssl']      = (isset($options['ssl'])) ? $options['ssl'] : null;
+
+		if ($options['ssl'] !== null)
+		{
+			$options['ssl']['key']    = (isset($options['ssl']['key'])) ? $options['ssl']['key'] : null;
+			$options['ssl']['cert']   = (isset($options['ssl']['cert'])) ? $options['ssl']['cert'] : null;
+			$options['ssl']['ca']     = (isset($options['ssl']['ca'])) ? $options['ssl']['ca'] : null;
+			$options['ssl']['capath'] = (isset($options['ssl']['capath'])) ? $options['ssl']['capath'] : null;
+			$options['ssl']['cipher'] = (isset($options['ssl']['key'])) ? $options['ssl']['cipher'] : null;
+		}
 
 		// Finalize initialisation.
 		parent::__construct($options);
@@ -219,6 +229,12 @@ class MysqliDriver extends DatabaseDriver
 		}
 
 		$this->connection = mysqli_init();
+
+		// Add SSL/TLS options.
+		if ($this->options['ssl'] !== null)
+		{
+			$this->connection->ssl_set($this->options['ssl']['key'], $this->options['ssl']['cert'], $this->options['ssl']['ca'], $this->options['ssl']['capath'], $this->options['ssl']['cipher']);
+		}
 
 		// Attempt to connect to the server.
 		$connected = $this->connection->real_connect(

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -128,7 +128,7 @@ class MysqliDriver extends DatabaseDriver
 			$options['ssl']['cert']   = isset($options['ssl']['cert']) ? $options['ssl']['cert'] : null;
 			$options['ssl']['ca']     = isset($options['ssl']['ca']) ? $options['ssl']['ca'] : null;
 			$options['ssl']['capath'] = isset($options['ssl']['capath']) ? $options['ssl']['capath'] : null;
-			$options['ssl']['cipher'] = isset($options['ssl']['key']) ? $options['ssl']['cipher'] : null;
+			$options['ssl']['cipher'] = isset($options['ssl']['cipher']) ? $options['ssl']['cipher'] : null;
 		}
 
 		// Finalize initialisation.


### PR DESCRIPTION
### Summary of Changes

1. Allow to add flags to the database connection.

For instance, using `MYSQLI_CLIENT_SSL` flag (see https://www.php.net/manual/en/mysqli.real-connect.php) in a SSL/TLS capable MySQL/MariaDb server to encrypt the connection to the database.

2. Also allow to define the ssl/tls database  connection options

### Testing Instructions

1. Code review
2. Have a SSL/TLS capable MySQL/MariaDB server.
Example: in /etc/my.cnf
```ini
[mysqld]
...
# SSL
ssl        = 1
ssl_cert   = /path/to/cert.cer
ssl_key    = /path/to/cert.key
ssl_cipher = kECDHE+aECDSA+AESGCM+AES128:kECDHE+aECDSA+AESGCM+AES256:kECDHE+aECDSA+AES128+SHA:kECDHE+aECDSA+AES256+SHA:kECDHE+aRSA+AESGCM+AES128:kECDHE+aRSA+AESGCM+AES256:kECDHE+aRSA+AES128+SHA:kECDHE+aRSA+AES256+SHA:kRSA+aRSA+AESGCM+AES128:kRSA+aRSA+AESGCM+AES256:kRSA+aRSA+AES128+SHA:kRSA+aRSA+AES256+SHA
```
Make sure the DB server is capable of working in encrypted mode. 
`mysql -u myuser -p --ssl` and then `status`, should appear something like `SSL: Cipher in use is AES256-GCM-SHA384`

3. Make a encrypted connection, add to the database connection options
```
'flags' => MYSQLI_CLIENT_SSL
```

4. Try to use other parameters for the ssl/tls database connection. Must be valid cert files.
```
'ssl' => array('key' => '/path/to/custom.key', 'cert' => '/path/to/custom.cer')
```

### Notes

This would allow in the future for the CMS to have this options for encryption (and others) in the database connection parameters.
Don't know how to do this in other database systems so this is a incomplete PR, hope others help with that.