### PR TITLE
[2.0] Dereference parameters in DebugMonitor

### DIFF
--- a/Tests/AbstractDatabaseDriverTestCase.php
+++ b/Tests/AbstractDatabaseDriverTestCase.php
@@ -982,8 +982,6 @@ abstract class AbstractDatabaseDriverTestCase extends DatabaseTestCase
 			],
 			$params
 		);
-
-		static::$connection->setMonitor(null);
 	}
 
 	/**
@@ -1020,7 +1018,5 @@ abstract class AbstractDatabaseDriverTestCase extends DatabaseTestCase
 			],
 			$params
 		);
-
-		static::$connection->setMonitor(null);
 	}
 }

--- a/src/Monitor/DebugMonitor.php
+++ b/src/Monitor/DebugMonitor.php
@@ -71,7 +71,7 @@ final class DebugMonitor implements QueryMonitorInterface
 	public function startQuery(string $sql, ?array $boundParams = null): void
 	{
 		$this->logs[]        = $sql;
-		$this->boundParams[] = $boundParams;
+		$this->boundParams[] = unserialize(serialize($boundParams));
 		$this->callStacks[]  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		$this->memoryLogs[]  = memory_get_usage();
 		$this->timings[]     = microtime(true);

--- a/src/Monitor/DebugMonitor.php
+++ b/src/Monitor/DebugMonitor.php
@@ -71,7 +71,10 @@ final class DebugMonitor implements QueryMonitorInterface
 	public function startQuery(string $sql, ?array $boundParams = null): void
 	{
 		$this->logs[]        = $sql;
+
+		// Dereference bound parameters to prevent reporting wrong value when reusing the same query object.
 		$this->boundParams[] = unserialize(serialize($boundParams));
+
 		$this->callStacks[]  = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		$this->memoryLogs[]  = memory_get_usage();
 		$this->timings[]     = microtime(true);


### PR DESCRIPTION
### Summary of Changes

Dereferences bound parameters in `DebugMonitor` to prevent reporting wrong value when reusing the same query object.

### Testing Instructions

Set up  a connection with debug monitor.
Run the same query with different bound parameters.

Check that `DebugMonitor::getBoundParams()` returns correct values.

### Documentation Changes Required
No.