### PR TITLE
Database exporter fix for php 8.1 deprecations

### DIFF
--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -302,7 +302,7 @@ abstract class DatabaseExporter
 				{
 					if (!in_array($key, $colblob))
 					{
-						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
+						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value ?? '', ENT_COMPAT, 'UTF-8') . '</field>';
 					}
 					else
 					{


### PR DESCRIPTION
### Summary of Changes
used null coalescing operator

### Testing Instructions
with Error Reporting setted to Maximum
run `php cli/joomla.php database:export --folder=tmp/`

you got  a lot of `PHP Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /shared/httpd/test/zzzz/libraries/vendor/joomla/database/src/DatabaseExporter.php on line 305`