### PR TITLE
[2.0-dev] New option to set sql_big_selects on MySQL/MariaDB

### DIFF
--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -159,6 +159,28 @@ interface DatabaseInterface
 	public function isConnectionEncryptionSupported(): bool;
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool;
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string;
+
+	/**
 	 * Method to check whether the installed database version is supported by the database driver
 	 *
 	 * @return  boolean  True if the database version is supported

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -159,7 +159,7 @@ interface DatabaseInterface
 	public function isConnectionEncryptionSupported(): bool;
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -170,7 +170,7 @@ interface DatabaseInterface
 	public function getSqlBigSelects(): bool;
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -393,6 +393,36 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool
+	{
+		$this->connect();
+
+		return $this->setQuery('SELECT @@sql_big_selects;')->loadResult() == 1;
+	}
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string
+	{
+		return $this->setQuery('SELECT @@max_join_size;')->loadResult();
+	}
+
+	/**
 	 * Return the query string to create new Database.
 	 *
 	 * @param   stdClass  $options  Object used to pass user and database name to database driver. This object must have "db_name" and "db_user" set.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -122,10 +122,10 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['driver']       = 'mysql';
-		$options['charset']      = $options['charset'] ?? 'utf8';
-		$options['sqlModes']     = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelect'] = isset($options['sqlBigSelect']) ? (bool) $options['sqlBigSelect'] : false;
+		$options['driver']        = 'mysql';
+		$options['charset']       = $options['charset'] ?? 'utf8';
+		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : false;
 
 		$this->charset = $options['charset'];
 
@@ -236,7 +236,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		}
 
 		// If needed, enable SQL big selects
-		if ($this->options['sqlBigSelect'])
+		if ($this->options['sqlBigSelects'])
 		{
 			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
 		}

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -125,10 +125,12 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['driver']        = 'mysql';
 		$options['charset']       = $options['charset'] ?? 'utf8';
 		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 
-		// Set maxJoinSize only if sqlBigSelects is explicitely set to false.
-		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] === false ? $options['maxJoinSize'] : null;
+		// Ignore sqlBigSelects if maxJoinSize is explicitely set.
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) && !isset($options['maxJoinSize']) ? (bool) $options['sqlBigSelects'] : null;
+
+		// Ignore maxJoinSize if sqlBigSelects is explicitely enabled.
+		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] !== true ? $options['maxJoinSize'] : null;
 
 		$this->charset = $options['charset'];
 

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -122,9 +122,9 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['driver']        = 'mysql';
-		$options['charset']       = $options['charset'] ?? 'utf8';
-		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['driver']   = 'mysql';
+		$options['charset']  = $options['charset'] ?? 'utf8';
+		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
 		// Ignore sqlBigSelects if maxJoinSize is explicitely set.
 		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) && !isset($options['maxJoinSize']) ? (bool) $options['sqlBigSelects'] : null;

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -126,10 +126,10 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['charset']  = $options['charset'] ?? 'utf8';
 		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
-		// Ignore sqlBigSelects if maxJoinSize is explicitely set.
+		// Ignore sqlBigSelects if maxJoinSize is explicitly set.
 		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) && !isset($options['maxJoinSize']) ? (bool) $options['sqlBigSelects'] : null;
 
-		// Ignore maxJoinSize if sqlBigSelects is explicitely enabled.
+		// Ignore maxJoinSize if sqlBigSelects is explicitly enabled.
 		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] !== true ? $options['maxJoinSize'] : null;
 
 		$this->charset = $options['charset'];

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -122,9 +122,10 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['driver']   = 'mysql';
-		$options['charset']  = $options['charset'] ?? 'utf8';
-		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['driver']       = 'mysql';
+		$options['charset']      = $options['charset'] ?? 'utf8';
+		$options['sqlModes']     = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['sqlBigSelect'] = isset($options['sqlBigSelect']) ? (bool) $options['sqlBigSelect'] : false;
 
 		$this->charset = $options['charset'];
 
@@ -232,6 +233,12 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		if ($this->options['sqlModes'] !== [])
 		{
 			$this->connection->query('SET @@SESSION.sql_mode = \'' . implode(',', $this->options['sqlModes']) . '\';');
+		}
+
+		// If needed, enable SQL big selects
+		if ($this->options['sqlBigSelect'])
+		{
+			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
 		}
 
 		$this->setOption(\PDO::ATTR_EMULATE_PREPARES, true);

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -125,7 +125,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['driver']        = 'mysql';
 		$options['charset']       = $options['charset'] ?? 'utf8';
 		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : false;
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 
 		$this->charset = $options['charset'];
 
@@ -235,10 +235,10 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 			$this->connection->query('SET @@SESSION.sql_mode = \'' . implode(',', $this->options['sqlModes']) . '\';');
 		}
 
-		// If needed, enable SQL big selects
-		if ($this->options['sqlBigSelects'])
+		// Set sql_big_selects if value provided in options
+		if ($this->options['sqlBigSelects'] !== null)
 		{
-			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
+			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
 		}
 
 		$this->setOption(\PDO::ATTR_EMULATE_PREPARES, true);

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -127,6 +127,9 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 
+		// Set maxJoinSize only if sqlBigSelects is explicitely set to false.
+		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] === false ? $options['maxJoinSize'] : null;
+
 		$this->charset = $options['charset'];
 
 		/*
@@ -239,6 +242,12 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		if ($this->options['sqlBigSelects'] !== null)
 		{
 			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
+		}
+
+		// Set max_join_size if value provided in options
+		if ($this->options['maxJoinSize'] !== null)
+		{
+			$this->connection->query('SET @@SESSION.max_join_size = ' . $this->options['maxJoinSize'] . ';');
 		}
 
 		$this->setOption(\PDO::ATTR_EMULATE_PREPARES, true);

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -393,7 +393,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -409,7 +409,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -114,17 +114,17 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['host']         = $options['host'] ?? 'localhost';
-		$options['user']         = $options['user'] ?? 'root';
-		$options['password']     = $options['password'] ?? '';
-		$options['database']     = $options['database'] ?? '';
-		$options['select']       = isset($options['select']) ? (bool) $options['select'] : true;
-		$options['port']         = isset($options['port']) ? (int) $options['port'] : null;
-		$options['socket']       = $options['socket'] ?? null;
-		$options['utf8mb4']      = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
-		$options['sqlModes']     = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelect'] = isset($options['sqlBigSelect']) ? (bool) $options['sqlBigSelect'] : false;
-		$options['ssl']          = isset($options['ssl']) ? $options['ssl'] : [];
+		$options['host']          = $options['host'] ?? 'localhost';
+		$options['user']          = $options['user'] ?? 'root';
+		$options['password']      = $options['password'] ?? '';
+		$options['database']      = $options['database'] ?? '';
+		$options['select']        = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['port']          = isset($options['port']) ? (int) $options['port'] : null;
+		$options['socket']        = $options['socket'] ?? null;
+		$options['utf8mb4']       = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
+		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : false;
+		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
 
 		if ($options['ssl'] !== [])
 		{
@@ -335,7 +335,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		$this->options['sqlModes'] = explode(',', $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult());
 
 		// If needed, enable SQL big selects
-		if ($this->options['sqlBigSelect'])
+		if ($this->options['sqlBigSelects'])
 		{
 			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
 		}

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -114,16 +114,16 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['host']          = $options['host'] ?? 'localhost';
-		$options['user']          = $options['user'] ?? 'root';
-		$options['password']      = $options['password'] ?? '';
-		$options['database']      = $options['database'] ?? '';
-		$options['select']        = isset($options['select']) ? (bool) $options['select'] : true;
-		$options['port']          = isset($options['port']) ? (int) $options['port'] : null;
-		$options['socket']        = $options['socket'] ?? null;
-		$options['utf8mb4']       = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
-		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
+		$options['host']     = $options['host'] ?? 'localhost';
+		$options['user']     = $options['user'] ?? 'root';
+		$options['password'] = $options['password'] ?? '';
+		$options['database'] = $options['database'] ?? '';
+		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['port']     = isset($options['port']) ? (int) $options['port'] : null;
+		$options['socket']   = $options['socket'] ?? null;
+		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
+		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['ssl']      = isset($options['ssl']) ? $options['ssl'] : [];
 
 		if ($options['ssl'] !== [])
 		{

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -558,7 +558,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -574,7 +574,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -126,6 +126,9 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
 
+		// Set maxJoinSize only if sqlBigSelects is explicitely set to false.
+		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] === false ? $options['maxJoinSize'] : null;
+
 		if ($options['ssl'] !== [])
 		{
 			$options['ssl']['enable']             = isset($options['ssl']['enable']) ? $options['ssl']['enable'] : false;
@@ -338,6 +341,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		if ($this->options['sqlBigSelects'] !== null)
 		{
 			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
+		}
+
+		// Set max_join_size if value provided in options
+		if ($this->options['maxJoinSize'] !== null)
+		{
+			$this->connection->query('SET @@SESSION.max_join_size = ' . $this->options['maxJoinSize'] . ';');
 		}
 
 		// If auto-select is enabled select the given database.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -136,10 +136,10 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 			$options['ssl']['verify_server_cert'] = isset($options['ssl']['verify_server_cert']) ? $options['ssl']['verify_server_cert'] : null;
 		}
 
-		// Ignore sqlBigSelects if maxJoinSize is explicitely set.
+		// Ignore sqlBigSelects if maxJoinSize is explicitly set.
 		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) && !isset($options['maxJoinSize']) ? (bool) $options['sqlBigSelects'] : null;
 
-		// Ignore maxJoinSize if sqlBigSelects is explicitely enabled.
+		// Ignore maxJoinSize if sqlBigSelects is explicitly enabled.
 		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] !== true ? $options['maxJoinSize'] : null;
 
 		// Finalize initialisation.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -558,6 +558,36 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool
+	{
+		$this->connect();
+
+		return $this->setQuery('SELECT @@sql_big_selects;')->loadResult() == 1;
+	}
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string
+	{
+		return $this->setQuery('SELECT @@max_join_size;')->loadResult();
+	}
+
+	/**
 	 * Return the query string to create new Database.
 	 *
 	 * @param   \stdClass  $options  Object used to pass user and database name to database driver. This object must have "db_name" and "db_user" set.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -123,11 +123,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		$options['socket']        = $options['socket'] ?? null;
 		$options['utf8mb4']       = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
 		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
-
-		// Set maxJoinSize only if sqlBigSelects is explicitely set to false.
-		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] === false ? $options['maxJoinSize'] : null;
 
 		if ($options['ssl'] !== [])
 		{
@@ -139,6 +135,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 			$options['ssl']['cert']               = isset($options['ssl']['cert']) ? $options['ssl']['cert'] : null;
 			$options['ssl']['verify_server_cert'] = isset($options['ssl']['verify_server_cert']) ? $options['ssl']['verify_server_cert'] : null;
 		}
+
+		// Ignore sqlBigSelects if maxJoinSize is explicitely set.
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) && !isset($options['maxJoinSize']) ? (bool) $options['sqlBigSelects'] : null;
+
+		// Ignore maxJoinSize if sqlBigSelects is explicitely enabled.
+		$options['maxJoinSize'] = isset($options['maxJoinSize']) && $options['sqlBigSelects'] !== true ? $options['maxJoinSize'] : null;
 
 		// Finalize initialisation.
 		parent::__construct($options);

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -114,16 +114,17 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		];
 
 		// Get some basic values from the options.
-		$options['host']     = $options['host'] ?? 'localhost';
-		$options['user']     = $options['user'] ?? 'root';
-		$options['password'] = $options['password'] ?? '';
-		$options['database'] = $options['database'] ?? '';
-		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
-		$options['port']     = isset($options['port']) ? (int) $options['port'] : null;
-		$options['socket']   = $options['socket'] ?? null;
-		$options['utf8mb4']  = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
-		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['ssl']      = isset($options['ssl']) ? $options['ssl'] : [];
+		$options['host']         = $options['host'] ?? 'localhost';
+		$options['user']         = $options['user'] ?? 'root';
+		$options['password']     = $options['password'] ?? '';
+		$options['database']     = $options['database'] ?? '';
+		$options['select']       = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['port']         = isset($options['port']) ? (int) $options['port'] : null;
+		$options['socket']       = $options['socket'] ?? null;
+		$options['utf8mb4']      = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
+		$options['sqlModes']     = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
+		$options['sqlBigSelect'] = isset($options['sqlBigSelect']) ? (bool) $options['sqlBigSelect'] : false;
+		$options['ssl']          = isset($options['ssl']) ? $options['ssl'] : [];
 
 		if ($options['ssl'] !== [])
 		{
@@ -332,6 +333,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
 		// And read the real sql mode to mitigate changes in mysql > 5.7.+
 		$this->options['sqlModes'] = explode(',', $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult());
+
+		// If needed, enable SQL big selects
+		if ($this->options['sqlBigSelect'])
+		{
+			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
+		}
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -123,7 +123,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		$options['socket']        = $options['socket'] ?? null;
 		$options['utf8mb4']       = isset($options['utf8mb4']) ? (bool) $options['utf8mb4'] : false;
 		$options['sqlModes']      = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : false;
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
 		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
 
 		if ($options['ssl'] !== [])
@@ -334,10 +334,10 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		// And read the real sql mode to mitigate changes in mysql > 5.7.+
 		$this->options['sqlModes'] = explode(',', $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult());
 
-		// If needed, enable SQL big selects
-		if ($this->options['sqlBigSelects'])
+		// Set sql_big_selects if value provided in options
+		if ($this->options['sqlBigSelects'] !== null)
 		{
-			$this->connection->query('SET @@SESSION.sql_big_selects = 1;');
+			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
 		}
 
 		// If auto-select is enabled select the given database.

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -179,7 +179,7 @@ class PgsqlDriver extends PdoDriver
 	}
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -193,7 +193,7 @@ class PgsqlDriver extends PdoDriver
 	}
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -179,6 +179,34 @@ class PgsqlDriver extends PdoDriver
 	}
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string
+	{
+		return '';
+	}
+
+	/**
 	 * Internal function to get the name of the default schema for the current PostgreSQL connection.
 	 * That is the schema where tables are created by Joomla.
 	 *

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -211,6 +211,34 @@ class SqliteDriver extends PdoDriver
 	}
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string
+	{
+		return '';
+	}
+
+	/**
 	 * Shows the table CREATE statement that creates the given tables.
 	 *
 	 * Note: Doesn't appear to have support in SQLite

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -211,7 +211,7 @@ class SqliteDriver extends PdoDriver
 	}
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -225,7 +225,7 @@ class SqliteDriver extends PdoDriver
 	}
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -382,7 +382,7 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
-	 * Method to get the sql_big_selects system variable.
+	 * Method to get the sql_big_selects session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return false.
 	 *
@@ -396,7 +396,7 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
-	 * Method to get the max_join_size system variable.
+	 * Method to get the max_join_size session variable.
 	 *
 	 * If the connector doesn't support reporting this value please return an empty string.
 	 *

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -382,6 +382,34 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Method to get the sql_big_selects system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return false.
+	 *
+	 * @return  boolean  Whether sql_big_selects is enabled or not.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getSqlBigSelects(): bool
+	{
+		return false;
+	}
+
+	/**
+	 * Method to get the max_join_size system variable.
+	 *
+	 * If the connector doesn't support reporting this value please return an empty string.
+	 *
+	 * @return  string  max_join_size value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMaxJoinSize(): string
+	{
+		return '';
+	}
+
+	/**
 	 * Retrieves field information about the given tables.
 	 *
 	 * @param   mixed    $table     A table name


### PR DESCRIPTION
Pull Request for CMS issues https://github.com/joomla/joomla-cms/issues/39479 and https://github.com/joomla/joomla-cms/issues/41156 .

Alternative to PR #266 .

### Summary of Changes

This Pull Request (PR) adds 2 new options to the MySQLi and MySQL (PDO) drivers to set corresponding session variables after connecting to the database:
- Option `sqlBigSelects` for the `sql_big_selects` variable
- Option `maxJoinSize` for the `max_join_size` variable

When a particular option is not used, nothing is done, i.e. any value of the corresponding session variable will not be changed.

When the `maxJoinSize` option is used, the `sqlBigSelects` will not be used because MySQL and MariaDB will automatically set the `sql_big_selects` variable to `OFF` (0) when the `max_join_size` variable is set.

When the `sqlBigSelects` option is used and equal to `true`, the `maxJoinSize` will not be used because MySQL and MariaDB will ignore the value of the `max_join_size` variable when the `sql_big_selects` variable is set to `ON` (1).

The `maxJoinSize` option is defined as string and not as integer or float because the maximum value of `18446744073709551615` is beyond everything which we can handle as integer value in PHP and also not precise when using a float.

See following documentation:
- For MySQL https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_join_size
and https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_big_selects
- For MariaDB https://mariadb.com/kb/en/server-system-variables/#max_join_size
and https://mariadb.com/kb/en/server-system-variables/#sql_big_selects

This will allow clients like e.g. Joomla CMS to set `sql_big_selects` to `ON` or `max_join_size` to a suitable value when they run into the SQL error 1104 `The SELECT would examine more than MAX_JOIN_SIZE rows; check your WHERE and use SET SQL_BIG_SELECTS=1 or SET MAX_JOIN_SIZE=# if the SELECT is okay.`.

In addition to that, this PR adds the necessary functions to get the current values of these 2 session variables so they can be shown in a client, e.g. in the System Information of the Joomla CMS Administrator.

### Testing Instructions

Will be added soon. As long as this is not done, I will keep this PR in draft status.

### Documentation Changes Required

None.