### PR TITLE
Keep statement after loading results

### DIFF
--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -1508,7 +1508,6 @@ class MysqliDriverTest extends DatabaseTestCase
 
 		// Test repeated statements.
 		static::$connection->setQuery($query);
-
 		$id        = 1;
 		$results[] = static::$connection->loadAssocList();
 		$id        = 4;
@@ -1525,7 +1524,7 @@ class MysqliDriverTest extends DatabaseTestCase
 				['id' => '4', 'title' => 'Testing4'],
 				['id' => '2', 'title' => 'Testing2'],
 			],
-			$result
+			$results
 		);
 	}
 }

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -1509,14 +1509,14 @@ class MysqliDriverTest extends DatabaseTestCase
 		// Test repeated statements.
 		static::$connection->setQuery($query);
 		$id        = 1;
-		$results[] = static::$connection->loadAssocList();
+		$results[] = static::$connection->loadAssoc();
 		$id        = 4;
-		$results[] = static::$connection->loadAssocList();
+		$results[] = static::$connection->loadAssoc();
 
 		// Also test that running a new query works.
 		static::$connection->setQuery($query);
 		$id        = 2;
-		$results[] = static::$connection->loadAssocList();
+		$results[] = static::$connection->loadAssoc();
 
 		$this->assertEquals(
 			[

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -1491,4 +1491,41 @@ class MysqliDriverTest extends DatabaseTestCase
 			$result
 		);
 	}
+
+	/**
+	 * @testdox  Select statements can be prepared once and executed repeateadly
+	 */
+	public function testRepeatedSelectStatement()
+	{
+		$this->loadExampleData();
+		$results = [];
+
+		$query = static::$connection->getQuery(true);
+		$query->select('id, title')
+			->from('#__dbtest')
+			->where('id = :id')
+			->bind(':id', $id, ParameterType::INTEGER);
+
+		// Test repeated statements.
+		static::$connection->setQuery($query);
+
+		$id        = 1;
+		$results[] = static::$connection->loadAssocList();
+		$id        = 4;
+		$results[] = static::$connection->loadAssocList();
+
+		// Also test that running a new query works.
+		static::$connection->setQuery($query);
+		$id        = 2;
+		$results[] = static::$connection->loadAssocList();
+
+		$this->assertEquals(
+			[
+				['id' => '1', 'title' => 'Testing1'],
+				['id' => '4', 'title' => 'Testing4'],
+				['id' => '2', 'title' => 'Testing2'],
+			],
+			$result
+		);
+	}
 }

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -773,7 +773,6 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 		if ($this->statement)
 		{
 			$this->statement->closeCursor();
-			$this->statement = null;
 		}
 	}
 

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -1031,7 +1031,6 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		if ($this->statement)
 		{
 			$this->statement->closeCursor();
-			$this->statement = null;
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-framework/database/issues/204.

### Summary of Changes

Keeps prepared statement intact after loading results to allow running the same statement again.

### Testing Instructions

Prepare a statement and run it multiple times, e.g.:

```
$query = $db->getQuery(true)
	->select($columns)
	->from($table)
	->where('column = :var')
	->bind(':var', $var);
$db->setQuery($query);

$var = 'value1';
$results = $db->loadObjectList();

$var = 'value2';
$results = $db->loadObjectList();
```
Before patch it doesn't work. After patch it should work. Everything else should work like before.

### Documentation Changes Required

IDK.