### PR TITLE
FIX  With Mariadb 11.1.2 ordering of table is broken #290

### DIFF
--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -196,29 +196,6 @@ trait MysqlQueryBuilder
     }
 
     /**
-     * Return the number of the current row.
-     *
-     * Usage:
-     * $query->select('id');
-     * $query->selectRowNumber('ordering,publish_up DESC', 'new_ordering');
-     * $query->from('#__content');
-     *
-     * @param   string  $orderBy           An expression of ordering for window function.
-     * @param   string  $orderColumnAlias  An alias for new ordering column.
-     *
-     * @return  $this
-     *
-     * @since   2.0.0
-     * @throws  \RuntimeException
-     */
-    public function selectRowNumber($orderBy, $orderColumnAlias)
-    {
-        $this->validateRowNumber($orderBy, $orderColumnAlias);
-
-        return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");
-    }
-
-    /**
      * Casts a value to a char.
      *
      * Ensure that the value is properly quoted before passing to the method.


### PR DESCRIPTION
Pull Request for Issue #290 
also see https://issues.joomla.org/tracker/joomla-cms/42333

### Summary of Changes
Removed   `public function selectRowNumber($orderBy, $orderColumnAlias)` in `MysqlQueryBuilder.php`
it already works within `DatabaseQuery.php` with window function `ROW_NUMBER()`
### Testing Instructions
see https://issues.joomla.org/tracker/joomla-cms/42333

### Documentation Changes Required
only valid for Joomla 5.x because MariaDB and MySQL miniumum 