### PR TITLE
Option to output the database query without pre tags

### DIFF
--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -731,13 +731,32 @@ abstract class DatabaseQuery
 	 * Usage:
 	 * echo $query->dump();
 	 *
+	 * To get only the query without <pre> tags:
+	 * echo $query->dump(false);
+	 *
+	 * @param.  boolean  $format  Set if the query should be surrounded by pre tags
+	 *
 	 * @return  string
 	 *
 	 * @since   1.0
 	 */
-	public function dump()
+	public function dump(bool $format = true)
 	{
-		return '<pre class="jdatabasequery">' . str_replace('#__', $this->db->getPrefix(), $this) . '</pre>';
+		$query = '';
+		
+		if ($format)
+		{
+			$query .= '<pre class="jdatabasequery">';
+		}
+		
+		$query .= str_replace('#__', $this->db->getPrefix(), $this);
+		
+		if ($format)
+		{
+			$query .= '</pre>';
+		}
+		
+		return $query;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
When you are developing and debugging with XDebug and want to get the query, you can do a `$query->dump()` but this includes the pre tags. You need to copy paste the query, remove the tags and then you can execute the query. With this change you can easily do `$query->dump(false)` to get the query without pre tags and just copy paste and execute.

### Testing Instructions
1. Apply patch
2. Add `$query->dump(false)` where you have a query
3. The output should not contain the pre tags.

### Documentation Changes Required
Document that you can pass false to get rid of the pre tags