### PR TITLE
Add groupConcat function to QueryInterface

### DIFF
--- a/Tests/Mock/Query.php
+++ b/Tests/Mock/Query.php
@@ -93,6 +93,24 @@ class Query extends \Joomla\Database\DatabaseQuery
 	}
 
 	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->groupConcat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string  Input values concatenated into a string, separated by delimiter
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($column, $separator = ',')
+	{
+		return '';
+	}
+
+	/**
 	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is returned.
 	 *
 	 * @param   mixed  $key  The bounded variable key to retrieve.

--- a/Tests/Stubs/nosqldriver.php
+++ b/Tests/Stubs/nosqldriver.php
@@ -282,6 +282,11 @@ class NosqlDriver extends DatabaseDriver
 				return parent::clear($clause);
 			}
 
+			public function groupConcat($column, $separator = ',')
+			{
+				return '';
+			}
+
 			public function &getBounded($key = null)
 			{
 				if (empty($key))

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1106,21 +1106,6 @@ abstract class DatabaseQuery implements QueryInterface
 	}
 
 	/**
-	 * Aggregate function to get input values concatenated into a string, separated by delimiter
-	 *
-	 * Usage:
-	 * $query->group_concat('id', ',');
-	 *
-	 * @param   string  $column      The name of the column to be concatenated.
-	 * @param   string  $separator   The delimiter of each concatenated value
-	 *
-	 * @return  string
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	abstract public function group_concat($column, $separator = ',');
-
-	/**
 	 * A conditions to the HAVING clause of the query.
 	 *
 	 * Usage:

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1106,6 +1106,21 @@ abstract class DatabaseQuery implements QueryInterface
 	}
 
 	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->group_concat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	abstract public function group_concat($column, $separator = ',');
+
+	/**
 	 * A conditions to the HAVING clause of the query.
 	 *
 	 * Usage:

--- a/src/Mysql/MysqlQuery.php
+++ b/src/Mysql/MysqlQuery.php
@@ -68,4 +68,22 @@ class MysqlQuery extends PdoQuery
 
 		return parent::__toString();
 	}
+
+	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->group_concat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function group_concat($column, $separator = ',')
+	{
+		return 'GROUP_CONCAT(' . $column . 'SEPARATOR' . $this->quote($separator) . ')';
+	}
 }

--- a/src/Mysql/MysqlQuery.php
+++ b/src/Mysql/MysqlQuery.php
@@ -73,16 +73,16 @@ class MysqlQuery extends PdoQuery
 	 * Aggregate function to get input values concatenated into a string, separated by delimiter
 	 *
 	 * Usage:
-	 * $query->group_concat('id', ',');
+	 * $query->groupConcat('id', ',');
 	 *
 	 * @param   string  $column      The name of the column to be concatenated.
 	 * @param   string  $separator   The delimiter of each concatenated value
 	 *
-	 * @return  string
+	 * @return  string  Input values concatenated into a string, separated by delimiter
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function group_concat($column, $separator = ',')
+	public function groupConcat($column, $separator = ',')
 	{
 		return 'GROUP_CONCAT(' . $column . 'SEPARATOR' . $this->quote($separator) . ')';
 	}

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -169,4 +169,22 @@ class MysqliQuery extends DatabaseQuery
 
 		return parent::clear($clause);
 	}
+
+	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->group_concat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function group_concat($column, $separator = ',')
+	{
+		return 'GROUP_CONCAT(' . $column . 'SEPARATOR' . $this->quote($separator) . ')';
+	}
 }

--- a/src/Mysqli/MysqliQuery.php
+++ b/src/Mysqli/MysqliQuery.php
@@ -174,16 +174,16 @@ class MysqliQuery extends DatabaseQuery
 	 * Aggregate function to get input values concatenated into a string, separated by delimiter
 	 *
 	 * Usage:
-	 * $query->group_concat('id', ',');
+	 * $query->groupConcat('id', ',');
 	 *
 	 * @param   string  $column      The name of the column to be concatenated.
 	 * @param   string  $separator   The delimiter of each concatenated value
 	 *
-	 * @return  string
+	 * @return  string  Input values concatenated into a string, separated by delimiter
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function group_concat($column, $separator = ',')
+	public function groupConcat($column, $separator = ',')
 	{
 		return 'GROUP_CONCAT(' . $column . 'SEPARATOR' . $this->quote($separator) . ')';
 	}

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -273,16 +273,16 @@ class PgsqlQuery extends PdoQuery
 	 * Aggregate function to get input values concatenated into a string, separated by delimiter
 	 *
 	 * Usage:
-	 * $query->group_concat('id', ',');
+	 * $query->groupConcat('id', ',');
 	 *
 	 * @param   string  $column      The name of the column to be concatenated.
 	 * @param   string  $separator   The delimiter of each concatenated value
 	 *
-	 * @return  string
+	 * @return  string  Input values concatenated into a string, separated by delimiter
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function group_concat($column, $separator = ',')
+	public function groupConcat($column, $separator = ',')
 	{
 		return 'string_agg(' . $column . '::text, ' . $this->quote($separator) . ')';
 	}

--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -268,4 +268,22 @@ class PgsqlQuery extends PdoQuery
 
 		return $this;
 	}
+
+	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->group_concat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function group_concat($column, $separator = ',')
+	{
+		return 'string_agg(' . $column . '::text, ' . $this->quote($separator) . ')';
+	}
 }

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -307,6 +307,21 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	public function group($columns);
 
 	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->groupConcat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string  Input values concatenated into a string, separated by delimiter
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($column, $separator = ',');
+
+	/**
 	 * A conditions to the HAVING clause of the query.
 	 *
 	 * Usage:

--- a/src/Sqlite/SqliteQuery.php
+++ b/src/Sqlite/SqliteQuery.php
@@ -256,4 +256,22 @@ class SqliteQuery extends PdoQuery
 		// Set up the name with parentheses, the DISTINCT flag is redundant
 		return $this->merge($distinct ? 'UNION SELECT * FROM ()' : 'UNION ALL SELECT * FROM ()', $query);
 	}
+
+	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->groupConcat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string  Input values concatenated into a string, separated by delimiter
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($column, $separator = ',')
+	{
+		return 'group_concat(' . $column . ', ' . $this->quote($separator) . ')';
+	}
 }

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -558,6 +558,24 @@ class SqlsrvQuery extends DatabaseQuery
 	}
 
 	/**
+	 * Aggregate function to get input values concatenated into a string, separated by delimiter
+	 *
+	 * Usage:
+	 * $query->groupConcat('id', ',');
+	 *
+	 * @param   string  $column      The name of the column to be concatenated.
+	 * @param   string  $separator   The delimiter of each concatenated value
+	 *
+	 * @return  string  Input values concatenated into a string, separated by delimiter
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($column, $separator = ',')
+	{
+		return 'string_agg(' . $column . ', ' . $this->quote($separator) . ')';
+	}
+
+	/**
 	 * Get the function to return a random floating-point value
 	 *
 	 * Usage:


### PR DESCRIPTION
Pull Request for Review https://github.com/joomla/joomla-cms/pull/20095/files#r300880121

### Summary of Changes
Add groupConcat function to QueryInterface

### Testing Instructions
Replace:
https://github.com/joomla/joomla-cms/blob/54c3a76adcfe5d1060f8a6f337c6a4fdfaab294f/libraries/src/Console/ListUserCommand.php#L64-L66

By: 
`$query = $db->getQuery(true);`
`$query`
`->select($db->quoteName(['u.id', 'u.username', 'u.name', 'u.email', 'u.block']))`
`->select($query->groupConcat($db->quoteName('g.group_id')) . ' AS ' . $db->quoteName('groups'))`

And execute:
> php cli/joomla.php user:list

### Documentation Changes Required
