### PR TITLE
[2.0] [WiP] MariaDB support for MySQLi and MySQL (PDO) drivers

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1167,7 +1167,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 	 */
 	public function isMinimumVersion()
 	{
-		return version_compare($this->getVersion(), static::$dbMinimum) >= 0;
+		return version_compare($this->getVersion(), $this->getMinimum()) >= 0;
 	}
 
 	/**

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -56,12 +56,28 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	protected $utf8mb4 = false;
 
 	/**
+	 * True if the database engine is MariaDB.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $mariadb = false;
+
+	/**
 	 * The minimum supported database version.
 	 *
 	 * @var    string
 	 * @since  1.0
 	 */
 	protected static $dbMinimum = '5.6';
+
+	/**
+	 * The minimum supported MariaDb database version.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $dbMinMariadb = '10.2';
 
 	/**
 	 * Constructor.
@@ -139,11 +155,19 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 			parent::connect();
 		}
 
+		$serverVersion = $this->getVersion();
+
+		$this->mariadb = stripos($serverVersion, 'mariadb') !== false;
+
 		if ($this->utf8mb4)
 		{
 			// At this point we know the client supports utf8mb4.  Now we must check if the server supports utf8mb4 as well.
-			$serverVersion = $this->getVersion();
 			$this->utf8mb4 = version_compare($serverVersion, '5.5.3', '>=');
+
+			if ($this->mariadb && version_compare($server_version, '10.0.0', '<'))
+			{
+				$this->utf8mb4 = false;
+			}
 
 			if (!$this->utf8mb4)
 			{

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -425,6 +425,18 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
+	 * Get the minimum supported database version.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMinimum()
+	{
+		return $this->mariadb ? static::dbMinMariadb : static::$dbMinimum;
+	}
+
+	/**
 	 * Determine whether the database engine support the UTF-8 Multibyte (utf8mb4) character encoding.
 	 *
 	 * @return  boolean  True if the database engine supports UTF-8 Multibyte.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -424,6 +424,29 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		return $this->setQuery('SHOW TABLES')->loadColumn();
 	}
 
+
+	/**
+	 * Get the version of the database connector.
+	 *
+	 * @return  string  The database connector version.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getVersion()
+	{
+		$this->connect();
+
+		$version = $this->getOption(\PDO::ATTR_SERVER_VERSION);
+
+		if (stripos($version, 'mariadb') !== false)
+		{
+			// MariaDB: Strip off any leading '5.5.5-', if present
+			return preg_replace('/^5\.5\.5-/', '', $version);
+		}
+
+		return $version;
+	}
+
 	/**
 	 * Get the minimum supported database version.
 	 *

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -433,7 +433,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	 */
 	public function getMinimum()
 	{
-		return $this->mariadb ? static::dbMinMariadb : static::$dbMinimum;
+		return $this->mariadb ? static::$dbMinMariadb : static::$dbMinimum;
 	}
 
 	/**

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -424,7 +424,6 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		return $this->setQuery('SHOW TABLES')->loadColumn();
 	}
 
-
 	/**
 	 * Get the version of the database connector.
 	 *

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -77,7 +77,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected static $dbMinMariadb = '10.2';
+	protected static $dbMinMariadb = '10.0';
 
 	/**
 	 * Constructor.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -72,7 +72,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	protected static $dbMinimum = '5.6';
 
 	/**
-	 * The minimum supported MariaDb database version.
+	 * The minimum supported MariaDB database version.
 	 *
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -86,7 +86,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	protected static $dbMinimum = '5.6';
 
 	/**
-	 * The minimum supported MariaDb database version.
+	 * The minimum supported MariaDB database version.
 	 *
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -565,7 +565,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	 */
 	public function getMinimum()
 	{
-		return $this->mariadb ? static::dbMinMariadb : static::$dbMinimum;
+		return $this->mariadb ? static::$dbMinMariadb : static::$dbMinimum;
 	}
 
 	/**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -565,7 +565,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	 */
 	public function getMinimum()
 	{
-		return $this->mariadb ? $this->dbMinMariadb : static::$dbMinimum;
+		return $this->mariadb ? static::dbMinMariadb : static::$dbMinimum;
 	}
 
 	/**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -78,7 +78,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	protected $mariadb = false;
 
 	/**
-	 * The minimum supported database version.
+	 * The minimum supported MySQL database version.
 	 *
 	 * @var    string
 	 * @since  1.0
@@ -554,6 +554,18 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		}
 
 		return $this->connection->server_info;
+	}
+
+	/**
+	 * Get the minimum supported database version.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMinimum()
+	{
+		return $this->mariadb ? $this->dbMinMariadb : static::$dbMinimum;
 	}
 
 	/**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -91,7 +91,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected static $dbMinMariadb = '10.2';
+	protected static $dbMinMariadb = '10.0';
 
 	/**
 	 * Constructor.

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -459,7 +459,15 @@ abstract class PdoDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		return $this->getOption(\PDO::ATTR_SERVER_VERSION);
+		$version = $this->getOption(\PDO::ATTR_SERVER_VERSION);
+
+		if (stripos($version, 'mariadb') !== false)
+		{
+			// MariaDB: Strip off any leading '5.5.5-', if present
+			return preg_replace('/^5\.5\.5-/', '', $version);
+		}
+
+		return $version;
 	}
 
 	/**

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -459,15 +459,7 @@ abstract class PdoDriver extends DatabaseDriver
 	{
 		$this->connect();
 
-		$version = $this->getOption(\PDO::ATTR_SERVER_VERSION);
-
-		if (stripos($version, 'mariadb') !== false)
-		{
-			// MariaDB: Strip off any leading '5.5.5-', if present
-			return preg_replace('/^5\.5\.5-/', '', $version);
-		}
-
-		return $version;
+		return $this->getOption(\PDO::ATTR_SERVER_VERSION);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Joomla Issue [https://github.com/joomla/joomla-cms/issues/25245](https://github.com/joomla/joomla-cms/issues/25245).

### Summary of Changes

Add version check compatibility for MariaDB to MySQLi and MySQL (PDO) drivers.

### Testing Instructions

Apply the changes in this PR to the corresponding files in folder `libraries/vendor/joomla/database/src` and sub-folders on a current 4.0-dev branch of Joomla CMS.

Check new installation with MySQLi and MySQL (PDO) works as well as before on a MySQL database with version >= 5.6.

Check new installation with MySQLi and MySQL (PDO) works now on a MariaDB database with version >= 10.0.

Plus do a code review.

### Documentation Changes Required

No.