### PR TITLE
[2.0] [PHP 8.1] Fix deprecated null parameter for string functions in the escape method of the drivers

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -728,7 +728,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		if (\is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -380,12 +380,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		if (\is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();
 
-		$result = $this->connection->real_escape_string($text);
+		$result = $this->connection->real_escape_string((string) $text);
 
 		if ($extra)
 		{

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -399,10 +399,10 @@ abstract class PdoDriver extends DatabaseDriver
 		if (\is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
-		$text = str_replace("'", "''", $text);
+		$text = str_replace("'", "''", (string) $text);
 
 		return addcslashes($text, "\000\n\r\\\032");
 	}


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

Analogue to PR https://github.com/joomla/joomla-cms/pull/36787 for the 3.10-dev branch of the CMS.

### Testing Instructions

A code review could be sufficient. Otherwise see https://github.com/joomla/joomla-cms/pull/36787 .

### Additional comments

Reading the code I think the return value should be type casted to sting also for the `is_int($text)` case a bit above the `is_float($text)` modified here. (There is no PHP 8.1 error at that place but it would be right due to the function documentation).

But that would change behaviour regarding the return value's type in that case, and so I think this should be done with a future clean-up, together with type-hinting the methods.

### Documentation Changes Required

None.