### PR TITLE
PHP 8 Deprecation Handling

### DIFF
--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -270,13 +270,13 @@ class PgsqlDriver extends PdoDriver
 			foreach ($fields as $field)
 			{
 				// Change Postgresql's NULL::* type with PHP's null one
-				if (preg_match('/^NULL::*/', $field->Default))
+				if (null !== $field->Default && preg_match('/^NULL::*/', $field->Default))
 				{
 					$field->Default = null;
 				}
 
 				// Normalise default values like datetime
-				if (preg_match('/^\'(.*)\'::.*/', $field->Default, $matches))
+				if (null !== $field->Default && preg_match('/^\'(.*)\'::.*/', $field->Default, $matches))
 				{
 					$field->Default = $matches[1];
 				}


### PR DESCRIPTION
Pull Request for Issue #257

<img width="1982" alt="Screenshot 2021-12-24 at 17 52 52" src="https://user-images.githubusercontent.com/400092/147367812-4a7538b7-72c9-4a29-8969-033ce7d768f5.png">

```
40s
255	  <br />
40s
256	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>273</b><br />
40s
257	  <br />
40s
258	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>279</b><br />
40s
259	  <br />
40s
260	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>273</b><br />
40s
261	  <br />
40s
262	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>279</b><br />
40s
263	  <br />
40s
264	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>273</b><br />
40s
265	  <br />
40s
266	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>279</b><br />
40s
267	  <br />
40s
268	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>273</b><br />
40s
269	  <br />
40s
270	  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgres/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>279</b><br />
40s
271	  <br />
40s
```