### PR TITLE
Only check types of postgres default values if set

### DIFF
--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -269,16 +269,19 @@ class PgsqlDriver extends PdoDriver
 		{
 			foreach ($fields as $field)
 			{
-				// Change Postgresql's NULL::* type with PHP's null one
-				if (preg_match('/^NULL::*/', $field->Default))
+				if ($field->Default !== null)
 				{
-					$field->Default = null;
-				}
+					// Change Postgresql's NULL::* type with PHP's null one
+					if (preg_match('/^NULL::*/', $field->Default))
+					{
+						$field->Default = null;
+					}
 
-				// Normalise default values like datetime
-				if (preg_match('/^\'(.*)\'::.*/', $field->Default, $matches))
-				{
-					$field->Default = $matches[1];
+					// Normalise default values like datetime
+					if (preg_match('/^\'(.*)\'::.*/', $field->Default, $matches))
+					{
+						$field->Default = $matches[1];
+					}
 				}
 
 				// Do some dirty translation to MySQL output.


### PR DESCRIPTION
The field default can be null. If that is the case then the preg_match gives a PHP deprecation warning in PHP 8.1. 

This can be seen at https://ci.joomla.org/joomla/joomla-cms/50349/1/31 phpnext-api-postgres test run

e.g.
```
  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgresphpnext/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>273</b><br />
  <br />
  <b>Deprecated</b>:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/tests/www/postgresphpnext/libraries/vendor/joomla/database/src/Pgsql/PgsqlDriver.php</b> on line <b>279</b><br />
```