### PR TITLE
Fix named prepared statement polyfill

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -1818,10 +1818,13 @@ class DatabaseQueryTest extends TestCase
 	 */
 	public function testWhereIn()
 	{
-		$this->instance->whereIn('id', [1, 2, 3]);
+		$this->instance->whereIn('id', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 		$this->assertThat(
 			trim(TestHelper::getValue($this->instance, 'where')),
-			$this->equalTo('WHERE id IN (:preparedArray1,:preparedArray2,:preparedArray3)'),
+			$this->equalTo(
+				'WHERE id IN (:preparedArray1,:preparedArray2,:preparedArray3,:preparedArray4,:preparedArray5,:preparedArray6,'
+				. ':preparedArray7,:preparedArray8,:preparedArray9,:preparedArray10,:preparedArray11,:preparedArray12)'
+			),
 			'Tests rendered value.'
 		);
 	}

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -326,7 +326,7 @@ class MysqliStatement implements StatementInterface
 	private function bindValues(array $values)
 	{
 		$params = [];
-		$types  = str_repeat('s', count($values));
+		$types  = str_repeat('s', \count($values));
 
 		if (!empty($this->parameterKeyMapping))
 		{
@@ -472,7 +472,7 @@ class MysqliStatement implements StatementInterface
 		{
 			$this->statement->store_result();
 
-			$this->rowBindedValues = array_fill(0, count($this->columnNames), null);
+			$this->rowBindedValues = array_fill(0, \count($this->columnNames), null);
 			$refs                  = [];
 
 			foreach ($this->rowBindedValues as $key => &$value)

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -219,7 +219,7 @@ class MysqliStatement implements StatementInterface
 					$endOfPlaceholder       = $match[1] + strlen($match[0]);
 					$beginOfNextPlaceholder = $matches[0][$i + 1][1] ?? strlen($substring);
 					$beginOfNextPlaceholder -= $endOfPlaceholder;
-					$literal                .= '?' . substr($substring, $endPlaceholder, $beginOfNextPlaceholder);
+					$literal                .= '?' . substr($substring, $endOfPlaceholder, $beginOfNextPlaceholder);
 				}
 			}
 			else

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -215,7 +215,7 @@ class SqlsrvStatement implements StatementInterface
 					$endOfPlaceholder       = $match[1] + strlen($match[0]);
 					$beginOfNextPlaceholder = $matches[0][$i + 1][1] ?? strlen($substring);
 					$beginOfNextPlaceholder -= $endOfPlaceholder;
-					$literal                .= '?' . substr($substring, $endPlaceholder, $beginOfNextPlaceholder);
+					$literal                .= '?' . substr($substring, $endOfPlaceholder, $beginOfNextPlaceholder);
 				}
 			}
 			else

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -200,18 +200,23 @@ class SqlsrvStatement implements StatementInterface
 			}
 
 			// Search for named prepared parameters and replace it with ? and save its position
-			$replace   = [];
 			$substring = substr($sql, $startPos, $j - $startPos);
 
-			if (preg_match_all($pattern, $substring, $matches, PREG_PATTERN_ORDER))
+			if (preg_match_all($pattern, $substring, $matches, PREG_PATTERN_ORDER + PREG_OFFSET_CAPTURE))
 			{
-				foreach ($matches[0] as $match)
+				foreach ($matches[0] as $i => $match)
 				{
-					$mapping[$match] = \count($mapping);
-					$replace[]       = $match;
-				}
+					if ($i === 0)
+					{
+						$literal .= substr($substring, 0, $match[1]);
+					}
 
-				$literal .= str_replace($replace, '?', $substring);
+					$mapping[$match[0]]     = \count($mapping);
+					$endOfPlaceholder       = $match[1] + strlen($match[0]);
+					$beginOfNextPlaceholder = $matches[0][$i + 1][1] ?? strlen($substring);
+					$beginOfNextPlaceholder -= $endOfPlaceholder;
+					$literal                .= '?' . substr($substring, $endPlaceholder, $beginOfNextPlaceholder);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
If you have multiple namedprepared parameters with the same substring in one section of a query the prepared statement polyfill fails.

### Summary of Changes
Only replace the first occur of a found named parameter.

### Testing Instructions
Create a query like this:
```php
$db = JFactory::getDbo();

$query = $db->getQuery(true);

$query->select('id')->from('#__content')->whereIn('id', [1,2,3,4,5,6,7,8,9,10,11]);

$db->setQuery($query);

$list = $db->loadObjectList();
```
