### PR TITLE
php 8.2 - dynamic property deperecation

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -94,6 +94,14 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	];
 
 	/**
+	 * The default charset.
+	 *
+	 * @var    string
+	 * @since  2.0.0
+	 */
+	protected $charset = 'utf8';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $options  Array of database options with keys: host, user, password, database, select.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -99,7 +99,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	 * @var    string
 	 * @since  2.0.0
 	 */
-	protected $charset = 'utf8';
+	public $charset = 'utf8';
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
Deprecated: Creation of dynamic property Joomla\Database\Mysql\MysqlDriver::$charset is deprecated in /shared/httpd/dev4/joomla-cms/libraries/vendor/joomla/database/src/Mysql/MysqlDriver.php on line 128

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
