### PR TITLE
Fix version check for display width modifier support in unit tests for MySQL

### DIFF
--- a/Tests/DriverMysqlTest.php
+++ b/Tests/DriverMysqlTest.php
@@ -311,10 +311,12 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		);
 
 		/* not only type field */
+		$version = self::$driver->getVersion();
+
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = (float)self::$driver->getVersion() < 8.0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = stripos($version, 'mariadb') || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;

--- a/Tests/DriverMysqlTest.php
+++ b/Tests/DriverMysqlTest.php
@@ -316,7 +316,7 @@ class DriverMysqlTest extends DatabaseMysqlCase
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = stripos($version, 'mariadb') || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = stripos($version, 'mariadb') !== false || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -305,7 +305,7 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = stripos($version, 'mariadb') || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = stripos($version, 'mariadb') !== false || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;

--- a/Tests/DriverMysqliTest.php
+++ b/Tests/DriverMysqliTest.php
@@ -300,10 +300,12 @@ class DriverMysqliTest extends DatabaseMysqliCase
 		);
 
 		/* not only type field */
+		$version = self::$driver->getVersion();
+
 		$id = new \stdClass;
 		$id->Default    = null;
 		$id->Field      = 'id';
-		$id->Type       = (float) self::$driver->getVersion() < 8.0 ? 'int(10) unsigned' : 'int unsigned';
+		$id->Type       = stripos($version, 'mariadb') || version_compare($version, '8.0.17') < 0 ? 'int(10) unsigned' : 'int unsigned';
 		$id->Null       = 'NO';
 		$id->Key        = 'PRI';
 		$id->Collation  = null;


### PR DESCRIPTION
Pull Request for Issue #241 .

### Summary of Changes

This pull request (PR) changes the 2 checks for display width modifier support in unit tests for the MySQL drivers so the check is correctly done if it's a MariaDB or a MySQL version lower than 8.0.17, which still use the display width modifier for integer data types, or if it's a MySQL 8.0.17 or later, on which the display width modifier is deprecated and not part of the column's type specifier returned e.g. by a "SHOW COLUMNS" and where it might not be supported in future.

It makes it possible to run the unit tests on MariaDB, too.

See https://github.com/joomla/joomla-cms/pull/32606 for details on the display width issue.

### Testing Instructions

Check if unit tests still pass.

### Documentation Changes Required

None.

### Additional information

I might do a follow-up PR later to remove the usage of the display width modifier from SQL statements in scripts and at other places.