### PR TITLE
[2.0-dev] New option to set sql_big_selects on MySQL/MariaDB

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -126,6 +126,9 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['charset']  = $options['charset'] ?? 'utf8';
 		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
 
+		// Use sqlBigSelects only if explicitly set.
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
+
 		$this->charset = $options['charset'];
 
 		/*
@@ -232,6 +235,12 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		if ($this->options['sqlModes'] !== [])
 		{
 			$this->connection->query('SET @@SESSION.sql_mode = \'' . implode(',', $this->options['sqlModes']) . '\';');
+		}
+
+		// Set sql_big_selects if value provided in options
+		if ($this->options['sqlBigSelects'] !== null)
+		{
+			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
 		}
 
 		$this->setOption(\PDO::ATTR_EMULATE_PREPARES, true);

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -136,6 +136,9 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 			$options['ssl']['verify_server_cert'] = isset($options['ssl']['verify_server_cert']) ? $options['ssl']['verify_server_cert'] : null;
 		}
 
+		// Use sqlBigSelects only if explicitly set.
+		$options['sqlBigSelects'] = isset($options['sqlBigSelects']) ? (bool) $options['sqlBigSelects'] : null;
+
 		// Finalize initialisation.
 		parent::__construct($options);
 	}
@@ -332,6 +335,12 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
 		// And read the real sql mode to mitigate changes in mysql > 5.7.+
 		$this->options['sqlModes'] = explode(',', $this->setQuery('SELECT @@SESSION.sql_mode;')->loadResult());
+
+		// Set sql_big_selects if value provided in options
+		if ($this->options['sqlBigSelects'] !== null)
+		{
+			$this->connection->query('SET @@SESSION.sql_big_selects = ' . ($this->options['sqlBigSelects'] ? '1' : '0') . ';');
+		}
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))


### PR DESCRIPTION
Pull Request for CMS issues https://github.com/joomla/joomla-cms/issues/39479 and https://github.com/joomla/joomla-cms/issues/41156 .

Alternative to PR #266 .

Replaces PR #284 .

### Summary of Changes

This Pull Request (PR) adds a new option `sqlBigSelects` to the MySQLi and MySQL (PDO) drivers to set the `sql_big_selects` session variable after connecting to the database.

When the new option is not used, i.e. not set in the connection parameters, then nothing is done, i.e. any value of the corresponding session variable will not be changed, and no additional SQL statement will be executed when connecting to the database.

This will allow Joomla CMS to set `sql_big_selects` to `ON` when they run into the SQL error 1104 `The SELECT would examine more than MAX_JOIN_SIZE rows; check your WHERE and use SET SQL_BIG_SELECTS=1 or SET MAX_JOIN_SIZE=# if the SELECT is okay.`.

The corresponding PR for the CMS to use the new option is https://github.com/joomla/joomla-cms/pull/42557 .

This will only allow to fix the mentioned CMS issues. For providing methods for the CMS to display the value of the `sql_big_selects` in system information I have created PR #294 for the 3.x-dev branch.

### Testing Instructions

Follow the testing instructions of the CMS PR https://github.com/joomla/joomla-cms/pull/42557 .

### Documentation Changes Required

None.