### PR TITLE
[2.0] Fix version check for display width modifier support in unit tests for MySQL

### DIFF
--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -91,6 +91,8 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
 	{
 		$isMySQL8 = !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=');
 
+		$useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
+
 		yield 'only column types' => [
 			'#__dbtest',
 			true,
@@ -109,7 +111,7 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
 			[
 				'id'          => (object) [
 					'Field'      => 'id',
-					'Type'       => $isMySQL8 ? 'int unsigned' : 'int(10) unsigned',
+					'Type'       => $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned',
 					'Collation'  => $isMySQL8 ? null : '',
 					'Null'       => 'NO',
 					'Key'        => 'PRI',

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -104,6 +104,8 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
 	{
 		$isMySQL8 = !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=');
 
+		$useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
+
 		yield 'only column types' => [
 			'#__dbtest',
 			true,
@@ -122,7 +124,7 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
 			[
 				'id'          => (object) [
 					'Field'      => 'id',
-					'Type'       => $isMySQL8 ? 'int unsigned' : 'int(10) unsigned',
+					'Type'       => $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned',
 					'Collation'  => $isMySQL8 ? null : '',
 					'Null'       => 'NO',
 					'Key'        => 'PRI',


### PR DESCRIPTION
Pull Request for Issue #241.

### Summary of Changes

Same as PR #242 for master, but here adapted to the 2.0-dev branch.

See description of that PR and the CMS PR linked there for details on the display width issue.

In opposite to the master branch, the tests on the 2.0-dev branch were already adapted for MariaDB, so in this PR here doesn't fix any MariaDB issue like the other PR does for the master branch.

### Testing Instructions

Check if unit tests still pass.

### Documentation Changes Required

None.