### PR TITLE
[3.x-dev] New methods to get bool and string session variables

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1893,4 +1893,34 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 
         return true;
     }
+
+    /**
+     * Get value of boolean session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  boolean|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarBool($name)
+    {
+        return null;
+    }
+
+    /**
+     * Get value of string session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarString($name)
+    {
+        return null;
+    }
 }

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -616,4 +616,28 @@ interface DatabaseInterface
      * @throws  \RuntimeException
      */
     public function updateObject($table, &$object, $key, $nulls = false);
+
+    /**
+     * Get value of boolean session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  boolean|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarBool($name);
+
+    /**
+     * Get value of string session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarString($name);
 }

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -804,4 +804,42 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
             }
         }
     }
+
+    /**
+     * Get value of boolean session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  boolean|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarBool($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT @@' . $name . ';')->loadResult();
+
+        return $result === null ? null : (bool) $result;
+    }
+
+    /**
+     * Get value of string session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarString($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT @@' . $name . ';')->loadResult();
+
+        return $result === null ? null : (string) $result;
+    }
 }

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -1082,4 +1082,42 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
         return $this->nullDate;
     }
+
+    /**
+     * Get value of boolean session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  boolean|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarBool($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT @@' . $name . ';')->loadResult();
+
+        return $result === null ? null : (bool) $result;
+    }
+
+    /**
+     * Get value of string session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarString($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT @@' . $name . ';')->loadResult();
+
+        return $result === null ? null : (string) $result;
+    }
 }

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -1063,4 +1063,42 @@ class PgsqlDriver extends PdoDriver
 
         return $data;
     }
+
+    /**
+     * Get value of boolean session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  boolean|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarBool($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT current_setting(\'' . $name . '\', true);')->loadResult();
+
+        return $result === null ? null : (bool) $result;
+    }
+
+    /**
+     * Get value of string session variable with the given name.
+     * Returns null if database doesn't support session variables or variable doesn't exist.
+     *
+     * @param   string  $name  The name of the session variable.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getSessionVarString($name)
+    {
+        $this->connect();
+
+        $result = $this->setQuery('SELECT current_setting(\'' . $name . '\', true);')->loadResult();
+
+        return $result === null ? null : (string) $result;
+    }
 }


### PR DESCRIPTION
Pull Request for new feature

Related to PR #293 .

Related CMS issues https://github.com/joomla/joomla-cms/issues/39479 and https://github.com/joomla/joomla-cms/issues/41156 .

### Summary of Changes

This Pull Request (PR) adds 2 new methods to get the values of session variables to the database drivers, one for boolean and one for string session variables.

This could be extended in future by methods to get array session variables like e.g. `sql_mode`.

For integer session variables this would not be easily applicable because the value range of integer session variables at least on MySQL and MariaDB exceeds everything which can be handled in PHP with integer or float variables without any maths extension. But they can be handled like strings.

This PR will allow Joomla CMS to show the values of the `sql_big_selects` and `max_join_size` variables in its system information.

The corresponding PR for the CMS is https://github.com/joomla/joomla-cms/pull/42559 .

### Testing Instructions

Will be added soon.

### Documentation Changes Required

None.