### PR TITLE
Fix tests where currently we don't perform assertions

### DIFF
--- a/Tests/Mysql/MysqlExporterTest.php
+++ b/Tests/Mysql/MysqlExporterTest.php
@@ -335,21 +335,9 @@ class MysqlExporterTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqlExporterInspector;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -361,22 +349,10 @@ class MysqlExporterTest extends TestCase
 	 */
 	public function testCheckWithNoTables()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqlExporterInspector;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -419,21 +395,9 @@ class MysqlExporterTest extends TestCase
 	 */
 	public function testFromWithBadInput()
 	{
+		$this->expectException(\InvalidArgumentException::class);
 		$instance = new MysqlExporterInspector;
-
-		try
-		{
-			$instance->from(new \stdClass);
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'From method should thrown an exception if argument is not a string or array.'
-		);
+		$instance->from(new \stdClass);
 	}
 
 	/**

--- a/Tests/Mysql/MysqlImporterTest.php
+++ b/Tests/Mysql/MysqlImporterTest.php
@@ -380,21 +380,9 @@ class ImporterMySqlTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqlImporterInspector;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -406,22 +394,10 @@ class ImporterMySqlTest extends TestCase
 	 */
 	public function testCheckWithNoFrom()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqlImporterInspector;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -437,22 +413,11 @@ class ImporterMySqlTest extends TestCase
 		$instance->setDbo($this->dbo);
 		$instance->from('foobar');
 
-		try
-		{
-			$result = $instance->check();
-
-			$this->assertThat(
-				$result,
-				$this->identicalTo($instance),
-				'check must return an object to support chaining.'
-			);
-		}
-		catch (\Exception $e)
-		{
-			$this->fail(
-				'Check method should not throw exception with good setup: ' . $e->getMessage()
-			);
-		}
+		$this->assertThat(
+			$instance->check(),
+			$this->identicalTo($instance),
+			'check must return an object to support chaining.'
+		);
 	}
 
 	/**
@@ -466,28 +431,19 @@ class ImporterMySqlTest extends TestCase
 	{
 		$instance = new MysqlImporterInspector;
 
-		try
-		{
-			$result = $instance->from('foobar');
+		$result = $instance->from('foobar');
 
-			$this->assertThat(
-				$result,
-				$this->identicalTo($instance),
-				'from must return an object to support chaining.'
-			);
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'from must return an object to support chaining.'
+		);
 
-			$this->assertThat(
-				$instance->from,
-				$this->equalTo('foobar'),
-				'The from method did not store the value as expected.'
-			);
-		}
-		catch (\Exception $e)
-		{
-			$this->fail(
-				'From method should not throw exception with good input: ' . $e->getMessage()
-			);
-		}
+		$this->assertThat(
+			$instance->from,
+			$this->equalTo('foobar'),
+			'The from method did not store the value as expected.'
+		);
 	}
 
 	/**

--- a/Tests/Mysqli/MysqliExporterTest.php
+++ b/Tests/Mysqli/MysqliExporterTest.php
@@ -48,21 +48,9 @@ class MysqliExporterTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqliExporter;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -74,22 +62,10 @@ class MysqliExporterTest extends TestCase
 	 */
 	public function testCheckWithNoTables()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqliExporter;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**

--- a/Tests/Mysqli/MysqliImporterTest.php
+++ b/Tests/Mysqli/MysqliImporterTest.php
@@ -48,21 +48,9 @@ class MysqliImporterTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqliImporter;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -74,22 +62,10 @@ class MysqliImporterTest extends TestCase
 	 */
 	public function testCheckWithNoTables()
 	{
+		$this->expectException(\RuntimeException::class);
 		$instance = new MysqliImporter;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -105,22 +81,13 @@ class MysqliImporterTest extends TestCase
 		$instance->setDbo($this->dbo);
 		$instance->from('foobar');
 
-		try
-		{
-			$result = $instance->check();
+		$result = $instance->check();
 
-			$this->assertThat(
-				$result,
-				$this->identicalTo($instance),
-				'check must return an object to support chaining.'
-			);
-		}
-		catch (\Exception $e)
-		{
-			$this->fail(
-				'Check method should not throw exception with good setup: ' . $e->getMessage()
-			);
-		}
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'check must return an object to support chaining.'
+		);
 	}
 
 	/**
@@ -133,23 +100,12 @@ class MysqliImporterTest extends TestCase
 	public function testSetDboWithGoodInput()
 	{
 		$instance = new MysqliImporter;
+		$result   = $instance->setDbo($this->dbo);
 
-		try
-		{
-			$result = $instance->setDbo($this->dbo);
-
-			$this->assertThat(
-				$result,
-				$this->identicalTo($instance),
-				'setDbo must return an object to support chaining.'
-			);
-		}
-		catch (\PHPUnit_Framework_Error $e)
-		{
-			// Unknown error has occurred.
-			$this->fail(
-				$e->getMessage()
-			);
-		}
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'setDbo must return an object to support chaining.'
+		);
 	}
 }

--- a/Tests/Pgsql/PgsqlExporterTest.php
+++ b/Tests/Pgsql/PgsqlExporterTest.php
@@ -427,21 +427,9 @@ class PgsqlExporterTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\Exception::class);
 		$instance = new PgsqlExporterInspector;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -453,22 +441,10 @@ class PgsqlExporterTest extends TestCase
 	 */
 	public function testCheckWithNoTables()
 	{
+		$this->expectException(\Exception::class);
 		$instance	= new PgsqlExporterInspector;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -511,21 +487,9 @@ class PgsqlExporterTest extends TestCase
 	 */
 	public function testFromWithBadInput()
 	{
+		$this->expectException(\InvalidArgumentException::class);
 		$instance = new PgsqlExporterInspector;
-
-		try
-		{
-			$instance->from(new \stdClass);
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'From method should thrown an exception if argument is not a string or array.'
-		);
+		$instance->from(new \stdClass);
 	}
 
 	/**

--- a/Tests/Pgsql/PgsqlImporterTest.php
+++ b/Tests/Pgsql/PgsqlImporterTest.php
@@ -483,21 +483,9 @@ class PgsqlImporterTest extends TestCase
 	 */
 	public function testCheckWithNoDbo()
 	{
+		$this->expectException(\Exception::class);
 		$instance = new PgsqlImporterInspector;
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**
@@ -509,22 +497,10 @@ class PgsqlImporterTest extends TestCase
 	 */
 	public function testCheckWithNoFrom()
 	{
+		$this->expectException(\Exception::class);
 		$instance	= new PgsqlImporterInspector;
 		$instance->setDbo($this->dbo);
-
-		try
-		{
-			$instance->check();
-		}
-		catch (\Exception $e)
-		{
-			// Exception expected.
-			return;
-		}
-
-		$this->fail(
-			'Check method should throw exception if DBO not set'
-		);
+		$instance->check();
 	}
 
 	/**


### PR DESCRIPTION
Fixes all my local tests where I'm getting warnings about tests that don't assert things

I'm deliberately not fixing the inconsistencies between the pgsql and mysql exporter implementations right now so this is just a test fix - that can come in a future PR