### PR TITLE
Fixing default values from getTableColumns

### DIFF
--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -334,6 +334,7 @@ class PgsqlDriverTest extends PgsqlCase
 			'id' => 'integer',
 			'title' => 'character varying',
 			'start_date' => 'timestamp without time zone',
+			'end_date' => 'timestamp without time zone',
 			'description' => 'text',
 			'data' => 'bytea',
 		);
@@ -371,6 +372,16 @@ class PgsqlDriverTest extends PgsqlCase
 		$start_date->Default = null;
 		$start_date->comments = '';
 
+		$end_date = new \stdClass;
+		$end_date->column_name = 'end_date';
+		$end_date->Field = 'end_date';
+		$end_date->type = 'timestamp without time zone';
+		$end_date->Type = 'timestamp without time zone';
+		$end_date->null = 'NO';
+		$end_date->Null = 'NO';
+		$end_date->Default = '1970-01-01 00:00:00';
+		$end_date->comments = '';
+
 		$description = new \stdClass;
 		$description->column_name = 'description';
 		$description->Field = 'description';
@@ -398,6 +409,7 @@ class PgsqlDriverTest extends PgsqlCase
 					'id' => $id,
 					'title' => $title,
 					'start_date' => $start_date,
+					'end_date' => $end_date,
 					'description' => $description,
 					'data' => $data,
 				)
@@ -702,6 +714,7 @@ class PgsqlDriverTest extends PgsqlCase
 		$objCompare->id = 3;
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->end_date = '1970-01-01 00:00:00';
 		$objCompare->description = 'three';
 		$objCompare->data = null;
 
@@ -730,6 +743,7 @@ class PgsqlDriverTest extends PgsqlCase
 		$objCompare->id = 1;
 		$objCompare->title = 'Testing';
 		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->end_date = '1970-01-01 00:00:00';
 		$objCompare->description = 'one';
 		$objCompare->data = null;
 
@@ -739,6 +753,7 @@ class PgsqlDriverTest extends PgsqlCase
 		$objCompare->id = 2;
 		$objCompare->title = 'Testing2';
 		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->end_date = '1970-01-01 00:00:00';
 		$objCompare->description = 'one';
 		$objCompare->data = null;
 
@@ -748,6 +763,7 @@ class PgsqlDriverTest extends PgsqlCase
 		$objCompare->id = 3;
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->end_date = '1970-01-01 00:00:00';
 		$objCompare->description = 'three';
 		$objCompare->data = null;
 
@@ -757,6 +773,7 @@ class PgsqlDriverTest extends PgsqlCase
 		$objCompare->id = 4;
 		$objCompare->title = 'Testing4';
 		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->end_date = '1970-01-01 00:00:00';
 		$objCompare->description = 'four';
 		$objCompare->data = null;
 
@@ -801,7 +818,7 @@ class PgsqlDriverTest extends PgsqlCase
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three', null);
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', '1970-01-01 00:00:00', 'three', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -823,8 +840,8 @@ class PgsqlDriverTest extends PgsqlCase
 		$result = self::$driver->loadRowList();
 
 		$expected = array(
-			array(1, 'Testing', '1980-04-18 00:00:00', 'one', null),
-			array(2, 'Testing2', '1980-04-18 00:00:00', 'one', null)
+			array(1, 'Testing', '1980-04-18 00:00:00', '1970-01-01 00:00:00', 'one', null),
+			array(2, 'Testing2', '1980-04-18 00:00:00', '1970-01-01 00:00:00', 'one', null)
 		);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
@@ -1078,7 +1095,7 @@ class PgsqlDriverTest extends PgsqlCase
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array(6, 'testTitle', '1970-01-01 00:00:00', 'testDescription', null);
+		$expected = array(6, 'testTitle', '1970-01-01 00:00:00', '1970-01-01 00:00:00', 'testDescription', null);
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}

--- a/Tests/Stubs/postgresql.sql
+++ b/Tests/Stubs/postgresql.sql
@@ -558,6 +558,7 @@ CREATE TABLE "dbtest" (
   "id" serial NOT NULL,
   "title" character varying(50) NOT NULL,
   "start_date" timestamp without time zone NOT NULL,
+  "end_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "description" text NOT NULL,
   "data" bytea,
   PRIMARY KEY ("id")

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -566,6 +566,7 @@ class PgsqlDriver extends PdoDriver
 
 				break;
 
+			case 'timestamp without time zone':
 			case 'date':
 				if (empty($field_value))
 				{

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -208,6 +208,18 @@ class PgsqlDriver extends PdoDriver
 		{
 			foreach ($fields as $field)
 			{
+				// Change Postgresql's NULL::* type with PHP's null one
+				if (preg_match('/^NULL::*/', $field->Default))
+				{
+					$field->Default = null;
+				}
+
+				// Normalise default values like datetime
+				if (preg_match('/^\'(.*)\'::.*/', $field->Default, $matches))
+				{
+					$field->Default = $matches[1];
+				}
+
 				// Do some dirty translation to MySQL output.
 				// @todo: Come up with and implement a standard across databases.
 				$result[$field->column_name] = (object) [
@@ -222,15 +234,6 @@ class PgsqlDriver extends PdoDriver
 					// @todo: Improve query above to return primary key info as well
 					// 'Key' => ($field->PK == '1' ? 'PRI' : '')
 				];
-			}
-		}
-
-		// Change Postgresql's NULL::* type with PHP's null one
-		foreach ($fields as $field)
-		{
-			if (preg_match('/^NULL::*/', $field->Default))
-			{
-				$field->Default = null;
 			}
 		}
 


### PR DESCRIPTION
This PR stems from an error thrown by the tests in this PR: https://github.com/joomla/joomla-cms/pull/25761

The getTableColumns() method for Postgres returns some funky data for at least the datetime column type. The default for the given column is '1970-01-01 00:00:00' (as wrong as that is as a null value...), but the default value given from getTableColumns (and subsequently used by JTable) is "'1970-01-01 00:00:00'::timestamp without time zone". This tries to fix that. I also think that the null-code around line 228 has to be moved up like I did, otherwise it wont do anything... With this code, the PR mentioned above, passes.