### PR TITLE
Remove display width from test stubs for MySQL

### DIFF
--- a/Tests/Stubs/ddl.sql
+++ b/Tests/Stubs/ddl.sql
@@ -177,7 +177,7 @@ CREATE TABLE `jos_languages` (
   `metadesc` TEXT NOT NULL DEFAULT '',
   `sitename` varchar(1024) NOT NULL default '',
   `published` INTEGER NOT NULL DEFAULT '0',
-  `ordering` int(11) NOT NULL default '0',
+  `ordering` INTEGER NOT NULL default '0',
   CONSTRAINT `idx_languages_sef` UNIQUE (`sef`)
   CONSTRAINT `idx_languages_image` UNIQUE (`image`)
   CONSTRAINT `idx_languages_lang_code` UNIQUE (`lang_code`)

--- a/Tests/Stubs/mysql.sql
+++ b/Tests/Stubs/mysql.sql
@@ -16,7 +16,7 @@ ALTER DATABASE joomla_ut CHARACTER SET utf8 COLLATE utf8_general_ci;
 DROP TABLE IF EXISTS `jos_dbtest`;
 
 CREATE TABLE `jos_dbtest` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(50) NOT NULL,
   `start_date` datetime NOT NULL,
   `description` text NOT NULL,


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Remove the display width modifier from the unit test stub SQL scripts.

On databases which still use this modifier, i.e. MySQL versions lower than 8.0.17 or any version of MariaDB, the default value is used, which is 10 for an unsigned integer.

The unit tests here are already using this value and so don't have to be changed.

But this PR makes them safe for still working on a future version where MySQL may change the deprecated status of that modifier to unsupported.

### Testing Instructions

Check if unit tests still pass.

### Documentation Changes Required

None.