### PR TITLE
[2.0] Add missing case CUSTOM_OBJECT to statement

### DIFF
--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -540,6 +540,7 @@ class MysqliStatement implements StatementInterface
 				return $ret;
 
 			case FetchMode::STANDARD_OBJECT:
+			case FetchMode::CUSTOM_OBJECT:
 				return (object) array_combine($this->columnNames, $values);
 
 			default:


### PR DESCRIPTION
## Summary of Changes

Just adding a missing statement for custom

### Testing Instructions

This issue can be reproduced calling a `loadObjectList` method using the second parameter for a (custom?) class. 

For example

```
		$db = $this->getDbo();

		$query = $db->getQuery(true)
			->select(
				$db->quoteName(
					[
						'menu.id',
						'menu.menutype',
						'menu.title',
						'menu.alias',
						'menu.note',
						'menu.link',
						'menu.type',
						'menu.level',
						'menu.language',
						'menu.browserNav',
						'menu.access',
						'menu.params',
						'menu.home',
						'menu.img',
						'menu.template_style_id',
						'menu.component_id',
						'menu.parent_id'
					]
				)
			)
			->select(
				$db->quoteName(
					[
						'menu.path',
						'extensions.element',
						'menu_types.title',
						'pwtsitemap_menu_types.custom_title'
					],
					[
						'route',
						'component',
						'menuTitle',
						'customTitle'
					]
				)
			)
			->from($db->quoteName('#__menu', 'menu'))
			->leftJoin(
				$db->quoteName('#__extensions', 'extensions')
				. ' ON ' . $db->quoteName('menu.component_id') . ' = ' . $db->quoteName('extensions.extension_id')
			)
			->leftJoin(
				$db->quoteName('#__menu_types', 'menu_types')
				. ' ON ' . $db->quoteName('menu_types.menutype') . ' = ' . $db->quoteName('menu.menutype')
			)
			->leftJoin(
				$db->quoteName('#__pwtsitemap_menu_types', 'pwtsitemap_menu_types')
				. ' ON ' . $db->quoteName('pwtsitemap_menu_types.menu_types_id') . ' = ' . $db->quoteName('menu_types.id')
			)
			->where($db->quoteName('menu.published') . ' = 1')
			->where($db->quoteName('menu.parent_id') . ' > 0')
			->where($db->quoteName('menu.client_id') . ' = 0')
			->order($db->quoteName('pwtsitemap_menu_types.ordering') . ' ASC')
			->order($db->quoteName('menu.lft'));

		// Set the query
		$db->setQuery($query);

		$this->items = $db->loadObjectList('id', MenuItem::class);
```

I tested this using Joomla! 4 on github repository and the latest `4.0-dev` branch

### Documentation Changes Required
