### PR TITLE
Enable 'SQL_BIG_SELECT'

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -292,6 +292,9 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		// And read the real sql mode to mitigate changes in mysql > 5.7.+
 		$this->options['sqlModes'] = explode(',', $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult());
 
+		// Turn 'big selects' on to ensure certain selects work on platforms that try to prevent these...  
+		$this->connection->query("SET @@SESSION.sql_big_selects = 1;" );
+
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))
 		{


### PR DESCRIPTION
Enabled this to support certain issues (especially when upgrading Joomla) with providers that have this setting disabled by default.

I experienced issues when upgrading a vanilla version of Joomla 4.1.4 to 4.1.5 which is due to the provider having disabled the 'SQL_BIG_SELECT' by default. Because this was disabled an error occurred when attempting to upgrade Joomla to the newer version. Combine this with the insistent upgrade emails from many installations at the same provider and it it gets old real fast....

Enabling this setting resolves the bug.

### Summary of Changes
Only one line of code was needed

### Testing Instructions
Requires some doing to set things up, but a vanilla upgrade of Joomla CMS 4.1.4 to 4.1.5 on a provider with the setting disabled and this patch not installed should reproduce the issue, pathing it would be the test. 

### Documentation Changes Required
