### PR TITLE
Removing double LIMIT for special queries

### DIFF
--- a/src/Pgsql/PgsqlQuery.php
+++ b/src/Pgsql/PgsqlQuery.php
@@ -110,6 +110,8 @@ class PgsqlQuery extends PdoQuery
 					$query .= (string) $this->noWait;
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			case 'update':
@@ -150,6 +152,8 @@ class PgsqlQuery extends PdoQuery
 					$query .= (string) $this->where;
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			case 'insert':
@@ -177,13 +181,13 @@ class PgsqlQuery extends PdoQuery
 					}
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			default:
 				$query = parent::__toString();
 		}
-
-		$query = $this->processLimit($query, $this->limit, $this->offset);
 
 		if ($this->type === 'select' && $this->alias !== null)
 		{

--- a/src/Query/PostgresqlQueryBuilder.php
+++ b/src/Query/PostgresqlQueryBuilder.php
@@ -126,6 +126,8 @@ trait PostgresqlQueryBuilder
 					$query .= (string) $this->noWait;
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			case 'update':
@@ -168,6 +170,8 @@ trait PostgresqlQueryBuilder
 					$query .= (string) $this->where;
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			case 'insert':
@@ -195,6 +199,8 @@ trait PostgresqlQueryBuilder
 					}
 				}
 
+				$query = $this->processLimit($query, $this->limit, $this->offset);
+
 				break;
 
 			default:
@@ -203,7 +209,7 @@ trait PostgresqlQueryBuilder
 				break;
 		}
 
-		return $this->processLimit($query, $this->limit, $this->offset);
+		return $query;
 	}
 
 	/**


### PR DESCRIPTION
At the point when this PR was created, our unittests for Postgres were failing silently in the testQuerySetWithUnionAll() test. This was due to a broken query created by the query builder.

The test uses $query->querySet(), which set the type of the query to 'querySet'. This in return resulted in an issue in the __toString() method. Based on the query type, a certain path in the switch-statement is used and 'querySet' is falling through to the default case. The default case is calling the parent builder and the parent builder processes the LIMIT at the end. Unfortunately the query builder also did the LIMIT processing at the end unconditionally. This PR fixes that. 

After this, the tests should properly pass again. While this fixes the initial error, this still does not fix the broken error handling that resulted in the tests failing silently.