### PR TITLE
Allow the use of UNIX socket with unix: URI

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -17,6 +17,7 @@ use Joomla\Database\Exception\PrepareStatementFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\StatementInterface;
 use Joomla\Database\UTF8MB4SupportInterface;
+
 /**
  * MySQLi Database Driver
  *

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -7,7 +7,6 @@
  */
 
 namespace Joomla\Database\Mysqli;
-
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseEvents;
 use Joomla\Database\Event\ConnectionEvent;

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -7,6 +7,7 @@
  */
 
 namespace Joomla\Database\Mysqli;
+
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseEvents;
 use Joomla\Database\Event\ConnectionEvent;

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -17,7 +17,6 @@ use Joomla\Database\Exception\PrepareStatementFailureException;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\StatementInterface;
 use Joomla\Database\UTF8MB4SupportInterface;
-
 /**
  * MySQLi Database Driver
  *

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -168,7 +168,14 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		 */
 		$port = isset($this->options['port']) ? $this->options['port'] : 3306;
 
-		if (preg_match(
+		if (preg_match('/^unix:(?P<socket>[^:]+)$/', $this->options['host'], $matches))
+		{
+			// UNIX socket URI, e.g. 'unix:/path/to/unix/socket.sock'
+			$this->options['host']   = null;
+			$this->options['socket'] = $matches['socket'];
+			$this->options['port']   = null;
+		}
+		elseif (preg_match(
 			'/^(?P<host>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(:(?P<port>.+))?$/',
 			$this->options['host'],
 			$matches

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -230,7 +230,13 @@ abstract class PdoDriver extends DatabaseDriver
 				}
 
 				$replace = ['#HOST#', '#PORT#', '#SOCKET#', '#DBNAME#', '#CHARSET#'];
-				$with    = [$this->options['host'], $this->options['port'], $this->options['socket'], $this->options['database'], $this->options['charset']];
+				$with    = [
+					$this->options['host'],
+					$this->options['port'],
+					$this->options['socket'],
+					$this->options['database'],
+					$this->options['charset']
+				];
 
 				break;
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -79,6 +79,7 @@ abstract class PdoDriver extends DatabaseDriver
 		$options['password']      = $options['password'] ?? '';
 		$options['driverOptions'] = $options['driverOptions'] ?? [];
 		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
+		$options['socket']        = \strpos($options['host'], 'unix:') !== false ? \str_replace('unix:', '', $options['host']) : null;
 
 		if ($options['ssl'] !== [])
 		{
@@ -219,10 +220,17 @@ abstract class PdoDriver extends DatabaseDriver
 			case 'mysql':
 				$this->options['port'] = $this->options['port'] ?? 3306;
 
-				$format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#;charset=#CHARSET#';
+				if ($this->options['socket'] !== null)
+				{
+					$format = 'mysql:unix_socket=#SOCKET#;dbname=#DBNAME#;charset=#CHARSET#';
+				}
+				else
+				{
+					$format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#;charset=#CHARSET#';
+				}
 
-				$replace = ['#HOST#', '#PORT#', '#DBNAME#', '#CHARSET#'];
-				$with    = [$this->options['host'], $this->options['port'], $this->options['database'], $this->options['charset']];
+				$replace = ['#HOST#', '#PORT#', '#SOCKET#', '#DBNAME#', '#CHARSET#'];
+				$with    = [$this->options['host'], $this->options['port'], $this->options['socket'], $this->options['database'], $this->options['charset']];
 
 				break;
 
@@ -260,10 +268,17 @@ abstract class PdoDriver extends DatabaseDriver
 			case 'pgsql':
 				$this->options['port'] = $this->options['port'] ?? 5432;
 
-				$format = 'pgsql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
+				if ($this->options['socket'] !== null)
+				{
+					$format = 'pgsql:host=#SOCKET#;dbname=#DBNAME#';
+				}
+				else
+				{
+					$format = 'pgsql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
+				}
 
-				$replace = ['#HOST#', '#PORT#', '#DBNAME#'];
-				$with    = [$this->options['host'], $this->options['port'], $this->options['database']];
+				$replace = ['#HOST#', '#PORT#', '#SOCKET#', '#DBNAME#'];
+				$with    = [$this->options['host'], $this->options['port'], $this->options['socket'], $this->options['database']];
 
 				// For data in transit TLS encryption.
 				if ($this->options['ssl'] !== [] && $this->options['ssl']['enable'] === true)


### PR DESCRIPTION
### Summary of Changes
- Allow to use unix socket URI (ex: `unix:/path/to/unix/socket.sock`) in PDO MySql/PDO PostgreSQL and MySqli drivers
- Allows to use unix sockets in PDO MySql
- Just this has added in this PR, the rest should work as before

### Testing Instructions

- Code review
- Use joomla latest 4.0 version
- Apply this patch to the framework database package
- Try to connect to the database with PDO Mysql/PDO PostgreSQL and MySqli DB connectors using a UNIX socket URI in the database "Host" field in global config

Examples of UNIX socket URI:
`unix:/var/run/mysqld/mysqld.sock`
`unix:/var/run/mariadb/mariadb.sock`
`unix:/var/run/postgresql/`

### Additional information

*MySQL/MariaDB*
- At least in CentOS, MySql socket path is in `/etc/my.cnf` (or `/etc/my.cnf.d/*.conf`)
- For Mysql i also added the same path in php ini config
```ini
mysqli.default_socket    = /var/run/mariadb/mariadb.sock
pdo_mysql.default_socket = /var/run/mariadb/mariadb.sock
```
*PostgreSQL*
- At least in CentOS, PostgreSQL socket path is in `/var/lib/pgsql/data/postgresql.conf` (or `/var/lib/pgsql/<version>/data/postgresql.conf`)
- In postgresql you will probably need to give permission for the user to use UNIX sockets. At least in CentOS is in `/var/lib/pgsql/data/pg_hba.conf` (or `/var/lib/pgsql/<version>/data/pg_hba.conf`)
Replace `local   all             all                                     peer` with `local   all             all                                     md5` (replace `peer` by `md5`) and restart postgresql
