### PR TITLE
Set the correct fetch mode for non-PDO drivers

### DIFF
--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -628,7 +628,9 @@ class MysqliStatement implements StatementInterface
 	{
 		$this->defaultObjectClass = $className;
 
-		return $this->fetch(FetchMode::STANDARD_OBJECT);
+		$fetchMode = $className === \stdClass::class ? FetchMode::STANDARD_OBJECT : FetchMode::CUSTOM_OBJECT;
+
+		return $this->fetch($fetchMode);
 	}
 
 	/**

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -507,7 +507,9 @@ class SqlsrvStatement implements StatementInterface
 	{
 		$this->defaultObjectClass = $className;
 
-		return $this->fetch(FetchMode::STANDARD_OBJECT);
+		$fetchMode = $className === \stdClass::class ? FetchMode::STANDARD_OBJECT : FetchMode::CUSTOM_OBJECT;
+
+		return $this->fetch($fetchMode);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #199

### Summary of Changes

We have a fetch mode for specifying a custom PHP class should be used instead of a plain `stdClass`, the `FetchMode::CUSTOM_OBJECT` (mapped to `PDO::FETCH_CLASS` for the PDO drivers).  Because of the way MySQLi is structured, it isn't actually possible to fully support custom class objects in the same way that the PHP extensions would handle business, and use of a custom class should trigger an Exception as a result.  However, the code isn't switching over to this fetch mode which means the Exception isn't being reached.  So, this PR adds a check to force the statement into the correct mode.