### PR TITLE
Update SqlsrvDriver.php

### DIFF
--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -87,6 +87,7 @@ class SqlsrvDriver extends DatabaseDriver
 		$options['password'] = $options['password'] ?? '';
 		$options['database'] = $options['database'] ?? '';
 		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['trust_certificate'] = $options['trust_certificate'] ?? false;
 
 		// Finalize initialisation
 		parent::__construct($options);
@@ -118,6 +119,7 @@ class SqlsrvDriver extends DatabaseDriver
 			'Database'             => $this->options['database'],
 			'uid'                  => $this->options['user'],
 			'pwd'                  => $this->options['password'],
+			'TrustServerCertificate' => $this->options['trust_certificate'],
 			'CharacterSet'         => 'UTF-8',
 			'ReturnDatesAsStrings' => true,
 		];


### PR DESCRIPTION
### Summary of Changes

MS Changed their most recent SQLServer component for PHP to fail on SQL's default self-signed certificate unless you say TrustServerCertificate true. Unfortunately there is no current means to pass that value through the Joomla framework

### Testing Instructions

`

	$option = array();
	$option['driver']   = 'sqlsrv';
	$option['host']     = '(host)';
	$option['user']     = '(user)'; 
	$option['password'] = '(pass) ';
	$option['database'] = '(db-name)';
	$option['trust_certificate'] = true;

	$db = (new Joomla\Database\DatabaseFactory)->getDriver('sqlsrv', $option);

	$db->setQuery('SELECT COUNT(*) FROM MyTable');
	echo 'Results: ' . (int) $db->loadResult();`

### Documentation Changes Required
