### PR TITLE
[2.0] Remove display width from test stub for MySQL

### DIFF
--- a/Tests/Stubs/Schema/mysql.sql
+++ b/Tests/Stubs/Schema/mysql.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `#__dbtest` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(50) NOT NULL,
   `start_date` datetime NOT NULL,
   `description` text NOT NULL,


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Remove the display width modifier from the unit test stub SQL script.

See also #244 for the master branch.

On databases which still use this modifier, i.e. MySQL versions lower than 8.0.17 or any version of MariaDB, the default value is used, which is 10 for an unsigned integer.

The unit tests here are already using this value and so don't have to be changed.

But this PR makes them safe for still working on a future version where MySQL may change the deprecated status of that modifier to unsupported.

### Testing Instructions

Check if unit tests still pass.

### Documentation Changes Required

None.