### PR TITLE
Fix - Don't leak CI configuration into tests

### DIFF
--- a/Tests/DriverMysqlTest.php
+++ b/Tests/DriverMysqlTest.php
@@ -314,7 +314,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = (float) getenv('MYSQL_VERSION') < 8.0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = (float)self::$driver->getVersion() < 8.0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -303,7 +303,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = (float) getenv('MYSQL_VERSION') < 8.0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = (float) self::$driver->getVersion() < 8.0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;


### PR DESCRIPTION
Pull Request for Issue #222

### Summary of Changes

Use DatabaseDriver::getVersion instead of environment variable

### Testing Instructions

Code review

### Documentation Changes Required

No