### PR TITLE
PdoStatement and StatementInterface changes

### DIFF
--- a/src/DatabaseFactory.php
+++ b/src/DatabaseFactory.php
@@ -129,7 +129,12 @@ class DatabaseFactory
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getIterator(string $name, StatementInterface $statement, ?string $column = null, string $class = '\\stdClass'): DatabaseIterator
+	public function getIterator(
+		string $name,
+		StatementInterface $statement,
+		?string $column = null,
+		string $class = \stdClass::class
+	): DatabaseIterator
 	{
 		// Derive the class name from the driver.
 		$iteratorClass = __NAMESPACE__ . '\\' . ucfirst($name) . '\\' . ucfirst($name) . 'Iterator';

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -377,7 +377,7 @@ interface DatabaseInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	public function loadObject($class = 'stdClass');
+	public function loadObject($class = \stdClass::class);
 
 	/**
 	 * Method to get an array of the result set rows from the database query where each row is an object.  The array
@@ -393,7 +393,7 @@ interface DatabaseInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	public function loadObjectList($key = '', $class = 'stdClass');
+	public function loadObjectList($key = '', $class = \stdClass::class);
 
 	/**
 	 * Method to get the first field of the first row of the result set from the database query.

--- a/src/DatabaseIterator.php
+++ b/src/DatabaseIterator.php
@@ -73,11 +73,26 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @since   1.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function __construct(StatementInterface $statement, $column = null, $class = '\\stdClass')
+	public function __construct(StatementInterface $statement, $column = null, $class = \stdClass::class)
 	{
 		if (!class_exists($class))
 		{
 			throw new \InvalidArgumentException(sprintf('new %s(*%s*, cursor)', \get_class($this), \gettype($class)));
+		}
+
+		if ($statement)
+		{
+			$fetchMode = $class === \stdClass::class ? FetchMode::STANDARD_OBJECT : FetchMode::CUSTOM_OBJECT;
+
+			// PDO doesn't allow extra arguments for \PDO::FETCH_CLASS, so only forward the class for the custom object mode
+			if ($fetchMode === FetchMode::STANDARD_OBJECT)
+			{
+				$statement->setFetchMode($fetchMode);
+			}
+			else
+			{
+				$statement->setFetchMode($fetchMode, $class);
+			}
 		}
 
 		$this->statement = $statement;
@@ -212,7 +227,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	{
 		if ($this->statement)
 		{
-			return $this->statement->fetchObject($this->class);
+			return $this->statement->fetch();
 		}
 
 		return false;

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -343,7 +343,6 @@ abstract class PdoDriver extends DatabaseDriver
 			throw new ConnectionFailureException('Could not connect to PDO: ' . $e->getMessage(), $e->getCode(), $e);
 		}
 
-		$this->setOption(\PDO::ATTR_STATEMENT_CLASS, [PdoStatement::class, []]);
 		$this->setOption(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 
 		$this->dispatchEvent(new ConnectionEvent(DatabaseEvents::POST_CONNECT, $this));
@@ -734,7 +733,7 @@ abstract class PdoDriver extends DatabaseDriver
 	{
 		try
 		{
-			return $this->connection->prepare($query, $this->options['driverOptions']);
+			return new PdoStatement($this->connection->prepare($query, $this->options['driverOptions']));
 		}
 		catch (\PDOException $exception)
 		{

--- a/src/Pdo/PdoStatement.php
+++ b/src/Pdo/PdoStatement.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Database\Pdo;
 
+use Joomla\Database\FetchMode;
+use Joomla\Database\FetchOrientation;
 use Joomla\Database\ParameterType;
 use Joomla\Database\StatementInterface;
 
@@ -16,15 +18,30 @@ use Joomla\Database\StatementInterface;
  *
  * @since  __DEPLOY_VERSION__
  */
-class PdoStatement extends \PDOStatement implements StatementInterface
+class PdoStatement implements StatementInterface
 {
+	/**
+	 * Mapping array for fetch modes.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private const FETCH_MODE_MAP = [
+		FetchMode::ASSOCIATIVE     => \PDO::FETCH_ASSOC,
+		FetchMode::NUMERIC         => \PDO::FETCH_NUM,
+		FetchMode::MIXED           => \PDO::FETCH_BOTH,
+		FetchMode::STANDARD_OBJECT => \PDO::FETCH_OBJ,
+		FetchMode::COLUMN          => \PDO::FETCH_COLUMN,
+		FetchMode::CUSTOM_OBJECT   => \PDO::FETCH_CLASS,
+	];
+
 	/**
 	 * Mapping array for parameter types.
 	 *
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $parameterTypeMapping = [
+	private const PARAMETER_TYPE_MAP = [
 		ParameterType::BOOLEAN      => \PDO::PARAM_BOOL,
 		ParameterType::INTEGER      => \PDO::PARAM_INT,
 		ParameterType::LARGE_OBJECT => \PDO::PARAM_LOB,
@@ -33,14 +50,23 @@ class PdoStatement extends \PDOStatement implements StatementInterface
 	];
 
 	/**
+	 * The decorated PDOStatement object.
+	 *
+	 * @var    \PDOStatement
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $pdoStatement;
+
+	/**
 	 * Statement constructor
 	 *
-	 * This class is not instantiated as part of the public API, the PDO internals handle this condition without issue.
+	 * @param   \PDOStatement  $pdoStatement  The decorated PDOStatement object.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function __construct()
+	public function __construct(\PDOStatement $pdoStatement)
 	{
+		$this->pdoStatement = $pdoStatement;
 	}
 
 	/**
@@ -50,7 +76,7 @@ class PdoStatement extends \PDOStatement implements StatementInterface
 	 *                                          name of the form `:name`. For a prepared statement using question mark placeholders, this will be
 	 *                                          the 1-indexed position of the parameter.
 	 * @param   mixed           $variable       Name of the PHP variable to bind to the SQL statement parameter.
-	 * @param   integer         $dataType       Constant corresponding to a SQL datatype, this should be the processed type from the QueryInterface.
+	 * @param   string          $dataType       Constant corresponding to a SQL datatype, this should be the processed type from the QueryInterface.
 	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
@@ -58,14 +84,163 @@ class PdoStatement extends \PDOStatement implements StatementInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function bindParam($parameter, &$variable, $dataType = ParameterType::STRING, $length = null, $driverOptions = null)
+	public function bindParam($parameter, &$variable, string $dataType = ParameterType::STRING, ?int $length = null, ?array $driverOptions = null)
 	{
-		// Validate parameter type
-		if (!isset($this->parameterTypeMapping[$dataType]))
+		$type            = $this->convertParameterType($dataType);
+		$extraParameters = array_slice(func_get_args(), 3);
+
+		if (count($extraParameters) !== 0)
 		{
-			throw new \InvalidArgumentException(sprintf('Unsupported parameter type `%s`', $dataType));
+			$extraParameters[0] = $extraParameters[0] ?? 0;
 		}
 
-		return parent::bindParam($parameter, $variable, $this->parameterTypeMapping[$dataType], $length, $driverOptions);
+		$this->pdoStatement->bindParam($parameter, $variable, $type, ...$extraParameters);
+
+		return true;
+	}
+
+	/**
+	 * Closes the cursor, enabling the statement to be executed again.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function closeCursor(): void
+	{
+		$this->pdoStatement->closeCursor();
+	}
+
+	/**
+	 * Fetches the SQLSTATE associated with the last operation on the statement handle.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function errorCode()
+	{
+		return $this->pdoStatement->errorCode();
+	}
+
+	/**
+	 * Fetches extended error information associated with the last operation on the statement handle.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function errorInfo()
+	{
+		return $this->pdoStatement->errorInfo();
+	}
+
+	/**
+	 * Executes a prepared statement
+	 *
+	 * @param   array|null  $parameters  An array of values with as many elements as there are bound parameters in the SQL statement being executed.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function execute(?array $parameters = null)
+	{
+		return $this->pdoStatement->execute($parameters);
+	}
+
+	/**
+	 * Fetches the next row from a result set
+	 *
+	 * @param   integer|null  $fetchStyle         Controls how the next row will be returned to the caller. This value must be one of the
+	 *                                            FetchMode constants, defaulting to value of FetchMode::MIXED.
+	 * @param   integer       $cursorOrientation  For a StatementInterface object representing a scrollable cursor, this value determines which row
+	 *                                            will be returned to the caller. This value must be one of the FetchOrientation constants,
+	 *                                            defaulting to FetchOrientation::NEXT.
+	 * @param   integer       $cursorOffset       For a StatementInterface object representing a scrollable cursor for which the cursorOrientation
+	 *                                            parameter is set to FetchOrientation::ABS, this value specifies the absolute number of the row in
+	 *                                            the result set that shall be fetched. For a StatementInterface object representing a scrollable
+	 *                                            cursor for which the cursorOrientation parameter is set to FetchOrientation::REL, this value
+	 *                                            specifies the row to fetch relative to the cursor position before `fetch()` was called.
+	 *
+	 * @return  mixed  The return value of this function on success depends on the fetch type. In all cases, boolean false is returned on failure.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function fetch(?int $fetchStyle = null, int $cursorOrientation = FetchOrientation::NEXT, int $cursorOffset = 0)
+	{
+		if ($fetchStyle === null)
+		{
+			return $this->pdoStatement->fetch();
+		}
+
+		return $this->pdoStatement->fetch($this->convertFetchMode($fetchStyle), $cursorOrientation, $cursorOffset);
+	}
+
+	/**
+	 * Returns the number of rows affected by the last SQL statement.
+	 *
+	 * @return  integer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function rowCount(): int
+	{
+		return $this->pdoStatement->rowCount();
+	}
+
+	/**
+	 * Sets the fetch mode to use while iterating this statement.
+	 *
+	 * @param   integer  $fetchMode  The fetch mode, must be one of the FetchMode constants.
+	 * @param   mixed    ...$args    Optional mode-specific arguments.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFetchMode(int $fetchMode, ...$args): void
+	{
+		$this->pdoStatement->setFetchMode($this->convertFetchMode($fetchMode), ...$args);
+	}
+
+	/**
+	 * Converts the database API's fetch mode to a PDO fetch mode
+	 *
+	 * @param   integer  $mode  Fetch mode to convert
+	 *
+	 * @return  integer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException if the fetch mode is unsupported
+	 */
+	private function convertFetchMode(int $mode): int
+	{
+		if (!isset(self::FETCH_MODE_MAP[$mode]))
+		{
+			throw new \InvalidArgumentException(sprintf('Unsupported fetch mode `%s`', $mode));
+		}
+
+		return self::FETCH_MODE_MAP[$mode];
+	}
+
+	/**
+	 * Converts the database API's parameter type to a PDO parameter type
+	 *
+	 * @param   string  $type  Parameter type to convert
+	 *
+	 * @return  integer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException if the parameter type is unsupported
+	 */
+	private function convertParameterType(string $type): int
+	{
+		if (!isset(self::PARAMETER_TYPE_MAP[$type]))
+		{
+			throw new \InvalidArgumentException(sprintf('Unsupported parameter type `%s`', $type));
+		}
+
+		return self::PARAMETER_TYPE_MAP[$type];
 	}
 }

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -295,7 +295,7 @@ class SqlsrvStatement implements StatementInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function bindParam($parameter, &$variable, $dataType = ParameterType::STRING, $length = null, $driverOptions = null)
+	public function bindParam($parameter, &$variable, string $dataType = ParameterType::STRING, ?int $length = null, ?array $driverOptions = null)
 	{
 		$this->bindedValues[$parameter] =& $variable;
 
@@ -334,15 +334,15 @@ class SqlsrvStatement implements StatementInterface
 	/**
 	 * Closes the cursor, enabling the statement to be executed again.
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function closeCursor()
+	public function closeCursor(): void
 	{
 		if (!$this->result || !\is_resource($this->statement))
 		{
-			return true;
+			return;
 		}
 
 		// Emulate freeing the result fetching and discarding rows, similarly to what PDO does in this case
@@ -352,8 +352,6 @@ class SqlsrvStatement implements StatementInterface
 		}
 
 		$this->result = false;
-
-		return true;
 	}
 
 	/**
@@ -390,13 +388,13 @@ class SqlsrvStatement implements StatementInterface
 	/**
 	 * Executes a prepared statement
 	 *
-	 * @param   array  $parameters  An array of values with as many elements as there are bound parameters in the SQL statement being executed.
+	 * @param   array|null  $parameters  An array of values with as many elements as there are bound parameters in the SQL statement being executed.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function execute($parameters = null)
+	public function execute(?array $parameters = null)
 	{
 		if (empty($this->bindedValues) && $parameters !== null)
 		{
@@ -429,22 +427,22 @@ class SqlsrvStatement implements StatementInterface
 	/**
 	 * Fetches the next row from a result set
 	 *
-	 * @param   integer $fetchStyle          Controls how the next row will be returned to the caller. This value must be one of the
-	 *                                       FetchMode constants, defaulting to value of FetchMode::MIXED.
-	 * @param   integer $cursorOrientation   For a StatementInterface object representing a scrollable cursor, this value determines which row will
-	 *                                       be returned to the caller. This value must be one of the FetchOrientation constants, defaulting to
-	 *                                       FetchOrientation::NEXT.
-	 * @param   integer $cursorOffset        For a StatementInterface object representing a scrollable cursor for which the cursorOrientation
-	 *                                       parameter is set to FetchOrientation::ABS, this value specifies the absolute number of the row in the
-	 *                                       result set that shall be fetched. For a StatementInterface object representing a scrollable cursor for
-	 *                                       which the cursorOrientation parameter is set to FetchOrientation::REL, this value specifies the row to
-	 *                                       fetch relative to the cursor position before StatementInterface::fetch() was called.
+	 * @param   integer|null  $fetchStyle         Controls how the next row will be returned to the caller. This value must be one of the
+	 *                                            FetchMode constants, defaulting to value of FetchMode::MIXED.
+	 * @param   integer       $cursorOrientation  For a StatementInterface object representing a scrollable cursor, this value determines which row
+	 *                                            will be returned to the caller. This value must be one of the FetchOrientation constants,
+	 *                                            defaulting to FetchOrientation::NEXT.
+	 * @param   integer       $cursorOffset       For a StatementInterface object representing a scrollable cursor for which the cursorOrientation
+	 *                                            parameter is set to FetchOrientation::ABS, this value specifies the absolute number of the row in
+	 *                                            the result set that shall be fetched. For a StatementInterface object representing a scrollable
+	 *                                            cursor for which the cursorOrientation parameter is set to FetchOrientation::REL, this value
+	 *                                            specifies the row to fetch relative to the cursor position before `fetch()` was called.
 	 *
 	 * @return  mixed  The return value of this function on success depends on the fetch type. In all cases, boolean false is returned on failure.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function fetch($fetchStyle = null, $cursorOrientation = FetchOrientation::NEXT, $cursorOffset = 0)
+	public function fetch(?int $fetchStyle = null, int $cursorOrientation = FetchOrientation::NEXT, int $cursorOffset = 0)
 	{
 		if (!$this->result)
 		{
@@ -491,23 +489,6 @@ class SqlsrvStatement implements StatementInterface
 		}
 
 		return $row[$columnIndex] ?? null;
-	}
-
-	/**
-	 * Fetches the next row and returns it as an object.
-	 *
-	 * @param   string  $className        Name of the created class.
-	 * @param   array   $constructorArgs  Elements of this array are passed to the constructor.
-	 *
-	 * @return  mixed  An instance of the required class with property names that correspond to the column names or boolean false on failure.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function fetchObject($className = null, $constructorArgs = null)
-	{
-		$this->defaultObjectClass = $className;
-
-		return $this->fetch(FetchMode::STANDARD_OBJECT);
 	}
 
 	/**
@@ -573,7 +554,7 @@ class SqlsrvStatement implements StatementInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function rowCount()
+	public function rowCount(): int
 	{
 		if (strncmp(strtoupper(ltrim($this->query)), 'SELECT', \strlen('SELECT')) === 0)
 		{
@@ -581,5 +562,25 @@ class SqlsrvStatement implements StatementInterface
 		}
 
 		return sqlsrv_rows_affected($this->statement);
+	}
+
+	/**
+	 * Sets the fetch mode to use while iterating this statement.
+	 *
+	 * @param   integer  $fetchMode  The fetch mode, must be one of the FetchMode constants.
+	 * @param   mixed    ...$args    Optional mode-specific arguments.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFetchMode(int $fetchMode, ...$args): void
+	{
+		$this->defaultFetchStyle = $fetchMode;
+
+		if (isset($args[0]))
+		{
+			$this->defaultObjectClass = $args[0];
+		}
 	}
 }

--- a/src/StatementInterface.php
+++ b/src/StatementInterface.php
@@ -24,7 +24,7 @@ interface StatementInterface
 	 *                                          name of the form `:name`. For a prepared statement using question mark placeholders, this will be
 	 *                                          the 1-indexed position of the parameter.
 	 * @param   mixed           $variable       Name of the PHP variable to bind to the SQL statement parameter.
-	 * @param   integer|string  $dataType       Constant corresponding to a SQL datatype, this should be the processed type from the QueryInterface.
+	 * @param   string          $dataType       Constant corresponding to a SQL datatype, this should be the processed type from the QueryInterface.
 	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
@@ -32,16 +32,16 @@ interface StatementInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function bindParam($parameter, &$variable, $dataType = \PDO::PARAM_STR, $length = null, $driverOptions = null);
+	public function bindParam($parameter, &$variable, string $dataType = ParameterType::STRING, ?int $length = null, ?array $driverOptions = null);
 
 	/**
 	 * Closes the cursor, enabling the statement to be executed again.
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function closeCursor();
+	public function closeCursor(): void;
 
 	/**
 	 * Fetches the SQLSTATE associated with the last operation on the statement handle.
@@ -64,45 +64,33 @@ interface StatementInterface
 	/**
 	 * Executes a prepared statement
 	 *
-	 * @param   array  $parameters  An array of values with as many elements as there are bound parameters in the SQL statement being executed.
+	 * @param   array|null  $parameters  An array of values with as many elements as there are bound parameters in the SQL statement being executed.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function execute($parameters = null);
+	public function execute(?array $parameters = null);
 
 	/**
 	 * Fetches the next row from a result set
 	 *
-	 * @param   integer  $fetchStyle         Controls how the next row will be returned to the caller. This value must be one of the
-	 *                                       FetchMode constants, defaulting to value of FetchMode::MIXED.
-	 * @param   integer  $cursorOrientation  For a StatementInterface object representing a scrollable cursor, this value determines which row will
-	 *                                       be returned to the caller. This value must be one of the FetchOrientation constants, defaulting to
-	 *                                       FetchOrientation::NEXT.
-	 * @param   integer  $cursorOffset       For a StatementInterface object representing a scrollable cursor for which the cursorOrientation
-	 *                                       parameter is set to FetchOrientation::ABS, this value specifies the absolute number of the row in the
-	 *                                       result set that shall be fetched. For a StatementInterface object representing a scrollable cursor for
-	 *                                       which the cursorOrientation parameter is set to FetchOrientation::REL, this value specifies the row to
-	 *                                       fetch relative to the cursor position before StatementInterface::fetch() was called.
+	 * @param   integer|null  $fetchStyle         Controls how the next row will be returned to the caller. This value must be one of the
+	 *                                            FetchMode constants, defaulting to value of FetchMode::MIXED.
+	 * @param   integer       $cursorOrientation  For a StatementInterface object representing a scrollable cursor, this value determines which row
+	 *                                            will be returned to the caller. This value must be one of the FetchOrientation constants,
+	 *                                            defaulting to FetchOrientation::NEXT.
+	 * @param   integer       $cursorOffset       For a StatementInterface object representing a scrollable cursor for which the cursorOrientation
+	 *                                            parameter is set to FetchOrientation::ABS, this value specifies the absolute number of the row in
+	 *                                            the result set that shall be fetched. For a StatementInterface object representing a scrollable
+	 *                                            cursor for which the cursorOrientation parameter is set to FetchOrientation::REL, this value
+	 *                                            specifies the row to fetch relative to the cursor position before `fetch()` was called.
 	 *
 	 * @return  mixed  The return value of this function on success depends on the fetch type. In all cases, boolean false is returned on failure.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function fetch($fetchStyle = null, $cursorOrientation = FetchOrientation::NEXT, $cursorOffset = 0);
-
-	/**
-	 * Fetches the next row and returns it as an object.
-	 *
-	 * @param   string  $className        Name of the created class.
-	 * @param   array   $constructorArgs  Elements of this array are passed to the constructor.
-	 *
-	 * @return  mixed  An instance of the required class with property names that correspond to the column names or boolean false on failure.
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function fetchObject($className = null, $constructorArgs = null);
+	public function fetch(?int $fetchStyle = null, int $cursorOrientation = FetchOrientation::NEXT, int $cursorOffset = 0);
 
 	/**
 	 * Returns the number of rows affected by the last SQL statement.
@@ -111,5 +99,17 @@ interface StatementInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function rowCount();
+	public function rowCount(): int;
+
+	/**
+	 * Sets the fetch mode to use while iterating this statement.
+	 *
+	 * @param   integer  $fetchMode  The fetch mode, must be one of the FetchMode constants.
+	 * @param   mixed    ...$args    Optional mode-specific arguments.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFetchMode(int $fetchMode, ...$args): void;
 }


### PR DESCRIPTION
### Summary of Changes

The original implementation of the `StatementInterface` resulted in a signature set matching up with `PDOStatement` since the PDO driver's statement class was a subclass of the PDO extension.  This PR refactors the `StatementInterface` structure so that the PDO driver's statement is a decorator around the native `PDOStatement` and makes some adjustments to the `StatementInterface` as a result.

Interface changes include:

- Removing `fetchObject()`, for the non-PDO drivers this ended up as a shortcut to the `fetch()` method with the fetch mode set by default, and in the case of PDO internally it sets the fetch mode to `PDO::FETCH_CLASS` (the mapping for our `FetchMode::CUSTOM_OBJECT`).  Instead, the driver should pass forward the appropriate fetch mode before loading any rows out of the result set.
- `bindParam()` default value for `$dataType` uses the `Joomla\Database\ParameterType` class instead of `PDO`
- Added `setFetchMode()`, it's a proxy to `PDOStatement::setFetchMode()` or internally configures the non-PDO statements in the necessary way
- Typehinted API

### Testing Instructions

Things should just keep working