### PR TITLE
Exporter: Handle NULL values properly

### DIFF
--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -302,9 +302,12 @@ abstract class DatabaseExporter
 				{
 					if (!in_array($key, $colblob))
 					{
-						if (is_null($value)) {
+						if (is_null($value))
+						{
 							$buffer[] = '    <field name="' . $key . '" value_is_null></field>';
-						} else {
+						}
+						else
+						{
 							$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
 						}
 					}

--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -302,7 +302,11 @@ abstract class DatabaseExporter
 				{
 					if (!in_array($key, $colblob))
 					{
-						$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
+						if (is_null($value)) {
+							$buffer[] = '    <field name="' . $key . '" value_is_null></field>';
+						} else {
+							$buffer[] = '    <field name="' . $key . '">' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</field>';
+						}
 					}
 					else
 					{

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -267,7 +267,11 @@ abstract class DatabaseImporter
 
 					foreach ($row->children() as $data)
 					{
-						$entry->{(string) $data['name']} = (string) $data;
+						if (isset($data['value_is_null'])) {
+							$entry->{(string)$data['name']} = null;
+						} else {
+							$entry->{(string)$data['name']} = (string)$data;
+						}
 					}
 
 					$this->db->insertObject($tableName, $entry);

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -269,11 +269,11 @@ abstract class DatabaseImporter
 					{
 						if (isset($data['value_is_null']))
 						{
-							$entry->{(string)$data['name']} = null;
+							$entry->{(string) $data['name']} = null;
 						}
 						else
 						{
-							$entry->{(string)$data['name']} = (string)$data;
+							$entry->{(string) $data['name']} = (string) $data;
 						}
 					}
 

--- a/src/DatabaseImporter.php
+++ b/src/DatabaseImporter.php
@@ -267,9 +267,12 @@ abstract class DatabaseImporter
 
 					foreach ($row->children() as $data)
 					{
-						if (isset($data['value_is_null'])) {
+						if (isset($data['value_is_null']))
+						{
 							$entry->{(string)$data['name']} = null;
-						} else {
+						}
+						else
+						{
 							$entry->{(string)$data['name']} = (string)$data;
 						}
 					}


### PR DESCRIPTION
### Summary of Changes
Right now we are not handling NULL values properly in export and import. We are effectively converting them from NULL to an empty string, which is actually a big problem. This PR adds a new attribute to the exported data `value_is_null`. If that attribute is set, on import it is replaced with NULL.

Right now, this also creates lots of errors in PHP 8.1, because htmlspecialchars() should not be called with a NULL value.

### Testing Instructions
On PHP 8.1 in Joomla call the CLI database exporter and see the notices. Apply the changes and instead of the notices see the new attribute. Works especially well in Joomla 5.

### Documentation Changes Required
This is a change in behavior, however for current backups the behavior would still be the same as before. Instead of a NULL value, you get an empty string. Also new exports would still be possible to be imported by old importers with the same behavior as before. The correct behavior to keep the NULL values would only work when both sides had this new feature and otherwise would simply behave like right now.