### PR TITLE
Using curly braces to access an array is removed in PHP 7.4

### DIFF
--- a/src/Oracle/OracleDriver.php
+++ b/src/Oracle/OracleDriver.php
@@ -602,7 +602,7 @@ class OracleDriver extends PdoDriver
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} === '\\')
+				while ($l >= 0 && $sql[$l] === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -783,7 +783,7 @@ class SqlsrvDriver extends DatabaseDriver
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} === '\\')
+				while ($l >= 0 && $sql[$l] === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;


### PR DESCRIPTION
See #186 
