### PR TITLE
adding ability to zip export of multiple tables

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -118,6 +118,9 @@ class ExportCommand extends AbstractCommand
 
             /** @var Zip $zipArchive */
             $zipArchive = (new Archive())->getAdapter('zip');
+
+            $filenames = [];
+            $zipFilesArray = [];
         }
 
         foreach ($tables as $table) {
@@ -137,12 +140,18 @@ class ExportCommand extends AbstractCommand
                 File::write($filename, $data);
 
                 if ($zip) {
-                    $zipFilesArray = [['name' => $table . '.xml', 'data' => $data]];
-                    $zipArchive->create($zipFile, $zipFilesArray);
-                    File::delete($filename);
+                    $zipFilesArray[] = ['name' => $table . '.xml', 'data' => $data];
+                    $filenames[] = $filename;
                 }
 
                 $symfonyStyle->text(sprintf('Exported data for %s in %d seconds', $table, round(microtime(true) - $taskTime, 3)));
+            }
+        }
+
+        if ($zip) {
+            $zipArchive->create($zipFile, $zipFilesArray);
+            foreach ($filenames as $fname) {
+                File::delete($fname);
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #298 

### Summary of Changes

- `php ./cli/joomla.php database:export --folder ./tmp --zip` is now able to export all tables and compress them in a single zip file

### Testing Instructions

- [ ] Have running Joomla installation
- [ ] Run `php ./cli/joomla.php database:export --folder ./tmp --zip`
- [ ] Assert in ./tmp folder there's a zip file that contains all tables in corresponding xml files

### Documentation Changes Required

No documentation changes required, the current on available on https://docs.joomla.org/J4.x:CLI_Database_Exporter_Importer already states, that `php cli/joomla.php database:export --zip` should "export the database as .zip file.