### PR TITLE
Fix typo "getAlterTableql" in DatabaseImporter.php

### DIFF
--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -261,7 +261,7 @@ abstract class DatabaseImporter
 			if (\in_array($tableName, $tables, true))
 			{
 				// The table already exists. Now check if there is any difference.
-				if ($queries = $this->getAlterTableql($xml->database->table_structure))
+				if ($queries = $this->getAlterTableSql($xml->database->table_structure))
 				{
 					// Run the queries to upgrade the data structure.
 					foreach ($queries as $query)


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/pull/22660#issuecomment-522591926](https://github.com/joomla/joomla-cms/pull/22660#issuecomment-522591926
)
### Summary of Changes

See title above.

### Testing Instructions

Code review and check with grep (Linux) or findstr (Windows) if that typo is not used anywhere else.

### Documentation Changes Required

None.

### Additional information

This change nedes to be merged up to 2.0-dev, see [https://github.com/joomla-framework/database/blob/2.0-dev/src/DatabaseImporter.php#L301](https://github.com/joomla-framework/database/blob/2.0-dev/src/DatabaseImporter.php#L301).

In CMS staging branch this has been fixed locally.