### PR TITLE
[2.0] Bind Assoc. Arrays

### DIFF
--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -2010,15 +2010,15 @@ abstract class DatabaseQuery implements QueryInterface
 
         if (\is_array($value))
         {
-            $value = array_values($value);
+            $array_keys = array_keys($value);
         }
 
 		for ($i = 0; $i < $count; $i++)
 		{
-			if (\is_array($value))
-			{
-				$localValue = &$value[$i];
-			}
+            if (\is_array($value) && isset($array_keys))
+            {
+                $localValue = &$value[$array_keys[$i]];
+            }
 			else
 			{
 				$localValue = &$value;

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -2010,15 +2010,15 @@ abstract class DatabaseQuery implements QueryInterface
 
         if (\is_array($value))
         {
-            $array_keys = array_keys($value);
+            $value = array_values($value);
         }
 
 		for ($i = 0; $i < $count; $i++)
 		{
-            if (\is_array($value) && isset($array_keys))
-            {
-                $localValue = &$value[$array_keys[$i]];
-            }
+			if (\is_array($value))
+			{
+				$localValue = &$value[$i];
+			}
 			else
 			{
 				$localValue = &$value;

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -2008,12 +2008,17 @@ abstract class DatabaseQuery implements QueryInterface
 			throw new \InvalidArgumentException('Array length of $key and $dataType are not equal');
 		}
 
+        if (\is_array($value))
+        {
+            $array_keys = array_keys($value);
+        }
+
 		for ($i = 0; $i < $count; $i++)
 		{
-			if (\is_array($value))
-			{
-				$localValue = &$value[$i];
-			}
+            if (\is_array($value) && isset($array_keys))
+            {
+                $localValue = &$value[$array_keys[$i]];
+            }
 			else
 			{
 				$localValue = &$value;

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -2008,17 +2008,17 @@ abstract class DatabaseQuery implements QueryInterface
 			throw new \InvalidArgumentException('Array length of $key and $dataType are not equal');
 		}
 
-        if (\is_array($value))
-        {
-            $array_keys = array_keys($value);
-        }
+		if (\is_array($value))
+		{
+			$array_keys = array_keys($value);
+		}
 
 		for ($i = 0; $i < $count; $i++)
 		{
-            if (\is_array($value) && isset($array_keys))
-            {
-                $localValue = &$value[$array_keys[$i]];
-            }
+			if (\is_array($value) && isset($array_keys))
+			{
+				$localValue = &$value[$array_keys[$i]];
+			}
 			else
 			{
 				$localValue = &$value;


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Allows the binding of data passed as assoc. arrays and do not use numerical indexes.
Also fixes issues with numerical indexed arrays, not using incremental indexes (e.g.` [0=>1, 2=>2, 3=>3]`)

### Testing Instructions
Try the following code, in a model:
```
            $db = $this->getDbo();
            $query = $db->getQuery(true);
            $query->select(
                [
                    $db->quoteName('a.id'),
                    $db->quoteName('a.type'),
                    $db->quoteName('a.name')
                ])
                ->from($db->quoteName('#__banners', 'a'));
            $query->whereIn($db->quoteName('a.catid'), ['cat1'=>1, 'cat2'=>2]);
```
As is it will not work, because of the assoc. array of the values. 
Try applying the patch and it will.

### Documentation Changes Required
IDK