### PR TITLE
Fix Extra Column import since MySQL 8

### DIFF
--- a/src/Mysql/MysqlImporter.php
+++ b/src/Mysql/MysqlImporter.php
@@ -284,7 +284,15 @@ class MysqlImporter extends DatabaseImporter
 
 		if ($fExtra)
 		{
-			$sql .= ' ' . strtoupper($fExtra);
+			// MySql 8.0 introduces DEFAULT_GENERATED in the extra column and should be replaced with the default value
+			if (stristr($fExtra, 'DEFAULT_GENERATED') !== false)
+			{
+				$sql .= ' ' . strtoupper(str_ireplace('DEFAULT_GENERATED', 'DEFAULT ' . $fDefault, $fExtra));
+			}
+			else
+			{
+				$sql .= ' ' . strtoupper($fExtra);
+			}
 		}
 
 		return $sql;

--- a/src/Mysqli/MysqliImporter.php
+++ b/src/Mysqli/MysqliImporter.php
@@ -323,7 +323,15 @@ class MysqliImporter extends DatabaseImporter
 
 		if ($fExtra)
 		{
-			$sql .= ' ' . strtoupper($fExtra);
+			// MySql 8.0 introduces DEFAULT_GENERATED in the extra column and should be replaced with the default value
+			if (stristr($fExtra, 'DEFAULT_GENERATED') !== false)
+			{
+				$sql .= ' ' . strtoupper(str_ireplace('DEFAULT_GENERATED', 'DEFAULT ' . $fDefault, $fExtra));
+			}
+			else
+			{
+				$sql .= ' ' . strtoupper($fExtra);
+			}
 		}
 
 		return $sql;


### PR DESCRIPTION
Pull Request for Issue #https://github.com/joomla/joomla-cms/issues/37662

### Summary of Changes
MySql 8.0 introduces DEFAULT_GENERATED in the extra column and should be replaced with the default value.

`Extra

Any additional information that is available about a given column. The value is nonempty in these cases:

auto_increment for columns that have the AUTO_INCREMENT attribute.

on update CURRENT_TIMESTAMP for TIMESTAMP or DATETIME columns that have the ON UPDATE CURRENT_TIMESTAMP attribute.

VIRTUAL GENERATED or STORED GENERATED for generated columns.

DEFAULT_GENERATED for columns that have an expression default value.`

See https://dev.mysql.com/doc/refman/8.0/en/show-columns.html

### Testing Instructions

- Export all tables and data to the folder:

php cli/joomla.php database:export --folder=<folder_path>

- Import all from folder:

php cli/joomla.php database:import --folder=<folder_path>



### Documentation Changes Required
