### PR TITLE
[3.x] Use row_number window function on MariaDB >= 11.0

### DIFF
--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -213,11 +213,11 @@ trait MysqlQueryBuilder
      */
     public function selectRowNumber($orderBy, $orderColumnAlias)
     {
-        $this->validateRowNumber($orderBy, $orderColumnAlias);
-
         if ($this->db->isMariaDb() && version_compare($this->db->getVersion(), '11.0.0', '>=')) {
-            return $this->select("ROW_NUMBER() OVER (ORDER BY $orderBy) AS $orderColumnAlias");
+            return parent::selectRowNumber($orderBy, $orderColumnAlias);
         }
+
+        $this->validateRowNumber($orderBy, $orderColumnAlias);
 
         return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");
     }

--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -215,6 +215,10 @@ trait MysqlQueryBuilder
     {
         $this->validateRowNumber($orderBy, $orderColumnAlias);
 
+        if ($this->db->isMariaDb() && version_compare($this->db->getVersion(), '11.0.0', '>=')) {
+            return $this->select("ROW_NUMBER() OVER (ORDER BY $orderBy) AS $orderColumnAlias");
+        }
+
         return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");
     }
 

--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -210,9 +210,14 @@ trait MysqlQueryBuilder
      *
      * @since   2.0.0
      * @throws  \RuntimeException
+     *
+     * @todo  Remove this method when the database version requirements have been raised
+     *        to >= 8.0.0 for MySQL and >= 10.2.0 for MariaDB so the ROW_NUMBER() window
+     *        function can be used in any case.
      */
     public function selectRowNumber($orderBy, $orderColumnAlias)
     {
+        // Use parent method with ROW_NUMBER() window function on MariaDB 11.0.0 and newer.
         if ($this->db->isMariaDb() && version_compare($this->db->getVersion(), '11.0.0', '>=')) {
             return parent::selectRowNumber($orderBy, $orderColumnAlias);
         }


### PR DESCRIPTION
Pull Request for Issue #290 .

Alternative to PR #291 .

See also https://github.com/joomla/joomla-cms/issues/42333 .

### Summary of Changes

Use the `ROW_NUMBER()` window function for MariaDB 11.0.0 and newer.

That function is supported on MySQL since version 8.0.0, too, and on MariaDB since version 10.2.0, but in order to play safe this PR only changes that for MariaDB 11.0.0 and newer, as for older MariaDB versions or MySQL the old code still seems to work. I've added a `@todo` comment to the `selectRowNumber` method and a comment to the version check for MariaDB 11.0.0 to make that clear.

I could not find any unit tests for the `selectRowNumber` method, so no changes on unit tests with this PR.

### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/42333 .

### Documentation Changes Required

None.