### PR TITLE
PHP 8.1 deprecation notices.

### DIFF
--- a/src/DatabaseIterator.php
+++ b/src/DatabaseIterator.php
@@ -123,6 +123,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Countable::count()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		if ($this->statement)
@@ -141,6 +142,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Iterator::current()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return $this->current;
@@ -154,6 +156,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Iterator::key()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function key()
 	{
 		return $this->key;
@@ -167,6 +170,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Iterator::next()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		// Set the default key as being the number of fetched object
@@ -199,6 +203,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Iterator::rewind()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 	}
@@ -211,6 +216,7 @@ class DatabaseIterator implements \Countable, \Iterator
 	 * @see     Iterator::valid()
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid()
 	{
 		return (boolean) $this->current;


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Silencing PHP 8.1 deprecation notices that prevents Joomla! from running with error reporting on.
Example of error message
PHP Deprecated:  Return type of Joomla\Database\DatabaseIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in D:\virtualhosts\clean40\libraries\vendor\joomla\database\src\DatabaseIterator.php on line 214

Snip from PHP.net Backward Incompatible Changes:

![image](https://user-images.githubusercontent.com/25645600/145472997-e6f9fdf6-bb38-4cb7-9262-aa02ead6284c.png)

### Testing Instructions
Code review or check that errors disappear from logfile.
### Documentation Changes Required
Probably not.