### PR TITLE
Cleanup of Appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ clone_folder: C:\projects\database
 
 ## Build matrix for lowest and highest possible targets
 environment:
-  DLLVersion: "5.8.0"
+  DLLVersion: "5.8.1"
   PHPBuild: "x64"
   VC: "vc15"
   matrix:
@@ -28,10 +28,11 @@ environment:
     db_version: sql2017
     php: 8.0
     DLLVersion: "5.9.0"
-#  - db: mssql
-#    driver: sqlsrv
-#    db_version: sql2017
-#    php: 8.1
+  - db: mssql
+    driver: sqlsrv
+    db_version: sql2017
+    php: 8.1
+    DLLVersion: "5.10.0"
 #  - db: mssql
 #    driver: sqlsrv
 #    db_version: sql2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,11 +28,13 @@ environment:
     db_version: sql2017
     php: 8.0
     DLLVersion: "5.9.0"
+    VC: "vs16"
   - db: mssql
     driver: sqlsrv
     db_version: sql2017
     php: 8.1
     DLLVersion: "5.10.0"
+    VC: "vs16"
 #  - db: mssql
 #    driver: sqlsrv
 #    db_version: sql2017

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,19 +1,8 @@
+image: Visual Studio 2022
 build: false
 platform:
   - x64
 clone_folder: C:\projects\database
-branches:
-  except:
-    - gh-pages
-clone_depth: 2
-
-cache:
-  - C:\ProgramData\chocolatey\bin -> .appveyor.yml
-  - C:\ProgramData\chocolatey\lib -> .appveyor.yml
-  - C:\tools\php -> .appveyor.yml
-  - C:\tools\cacert -> .appveyor.yml
-  - C:\tools\composer -> .appveyor.yml
-  - '%LOCALAPPDATA%\Composer\files -> composer.json'
 
 ## Build matrix for lowest and highest possible targets
 environment:
@@ -38,14 +27,15 @@ environment:
     driver: sqlsrv
     db_version: sql2017
     php: 8.0
-  - db: mssql
-    driver: sqlsrv
-    db_version: sql2017
-    php: 8.1
-  - db: mssql
-    driver: sqlsrv
-    db_version: sql2017
-    php: 8.2
+    DLLVersion: "5.9.0"
+#  - db: mssql
+#    driver: sqlsrv
+#    db_version: sql2017
+#    php: 8.1
+#  - db: mssql
+#    driver: sqlsrv
+#    db_version: sql2017
+#    php: 8.2
 
 init:
   - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;C:\tools\composer;%PATH%
@@ -55,65 +45,49 @@ init:
 ## Install PHP and composer, and run the appropriate composer command
 install:
     - ps: |
-        # Check if installation is cached
-        if (!(Test-Path c:\tools\php)) {
-          choco upgrade --no-progress --limit-output -y chocolatey --version 0.10.13 --allow-downgrade --force
-          appveyor-retry choco install --no-progress --limit-output -y --params '""/InstallDir:C:\tools\php""' --ignore-checksums php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-          # install sqlite
-          appveyor-retry choco install --no-progress --limit-output -y sqlite
-          Get-ChildItem -Path c:\tools\php
-          cd c:\tools\php
+        appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+        # install sqlite
+        appveyor-retry choco install sqlite --no-progress --limit-output -y
+        Get-ChildItem -Path c:\tools\php
+        cd c:\tools\php
 
-          # Set PHP environment items that are always needed
-          copy php.ini-production php.ini
-          Add-Content php.ini "`n date.timezone=UTC"
-          Add-Content php.ini "`n extension_dir=ext"
-          Add-Content php.ini "`n memory_limit=1G"
-          Add-Content php.ini "`n extension=php_openssl.dll"
-          Add-Content php.ini "`n extension=php_mbstring.dll"
-          Add-Content php.ini "`n extension=php_fileinfo.dll"
-          Add-Content php.ini "`n extension=php_pdo_sqlite.dll"
-          Add-Content php.ini "`n extension=php_sqlite3.dll"
-          Add-Content php.ini "`n extension=php_curl.dll"
-          Add-Content php.ini "`n curl.cainfo=C:\tools\cacert\bundle.pem"
+        # Set PHP environment items that are always needed
+        copy php.ini-production php.ini
+        Add-Content php.ini "`n date.timezone=UTC"
+        Add-Content php.ini "`n extension_dir=ext"
+        Add-Content php.ini "`n memory_limit=1G"
+        Add-Content php.ini "`n extension=php_openssl.dll"
+        Add-Content php.ini "`n extension=php_mbstring.dll"
+        Add-Content php.ini "`n extension=php_fileinfo.dll"
+        Add-Content php.ini "`n extension=php_pdo_sqlite.dll"
+        Add-Content php.ini "`n extension=php_sqlite3.dll"
+        Add-Content php.ini "`n extension=php_curl.dll"
+        Add-Content php.ini "`n curl.cainfo=C:\tools\cacert\bundle.pem"
 
-          # Get and install the MSSQL DLL's
-          cd c:\tools\php\ext
-          $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          $destination = "c:\tools\php\ext\php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-          $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          Invoke-WebRequest $source -OutFile $destination
-          7z x -y php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-          Remove-Item c:\tools\php\* -include .zip
-          cd c:\tools\php
-          Add-Content php.ini "`nextension=php_sqlsrv.dll"
-          Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
-          Add-Content php.ini "`n"
+        # Get and install the MSSQL DLL's
+        cd c:\tools\php\ext
+        $source = "https://windows.php.net/downloads/pecl/releases/sqlsrv/$($env:DLLVersion)/php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
+        $destination = "c:\tools\php\ext\php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
+        Invoke-WebRequest $source -OutFile $destination
+        7z x -y php_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+        $source = "https://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($env:DLLVersion)/php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
+        $destination = "c:\tools\php\ext\php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip"
+        Invoke-WebRequest $source -OutFile $destination
+        7z x -y php_pdo_sqlsrv-$($env:DLLVersion)-$($env:php)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
+        Remove-Item c:\tools\php\* -include .zip
+        cd c:\tools\php
+        Add-Content php.ini "`nextension=php_sqlsrv.dll"
+        Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
+        Add-Content php.ini "`n"
+        # download CA bundle
+        New-Item -path c:\tools\ -name cacert -itemtype directory
 
-          # download Composer
-          if (!(Test-Path C:\tools\composer)) {
-            New-Item -path c:\tools -name composer -itemtype directory
-          }
-          if (!(Test-Path c:\tools\composer\composer.phar)) {
-            appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar -Filename C:\tools\composer\composer.phar
-            Set-Content -path 'C:\tools\composer\composer.bat' -Value ('@php C:\tools\composer\composer.phar %*')
-          }
-
-          # download CA bundle
-          if (!(Test-Path C:\tools\cacert)) {
-            New-Item -path c:\tools\ -name cacert -itemtype directory
-          }
-          if (!(Test-Path c:\tools\cacert\bundle.pem)) {
-            appveyor-retry curl -fksSL -o C:\tools\cacert\bundle.pem https://curl.haxx.se/ca/cacert.pem
-          }
-        }
+        appveyor-retry curl -fksSL -o C:\tools\cacert\bundle.pem https://curl.haxx.se/ca/cacert.pem
     # install composer dependencies
     - cd C:\projects\database
-    - appveyor-retry composer self-update
-    - appveyor-retry composer install --no-progress --prefer-dist
+    - choco install composer --no-progress --limit-output -y
+    - refreshenv
+    - composer install --no-progress --prefer-dist
 
 before_test:
   - ps: $instanceName = $env:db_version.ToUpper()


### PR DESCRIPTION
This PR cleans up the appveyor configuration and does the following:
- Update the image to Visual Studio 2022 (in sync with the CMS)
- Remove the caching, since it doesn't work. :-(
- Comment the build for PHP 8.1 and 8.2 because there are no pecl sqlsrv driver for these versions.
- Don't downgrade chocolatey anymore
- Properly install composer