### PR TITLE
[2.0] Enforce the query type instead of only documenting a suggestion

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -8,6 +8,7 @@ namespace Joomla\Database\Tests;
 
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
+use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
 use Joomla\Database\ParameterType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -61,6 +62,18 @@ class DatabaseQueryTest extends TestCase
 			['foo', 'bar'],
 			$this->query->call->getElements()
 		);
+	}
+
+	/**
+	 * @testdox  The call method raises an exception if changing the query type
+	 */
+	public function testCallChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->select('foo')
+			->from('bar')
+			->call('foo');
 	}
 
 	/**
@@ -211,6 +224,18 @@ class DatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  The delete method raises an exception if changing the query type
+	 */
+	public function testDeleteChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->select('foo')
+			->from('bar')
+			->delete('foo');
+	}
+
+	/**
 	 * @testdox  The exec method correctly creates and manages a EXEC query element
 	 */
 	public function testExec()
@@ -222,6 +247,18 @@ class DatabaseQueryTest extends TestCase
 			['foo', 'bar'],
 			$this->query->exec->getElements()
 		);
+	}
+
+	/**
+	 * @testdox  The exec method raises an exception if changing the query type
+	 */
+	public function testExecChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->select('foo')
+			->from('bar')
+			->exec('foo');
 	}
 
 	/**
@@ -364,6 +401,18 @@ class DatabaseQueryTest extends TestCase
 		$this->assertSame($this->query, $this->query->insert('foo'), 'The query builder supports method chaining');
 
 		$this->assertNotNull($this->query->insert);
+	}
+
+	/**
+	 * @testdox  The insert method raises an exception if changing the query type
+	 */
+	public function testInsertChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->select('foo')
+			->from('bar')
+			->insert('foo');
 	}
 
 	/**
@@ -677,6 +726,17 @@ class DatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * @testdox  The select method raises an exception if changing the query type
+	 */
+	public function testSelectChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->delete('foo')
+			->select('foo');
+	}
+
+	/**
 	 * @testdox  The set method correctly creates and manages a SET query element
 	 */
 	public function testSet()
@@ -731,6 +791,18 @@ class DatabaseQueryTest extends TestCase
 		$this->assertSame($this->query, $this->query->update('foo'), 'The query builder supports method chaining');
 
 		$this->assertNotNull($this->query->update);
+	}
+
+	/**
+	 * @testdox  The update method raises an exception if changing the query type
+	 */
+	public function testUpdateChangeQueryType()
+	{
+		$this->expectException(QueryTypeAlreadyDefinedException::class);
+
+		$this->query->select('foo')
+			->from('bar')
+			->update('foo');
 	}
 
 	/**

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -108,3 +108,9 @@ The first argument, `$table`, stops accepting the array. Only `DatabaseQuery` ob
 - Argument `$subQueryAlias` has been removed.
 
 Instead of `$query->from($subquery, 'alias')` use `$query->from($subquery->alias('alias'))`.
+
+#### Query type immutability enforced
+
+Several methods which defined a query type (i.e. INSERT, SELECT, UPDATE) contained doc blocks indicating the query type should not be changed, but
+this was not enforced in the code. As of 2.0, an exception will be thrown if trying to change a query type. If intending to change the query type,
+either call `DatabaseQuery::clear()` (optionally only clearing the type clause) or a new query object should be created instead.

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Database;
 
+use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
+
 /**
  * Joomla Framework Query Building Class.
  *
@@ -87,7 +89,7 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * The query type.
 	 *
-	 * @var    string
+	 * @var    string|null
 	 * @since  1.0
 	 */
 	protected $type = '';
@@ -515,9 +517,6 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * Add a single column, or array of columns to the CALL clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 * The call method can, however, be called multiple times in the same query.
-	 *
 	 * Usage:
 	 * $query->call('a.*')->call('b.id');
 	 * $query->call(array('a.*', 'b.id'));
@@ -527,9 +526,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function call($columns)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'call')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "call" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type = 'call';
 
 		if ($this->call === null)
@@ -879,8 +890,6 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * Add a table name to the DELETE clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->delete('#__a')->where('id = 1');
 	 *
@@ -889,9 +898,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function delete($table = null)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'delete')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "delete" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type   = 'delete';
 		$this->delete = new Query\QueryElement('DELETE', null);
 
@@ -948,9 +969,6 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * Add a single column, or array of columns to the EXEC clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 * The exec method can, however, be called multiple times in the same query.
-	 *
 	 * Usage:
 	 * $query->exec('a.*')->exec('b.id');
 	 * $query->exec(array('a.*', 'b.id'));
@@ -960,9 +978,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function exec($columns)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'exec')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "exec" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type = 'exec';
 
 		if ($this->exec === null)
@@ -1208,8 +1238,6 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * Add a table name to the INSERT clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->insert('#__a')->set('id = 1');
 	 * $query->insert('#__a')->columns('id, title')->values('1,2')->values('3,4');
@@ -1221,9 +1249,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function insert($table, $incrementField = false)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'insert')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "insert" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type               = 'insert';
 		$this->insert             = new Query\QueryElement('INSERT INTO', $table);
 		$this->autoIncrementField = $incrementField;
@@ -1586,9 +1626,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function select($columns)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'select')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "select" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type = 'select';
 
 		if ($this->select === null)
@@ -1678,8 +1730,6 @@ abstract class DatabaseQuery implements QueryInterface
 	/**
 	 * Add a table name to the UPDATE clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->update('#__foo')->set(...);
 	 *
@@ -1688,9 +1738,21 @@ abstract class DatabaseQuery implements QueryInterface
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function update($table)
 	{
+		if ($this->type !== null && $this->type !== '' && $this->type !== 'update')
+		{
+			throw new QueryTypeAlreadyDefinedException(
+				\sprintf(
+					'Cannot set the query type to "update" as the query type is already set to "%s".'
+						. ' You should either call the `clear()` method to reset the type or create a new query object.',
+					$this->type
+				)
+			);
+		}
+
 		$this->type   = 'update';
 		$this->update = new Query\QueryElement('UPDATE', $table);
 

--- a/src/Exception/QueryTypeAlreadyDefinedException.php
+++ b/src/Exception/QueryTypeAlreadyDefinedException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Database Package
+ *
+ * @copyright  Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Exception;
+
+/**
+ * Exception class defining an exception when attempting to change a query type
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class QueryTypeAlreadyDefinedException extends \RuntimeException
+{
+}

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Database;
 
+use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
 
@@ -30,9 +31,6 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a single column, or array of columns to the CALL clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 * The call method can, however, be called multiple times in the same query.
-	 *
 	 * Usage:
 	 * $query->call('a.*')->call('b.id');
 	 * $query->call(array('a.*', 'b.id'));
@@ -42,6 +40,7 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function call($columns);
 
@@ -131,8 +130,6 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a table name to the DELETE clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->delete('#__a')->where('id = 1');
 	 *
@@ -141,14 +138,12 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function delete($table = null);
 
 	/**
 	 * Add a single column, or array of columns to the EXEC clause of the query.
-	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 * The exec method can, however, be called multiple times in the same query.
 	 *
 	 * Usage:
 	 * $query->exec('a.*')->exec('b.id');
@@ -159,6 +154,7 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function exec($columns);
 
@@ -339,8 +335,6 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a table name to the INSERT clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->insert('#__a')->set('id = 1');
 	 * $query->insert('#__a')->columns('id, title')->values('1,2')->values('3,4');
@@ -352,6 +346,7 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function insert($table, $incrementField = false);
 
@@ -463,9 +458,6 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a single column, or array of columns to the SELECT clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 * The select method can, however, be called multiple times in the same query.
-	 *
 	 * Usage:
 	 * $query->select('a.*')->select('b.id');
 	 * $query->select(array('a.*', 'b.id'));
@@ -475,6 +467,7 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function select($columns);
 
@@ -516,8 +509,6 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	/**
 	 * Add a table name to the UPDATE clause of the query.
 	 *
-	 * Note that you must not mix insert, update, delete and select method calls when building a query.
-	 *
 	 * Usage:
 	 * $query->update('#__foo')->set(...);
 	 *
@@ -526,6 +517,7 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
 	 * @return  $this
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  QueryTypeAlreadyDefinedException if the query type has already been defined
 	 */
 	public function update($table);
 


### PR DESCRIPTION
### Summary of Changes

Right now there are several doc blocks indicating that changing a query type should not be done (i.e. a `$query->select('foo')->delete('bar')` type chain, but this is only a suggestion and not enforced.  This PR proposes to change this from a suggestion to an enforced behavior by throwing an exception if trying to mutate the type.  Note this doesn't break if you clear a property that sets the type before calling a method that would reset the type (i.e. a `$query->select('foo')->clear('select')->delete('bar')` chain would still be valid).

On a side note, the type inconsistency of `DatabaseQuery::$type` is a pain in the backside...

### Testing Instructions

Code review, in downstream applications queries should be reviewed for potential type reset issues.

### Documentation Changes Required

Yep, already noted in doc blocks and upgrade guide.