### PR TITLE
[2.0] Default charset option to utf8mb4 for MySQL PDO

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -101,7 +101,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 
 		// Get some basic values from the options.
 		$options['driver']   = 'mysql';
-		$options['charset']  = $options['charset'] ?? 'utf8';
+		$options['charset']  = $options['charset'] ?? 'utf8mb4';
 		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
 		$this->charset = $options['charset'];


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Since the minimum MySQL requirement has been raised to 5.6 for the 2.0-dev branch, we can use a default value of 'utf8mb4' instead of 'utf8' as initial value for the `charset` option when that option is not explicitely given.

This fixes the problem that a new installation of J4 creates all tables with utf8 instead of utf8mb4 even when later after the installation the connection fully supports utf8mb4.

### Testing Instructions

Try to make a clean install of current Joomla CMS 4.0-dev branch on MySQL >= 5.6 using the PDO driver.

Check table charsets and collations in PhpMyAdmin.

Result: All tables created with utf8.

Do the same but with the changes in from this PR applied in the cooresponding file of J4.

Result: All tables created with utf8mb4.

### Documentation Changes Required

None.