### PR TITLE
Use $table as argument for getAlterTableSql call

### DIFF
--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -261,7 +261,7 @@ abstract class DatabaseImporter
 			if (\in_array($tableName, $tables, true))
 			{
 				// The table already exists. Now check if there is any difference.
-				if ($queries = $this->getAlterTableSql($xml->database->table_structure))
+				if ($queries = $this->getAlterTableSql($table))
 				{
 					// Run the queries to upgrade the data structure.
 					foreach ($queries as $query)


### PR DESCRIPTION
Pull Request for Issue [https://github.com/joomla/joomla-cms/issues/22620](https://github.com/joomla/joomla-cms/issues/22620).

Back port of PR [https://github.com/joomla/joomla-cms/pull/22660](https://github.com/joomla/joomla-cms/pull/22660).

### Summary of Changes

In function `mergeStructure` of the importer, use `$table` and not `$xml->database->table_structure` as arugment for call to function `getAlterTableSql` for importing not only the 1st table in case of multiple tables.

### Testing Instructions

Either code review, or create some code which calls the exporter to export a few tables to XML, and some other code to call the importer to importthat (for testing possibly modified) XML, and execute that code and check if all works, and all tables are imported.

### Documentation Changes Required

No.

### Additional Information

At a first view it seems there is no test yet for doing complete export and import to/from XML with multiple tables. I will investigate that further.