### PR TITLE
Fix unit tests

### DIFF
--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -564,6 +564,7 @@ abstract class PdoDriver extends DatabaseDriver
 	 * @return  boolean  True if connected to the database engine.
 	 *
 	 * @since   1.0
+	 * @throws  \LogicException
 	 */
 	public function connected()
 	{


### PR DESCRIPTION
In some of our unit tests on postgres we're die'ing (which is showing as a test pass). So swap this for a `\LogicException` in the `connected` method. Finally in `execute` add a new extra try/except to catch this exception and throw the documented `\Joomla\Database\Exception\ExecutionFailureException`