### PR TITLE
Several fixes from phpstan

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -12,6 +12,7 @@
 namespace Joomla\Database\Command;
 
 use Joomla\Archive\Archive;
+use Joomla\Archive\Exception\UnknownArchiveException;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
@@ -165,7 +166,7 @@ class ImportCommand extends AbstractCommand
 
             try {
                 (new Archive())->extract($zipPath, $folderPath);
-            } catch (\RuntimeException $e) {
+            } catch (UnknownArchiveException $e) {
                 $symfonyStyle->error($e->getMessage());
                 Folder::delete($folderPath);
 

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -240,7 +240,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
             $dir      = __DIR__;
             $iterator = new \DirectoryIterator($dir);
 
-            /** @var $file \DirectoryIterator */
+            /** @var \DirectoryIterator $file */
             foreach ($iterator as $file) {
                 // Only load for php files.
                 if (!$file->isDir()) {
@@ -250,7 +250,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
                 $baseName = $file->getBasename();
 
                 // Derive the class name from the type.
-                /** @var $class DatabaseDriver */
+                /** @var DatabaseDriver $class */
                 $class = __NAMESPACE__ . '\\' . ucfirst(strtolower($baseName)) . '\\' . ucfirst(strtolower($baseName)) . 'Driver';
 
                 // If the class doesn't exist, or if it's not supported on this system, move on to the next type.
@@ -968,7 +968,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @param   boolean  $new  False to return the current query object, True to return a new DatabaseQuery object.
      *
-     * @return  DatabaseQuery
+     * @return  QueryInterface
      *
      * @since   1.0
      */

--- a/src/DatabaseFactory.php
+++ b/src/DatabaseFactory.php
@@ -71,7 +71,7 @@ class DatabaseFactory
             throw new Exception\UnsupportedAdapterException('Database Exporter not found.');
         }
 
-        /** @var $o DatabaseExporter */
+        /** @var DatabaseExporter $o */
         $o = new $class();
 
         if ($db) {
@@ -103,7 +103,7 @@ class DatabaseFactory
             throw new Exception\UnsupportedAdapterException('Database importer not found.');
         }
 
-        /** @var $o DatabaseImporter */
+        /** @var DatabaseImporter $o */
         $o = new $class();
 
         if ($db) {

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -169,7 +169,7 @@ abstract class DatabaseImporter
      *
      * @since   1.0
      */
-    protected function getColumnSql(\SimpleXMLElement $field);
+    abstract protected function getColumnSql(\SimpleXMLElement $field);
 
     /**
      * Get the SQL syntax to drop a column.

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -161,6 +161,17 @@ abstract class DatabaseImporter
     }
 
     /**
+     * Get the SQL syntax for a single column that would be included in a table create or alter statement.
+     *
+     * @param   \SimpleXMLElement  $field  The XML field definition.
+     *
+     * @return  string
+     *
+     * @since   1.0
+     */
+    protected function getColumnSql(\SimpleXMLElement $field);
+
+    /**
      * Get the SQL syntax to drop a column.
      *
      * @param   string  $table  The table name.

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -214,6 +214,15 @@ interface DatabaseInterface
     public function getNullDate();
 
     /**
+     * Get the common table prefix for the database driver.
+     *
+     * @return  string  The common database table prefix.
+     *
+     * @since   3.0
+     */
+    public function getPrefix();
+
+    /**
      * Get the number of returned rows for the previous executed SQL statement.
      *
      * @return  integer

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1363,7 +1363,7 @@ abstract class DatabaseQuery implements QueryInterface
      *
      * @param   string  $value  The string to measure.
      *
-     * @return  integer
+     * @return  string
      *
      * @since   1.0
      */

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -333,7 +333,7 @@ class MysqliStatement implements StatementInterface
     /**
      * Fetches the SQLSTATE associated with the last operation on the statement handle.
      *
-     * @return  string
+     * @return  int
      *
      * @since   2.0.0
      */
@@ -345,7 +345,7 @@ class MysqliStatement implements StatementInterface
     /**
      * Fetches extended error information associated with the last operation on the statement handle.
      *
-     * @return  array
+     * @return  string
      *
      * @since   2.0.0
      */

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -199,14 +199,14 @@ class PgsqlDriver extends PdoDriver
      *
      * @param   mixed  $tables  A table name or a list of table names.
      *
-     * @return  string  An empty string because this function is not supported by PostgreSQL.
+     * @return  array  An empty array because this function is not supported by PostgreSQL.
      *
      * @since   1.5.0
      * @throws  \RuntimeException
      */
     public function getTableCreate($tables)
     {
-        return '';
+        return [];
     }
 
     /**

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -436,6 +436,31 @@ interface QueryInterface extends PreparableInterface, LimitableInterface
     public function order($columns);
 
     /**
+     * Wrap an SQL statement identifier name such as column, table or database names in quotes to prevent injection
+     * risks and reserved word conflicts.
+     *
+     * This method is provided for use where the query object is passed to a function for modification.
+     * If you have direct access to the database object, it is recommended you use the quoteName method directly.
+     *
+     * Note that 'qn' is an alias for this method as it is in DatabaseDriver.
+     *
+     * Usage:
+     * $query->quoteName('#__a');
+     * $query->qn('#__a');
+     *
+     * @param   array|string  $name  The identifier name to wrap in quotes, or an array of identifier names to wrap in quotes.
+     *                               Each type supports dot-notation name.
+     * @param   array|string  $as    The AS query part associated to $name. It can be string or array, in latter case it has to be
+     *                               same length of $name; if is null there will not be any AS part for string or array element.
+     *
+     * @return  array|string  The quote wrapped name, same type of $name.
+     *
+     * @since   1.0
+     * @throws  \RuntimeException if the internal db property is not a valid object.
+     */
+    public function quoteName($name, $as = null);
+
+    /**
      * Get the function to return a random floating-point value
      *
      * Usage:

--- a/src/Sqlsrv/SqlsrvQuery.php
+++ b/src/Sqlsrv/SqlsrvQuery.php
@@ -312,7 +312,7 @@ class SqlsrvQuery extends DatabaseQuery
      *
      * @param   string  $value  The string to measure.
      *
-     * @return  integer
+     * @return  string
      *
      * @since   1.0
      */


### PR DESCRIPTION
### Summary of Changes
This PR has several changes from reports from phpstan.
1. The exception, which we are trying to catch, isn't thrown in the code. Instead an UnknownArchiveException is used and should thus be properly caught.
2. Several docblocks have been fixed.
3. `DatabaseImporter` got a signature for `getColumnSQL()`
4. `DatabaseInterface` got a signature for `getPrefix()`
5. `QueryInterface` got a signature for `quoteName()`