### PR TITLE
Removing curly braces for array indexing

### DIFF
--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -248,7 +248,7 @@ class MysqliStatement implements StatementInterface
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} === '\\')
+				while ($l >= 0 && $sql[$l] === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -714,7 +714,7 @@ class SqlsrvDriver extends DatabaseDriver
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} === '\\')
+				while ($l >= 0 && $sql[$l] === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -244,7 +244,7 @@ class SqlsrvStatement implements StatementInterface
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} === '\\')
+				while ($l >= 0 && $sql[$l] === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;


### PR DESCRIPTION
This removes the curly braces to access indexes, as those are disallowed in PHP 7.4+.
