### PR TITLE
Add a castAs method

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
 use Joomla\Database\ParameterType;
+use Joomla\Database\Exception\UnknownTypeException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -82,6 +83,31 @@ class DatabaseQueryTest extends TestCase
 	public function testCastAsChar()
 	{
 		$this->assertSame('foo', $this->query->castAsChar('foo'));
+	}
+
+	/**
+	 * @testdox  A string is cast as a character string for the driver
+	 */
+	public function testCastAs()
+	{
+		$this->assertSame('123', $this->query->castAs('CHAR', '123'));
+	}
+
+	/**
+	 * @testdox  The length param is ignored for castAs when the sql driver doesn't support it
+	 */
+	public function testCastAsLengthParamIgnoredWhenNotSupported()
+	{
+		$this->assertSame('123', $this->query->castAs('CHAR', '123', 2));
+	}
+
+	/**
+	 * @testdox  Test an unknown type case return an unknown type exception
+	 */
+	public function testCastAsWithUnknownType()
+	{
+		$this->expectException(UnknownTypeException::class);
+		$this->query->castAs('INT', '123');
 	}
 
 	/**

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -128,4 +128,34 @@ class MysqlQueryTest extends TestCase
 			$this->query->regexp('foo')
 		);
 	}
+
+	/**
+	 * @testdox  A string is cast as a character string for the driver
+	 */
+	public function testCastAsWithChar()
+	{
+		$this->assertSame('123', $this->query->castAs('CHAR', '123'));
+	}
+
+	/**
+	 * @testdox  The length param is added to the CAST statement when provided
+	 */
+	public function testCastAsWithCharAndLengthParam()
+	{
+		$this->assertSame(
+			'CAST(123 AS CHAR(2))',
+			$this->query->castAs('CHAR', '123', 2)
+		);
+	}
+
+	/**
+	 * @testdox  Test castAs behaviour with INT (adds 0 to the input)
+	 */
+	public function testCastAsWithIntegerType()
+	{
+		$this->assertSame(
+			'(123 + 0)',
+			$this->query->castAs('INT', '123')
+		);
+	}
 }

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -128,4 +128,34 @@ class MysqliQueryTest extends TestCase
 			$this->query->regexp('foo')
 		);
 	}
+
+	/**
+	 * @testdox  A string is cast as a character string for the driver
+	 */
+	public function testCastAsWithChar()
+	{
+		$this->assertSame('123', $this->query->castAs('CHAR', '123'));
+	}
+
+	/**
+	 * @testdox  The length param is added to the CAST statement when provided
+	 */
+	public function testCastAsWithCharAndLengthParam()
+	{
+		$this->assertSame(
+			'CAST(123 AS CHAR(2))',
+			$this->query->castAs('CHAR', '123', 2)
+		);
+	}
+
+	/**
+	 * @testdox  Test castAs behaviour with INT (adds 0 to the input)
+	 */
+	public function testCastAsWithIntegerType()
+	{
+		$this->assertSame(
+			'(123 + 0)',
+			$this->query->castAs('INT', '123')
+		);
+	}
 }

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -54,6 +54,36 @@ class PgsqlQueryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  A string is cast as a character string for the driver
+	 */
+	public function testCastAsWithChar()
+	{
+		$this->assertSame('foo::text', $this->query->castAs('CHAR', 'foo'));
+	}
+
+	/**
+	 * @testdox  The length param is added to the CAST statement when provided
+	 */
+	public function testCastAsWithCharAndLengthParam()
+	{
+		$this->assertSame(
+			'CAST(foo AS CHAR(2))',
+			$this->query->castAs('CHAR', 'foo', 2)
+		);
+	}
+
+	/**
+	 * @testdox  Test castAs behaviour with INT
+	 */
+	public function testCastAsWithIntegerType()
+	{
+		$this->assertSame(
+			'CAST(123 AS INTEGER)',
+			$this->query->castAs('INT', '123')
+		);
+	}
+
+	/**
 	 * Data provider for concatenate test cases
 	 *
 	 * @return  \Generator

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -54,6 +54,36 @@ class SqlsrvQueryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  A string is cast as a character string for the driver
+	 */
+	public function testCastAsWithChar()
+	{
+		$this->assertSame('CAST(foo as NVARCHAR(10))', $this->query->castAs('CHAR', 'foo'));
+	}
+
+	/**
+	 * @testdox  The length param is added to the CAST statement when provided
+	 */
+	public function testCastAsWithCharAndLengthParam()
+	{
+		$this->assertSame(
+			'CAST(foo as NVARCHAR(2))',
+			$this->query->castAs('CHAR', 'foo', 2)
+		);
+	}
+
+	/**
+	 * @testdox  Test castAs behaviour with INT
+	 */
+	public function testCastAsWithIntegerType()
+	{
+		$this->assertSame(
+			'CAST(123 AS INT)',
+			$this->query->castAs('INT', '123')
+		);
+	}
+
+	/**
 	 * Data provider for character length test cases
 	 *
 	 * @return  \Generator

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -114,3 +114,9 @@ Instead of `$query->from($subquery, 'alias')` use `$query->from($subquery->alias
 Several methods which defined a query type (i.e. INSERT, SELECT, UPDATE) contained doc blocks indicating the query type should not be changed, but
 this was not enforced in the code. As of 2.0, an exception will be thrown if trying to change a query type. If intending to change the query type,
 either call `DatabaseQuery::clear()` (optionally only clearing the type clause) or a new query object should be created instead.
+
+#### `castAsChar` deprecated. Replaced with `castAs`
+
+`castAsChar($value)` has been deprecated in favour using of the more generic `castAs('CHAR', $value)` method. This
+method has support for supplying the length of a string and also accepting other types of casts such as integers.
+The intent is to add more cast types in the subsequent versions.

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -9,6 +9,7 @@
 namespace Joomla\Database;
 
 use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
+use Joomla\Database\Exception\UnknownTypeException;
 
 /**
  * Joomla Framework Query Building Class.
@@ -561,17 +562,52 @@ abstract class DatabaseQuery implements QueryInterface
 	 * Ensure that the value is properly quoted before passing to the method.
 	 *
 	 * Usage:
+	 * $query->select($query->castAs('CHAR', 'a'));
+	 *
+	 * @param   string  $type    The type of string to cast as.
+	 * @param   string  $value   The value to cast as a char.
+	 * @param   string  $length  Optionally specify the length of the field (if the type supports it otherwise
+	 *                           ignored).
+	 *
+	 * @return  string  SQL statement to cast the value as a char type.
+	 *
+	 * @since   1.0
+	 */
+	public function castAs(string $type, string $value, ?string $length = null)
+	{
+		switch (strtoupper($type))
+		{
+			case 'CHAR':
+				return $value;
+
+			default:
+				throw new UnknownTypeException(
+					sprintf(
+						'Type %s was not recognised by the database driver as valid for casting',
+						$type
+					)
+				);
+		}
+	}
+
+	/**
+	 * Casts a value to a char.
+	 *
+	 * Ensure that the value is properly quoted before passing to the method.
+	 *
+	 * Usage:
 	 * $query->select($query->castAsChar('a'));
 	 *
 	 * @param   string  $value  The value to cast as a char.
 	 *
-	 * @return  string  Returns the cast value.
+	 * @return  string  SQL statement to cast the value as a char type.
 	 *
-	 * @since   1.0
+	 * @since       1.0
+	 * @deprecated  3.0  Use $query->castAs('CHAR', $value)
 	 */
 	public function castAsChar($value)
 	{
-		return $value;
+		return $this->castAs('CHAR', $value);
 	}
 
 	/**

--- a/src/Exception/UnknownTypeException.php
+++ b/src/Exception/UnknownTypeException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Exception;
+
+/**
+ * Class representing an unknown type for a given database driver.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UnknownTypeException extends \InvalidArgumentException
+{
+}

--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -224,4 +224,41 @@ trait MysqlQueryBuilder
 
 		return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");
 	}
+
+	/**
+	 * Casts a value to a char.
+	 *
+	 * Ensure that the value is properly quoted before passing to the method.
+	 *
+	 * Usage:
+	 * $query->select($query->castAs('CHAR', 'a'));
+	 *
+	 * @param   string  $type    The type of string to cast as.
+	 * @param   string  $value   The value to cast as a char.
+	 * @param   string  $length  The value to cast as a char.
+	 *
+	 * @return  string  SQL statement to cast the value as a char type.
+	 *
+	 * @since   1.0
+	 */
+	public function castAs(string $type, string $value, ?string $length = null)
+	{
+		switch (strtoupper($type))
+		{
+			case 'CHAR':
+				if (!$length)
+				{
+					return $value;
+				}
+				else
+				{
+					return 'CAST(' . $value . ' AS CHAR(' . $length . '))';
+				}
+
+			case 'INT':
+				return '(' . $value . ' + 0)';
+		}
+
+		return parent::castAs($type, $value, $length);
+	}
 }

--- a/src/Query/PostgresqlQueryBuilder.php
+++ b/src/Query/PostgresqlQueryBuilder.php
@@ -308,23 +308,42 @@ trait PostgresqlQueryBuilder
 		return $this;
 	}
 
+
 	/**
 	 * Casts a value to a char.
 	 *
 	 * Ensure that the value is properly quoted before passing to the method.
 	 *
 	 * Usage:
-	 * $query->select($query->castAsChar('a'));
+	 * $query->select($query->castAs('CHAR', 'a'));
 	 *
-	 * @param   string  $value  The value to cast as a char.
+	 * @param   string  $type    The type of string to cast as.
+	 * @param   string  $value   The value to cast as a char.
+	 * @param   string  $length  The value to cast as a char.
 	 *
-	 * @return  string  Returns the cast value.
+	 * @return  string  SQL statement to cast the value as a char type.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.0
 	 */
-	public function castAsChar($value)
+	public function castAs(string $type, string $value, ?string $length = null)
 	{
-		return $value . '::text';
+		switch (strtoupper($type))
+		{
+			case 'CHAR':
+				if (!$length)
+				{
+					return $value . '::text';
+				}
+				else
+				{
+					return 'CAST(' . $value . ' AS CHAR(' . $length . '))';
+				}
+
+			case 'INT':
+				return 'CAST(' . $value . ' AS INTEGER)';
+		}
+
+		return parent::castAs($type, $value, $length);
 	}
 
 	/**

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -11,6 +11,7 @@ namespace Joomla\Database;
 use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
+use Joomla\Database\Exception\UnknownTypeException;
 
 /**
  * Joomla Framework Query Building Interface.
@@ -45,20 +46,24 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	public function call($columns);
 
 	/**
-	 * Casts a value to a char.
+	 * Casts a value to a specified type.
 	 *
 	 * Ensure that the value is properly quoted before passing to the method.
 	 *
 	 * Usage:
-	 * $query->select($query->castAsChar('a'));
+	 * $query->select($query->castAs('CHAR', 'a'));
 	 *
-	 * @param   string  $value  The value to cast as a char.
+	 * @param   string  $type    The type of string to cast as.
+	 * @param   string  $value   The value to cast as a char.
+	 * @param   string  $length  Optionally specify the length of the field (if the type supports it otherwise
+	 *                           ignored).
 	 *
 	 * @return  string  SQL statement to cast the value as a char type.
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  UnknownTypeException  When unsupported cast for a database driver
 	 */
-	public function castAsChar($value);
+	public function castAs(string $type, string $value, ?string $length = null);
 
 	/**
 	 * Gets the number of characters in a string.

--- a/src/Sqlite/SqliteQuery.php
+++ b/src/Sqlite/SqliteQuery.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Database\Sqlite;
 
+use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Pdo\PdoQuery;
 use Joomla\Database\Query\QueryElement;
 

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -260,15 +260,34 @@ class SqlsrvQuery extends DatabaseQuery
 	 *
 	 * Ensure that the value is properly quoted before passing to the method.
 	 *
-	 * @param   string  $value  The value to cast as a char.
+	 * Usage:
+	 * $query->select($query->castAs('CHAR', 'a'));
 	 *
-	 * @return  string  Returns the cast value.
+	 * @param   string  $type    The type of string to cast as.
+	 * @param   string  $value   The value to cast as a char.
+	 * @param   string  $length  The value to cast as a char.
+	 *
+	 * @return  string  SQL statement to cast the value as a char type.
 	 *
 	 * @since   1.0
 	 */
-	public function castAsChar($value)
+	public function castAs(string $type, string $value, ?string $length = null)
 	{
-		return 'CAST(' . $value . ' as NVARCHAR(10))';
+		switch (strtoupper($type))
+		{
+			case 'CHAR':
+				if (!$length)
+				{
+					$length = '10';
+				}
+
+				return 'CAST(' . $value . ' as NVARCHAR(' . $length . '))';
+
+			case 'INT':
+				return 'CAST(' . $value . ' AS INT)';
+		}
+
+		return parent::castAs($type, $value, $length);
 	}
 
 	/**


### PR DESCRIPTION
This method replaces `castAsChar` which had fallen behind the CMS in terms of support anyhow. This uses the concept proposed by @alikon in https://github.com/joomla/joomla-cms/pull/18961#issuecomment-406776272

Includes tests & docs

Somewhat related is https://github.com/joomla-framework/database/issues/157 over which matches some of the castAsChar stuff to gain complete sync with the CMS on the `castAsChar` method