### PR TITLE
Fix travis failures on Postgres in 2.0 branch

### DIFF
--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -312,11 +312,16 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 	 */
 	public function testGetConnectionEncryption()
 	{
-		$result = static::$connection->getConnectionEncryption();
-		echo $result;
+		$expectedResult = '';
 
-		$this->assertEmpty(
-			$result,
+		if (\getenv('TRAVIS') === true && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0']))
+		{
+			$expectedResult = 'FTLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
+		}
+
+		$this->assertEquals(
+			$expectedResult,
+			static::$connection->getConnectionEncryption(),
 			'The database connection is not encrypted by default'
 		);
 	}

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -313,11 +313,8 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 	public function testGetConnectionEncryption()
 	{
 		$expectedResult = '';
-		echo \getenv('TRAVIS');
-		echo \getenv('PGSQL_VERSION');
 
-
-		if (\getenv('TRAVIS') === true && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0']))
+		if (\getenv('TRAVIS') === 'true' && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0']))
 		{
 			$expectedResult = 'TLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
 		}

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -319,7 +319,7 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 
 		if (\getenv('TRAVIS') === true && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0']))
 		{
-			$expectedResult = 'FTLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
+			$expectedResult = 'TLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
 		}
 
 		$this->assertSame(

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -313,13 +313,16 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 	public function testGetConnectionEncryption()
 	{
 		$expectedResult = '';
+		echo \getenv('TRAVIS');
+		echo \getenv('PGSQL_VERSION');
+
 
 		if (\getenv('TRAVIS') === true && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0']))
 		{
 			$expectedResult = 'FTLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			$expectedResult,
 			static::$connection->getConnectionEncryption(),
 			'The database connection is not encrypted by default'

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -312,8 +312,11 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 	 */
 	public function testGetConnectionEncryption()
 	{
+		$result = static::$connection->getConnectionEncryption();
+		echo $result;
+
 		$this->assertEmpty(
-			static::$connection->getConnectionEncryption(),
+			$result,
 			'The database connection is not encrypted by default'
 		);
 	}


### PR DESCRIPTION
Fix travis by adding travis specific expected variables for TLS encryption supported