### PR TITLE
simplify PHP requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/database",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5|~8.0.0|~8.1.0",
+        "php": "^7.2.5|^8.0.0",
         "joomla/event": "^2.0",
         "symfony/deprecation-contracts": "^2.1"
     },


### PR DESCRIPTION
I would assume that we support all PHP versions and with the nightly builds, we should learn early enough if something breaks in a future PHP version. That's why I'd like to simplify this the proposed way.
