### PR TITLE
Add support for duplicate named query parameters to the mysqli driver

### DIFF
--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests\Mysql;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Database\Mysqli\MysqliStatement;
+use Joomla\Test\DatabaseTestCase;
+
+class MysqlPreparedStatementTest extends DatabaseTestCase
+{
+    /**
+     * This method is called before the first test of this test class is run.
+     *
+     * @return  void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!static::$connection || static::$connection->getName() !== 'mysql') {
+            self::markTestSkipped('MySQL database not configured.');
+        }
+    }
+
+    /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/mysql.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load MySQL database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
+     * Tears down the fixture.
+     *
+     * This method is called after a test is executed.
+     */
+    protected function tearDown(): void
+    {
+        foreach (static::$connection->getTableList() as $table) {
+            static::$connection->dropTable($table);
+        }
+    }
+
+    /**
+     * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithDuplicateKey()
+    {
+        $dummyValue = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search',
+            ])
+            ->bind(':search', $dummyValue);
+
+        static::$connection->setQuery($query)->execute();
+    }
+
+    /**
+     * Regression test to ensure running queries with named parameters appearing once didn't break.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithSingleKey()
+    {
+        $dummyValue = 'test';
+        $dummyValue2 = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search2',
+            ])
+            ->bind(':search', $dummyValue)
+            ->bind(':search2', $dummyValue2);
+
+        static::$connection->setQuery($query)->execute();
+    }
+}

--- a/Tests/Mysqli/MysqliPreparedStatementTest.php
+++ b/Tests/Mysqli/MysqliPreparedStatementTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests\Mysqli;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Database\Mysqli\MysqliStatement;
+use Joomla\Test\DatabaseTestCase;
+
+class MysqliPreparedStatementTest extends DatabaseTestCase
+{
+    /**
+     * This method is called before the first test of this test class is run.
+     *
+     * @return  void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!static::$connection || static::$connection->getName() !== 'mysqli') {
+            self::markTestSkipped('MySQL database not configured.');
+        }
+    }
+
+    /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/mysql.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load MySQL database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
+     * Tears down the fixture.
+     *
+     * This method is called after a test is executed.
+     */
+    protected function tearDown(): void
+    {
+        foreach (static::$connection->getTableList() as $table) {
+            static::$connection->dropTable($table);
+        }
+    }
+
+
+    /**
+     * Make sure the mysqli driver correctly maps named query parameters appearing more than once.
+     */
+    public function testPrepareParameterKeyMappingWithDuplicateKey()
+    {
+        $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search';
+        $mysqliStatementObject = new MysqliStatement(static::$connection->getConnection(), $statement);
+        $rawQuery = $mysqliStatementObject->prepareParameterKeyMapping($statement);
+
+        $this->assertEquals(
+            "SELECT * FROM dbtest WHERE `title` LIKE ? OR `description` LIKE ?",
+            $rawQuery
+        );
+
+        $refObject = new \ReflectionObject($mysqliStatementObject);
+        $refMapping = $refObject->getProperty('parameterKeyMapping');
+        /** @noinspection PhpExpressionResultUnusedInspection */
+        $refMapping->setAccessible(true);
+        $parameterKeyMapping = $refMapping->getValue($mysqliStatementObject);
+
+        $this->assertEquals(
+            [
+                ':search' => [0, 1],
+            ],
+            $parameterKeyMapping
+        );
+    }
+
+    /**
+     * Regression test to ensure mapping query parameters appearing once didn't break.
+     */
+    public function testPrepareParameterKeyMappingWithSingleKey()
+    {
+        $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search2';
+        $mysqliStatementObject = new MysqliStatement(static::$connection->getConnection(), $statement);
+        $rawQuery = $mysqliStatementObject->prepareParameterKeyMapping($statement);
+
+        $this->assertEquals(
+            "SELECT * FROM dbtest WHERE `title` LIKE ? OR `description` LIKE ?",
+            $rawQuery
+        );
+
+        $refObject = new \ReflectionObject($mysqliStatementObject);
+        $refMapping = $refObject->getProperty('parameterKeyMapping');
+        /** @noinspection PhpExpressionResultUnusedInspection */
+        $refMapping->setAccessible(true);
+        $parameterKeyMapping = $refMapping->getValue($mysqliStatementObject);
+
+        $this->assertEquals(
+            [
+                ':search' => 0,
+                ':search2' => 1,
+            ],
+            $parameterKeyMapping
+        );
+    }
+
+    /**
+     * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithDuplicateKey()
+    {
+        $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search';
+        $mysqliStatementObject = new MysqliStatement(static::$connection->getConnection(), $statement);
+        $dummyValue = 'test';
+        $mysqliStatementObject->bindParam(':search', $dummyValue);
+
+        $mysqliStatementObject->execute();
+    }
+
+    /**
+     * Regression test to ensure running queries with named parameters appearing once didn't break.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithSingleKey()
+    {
+        $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search2';
+        $mysqliStatementObject = new MysqliStatement(static::$connection->getConnection(), $statement);
+        $dummyValue = 'test';
+        $dummyValue2 = 'test';
+        $mysqliStatementObject->bindParam(':search', $dummyValue);
+        $mysqliStatementObject->bindParam(':search2', $dummyValue);
+
+        $mysqliStatementObject->execute();
+    }
+}

--- a/Tests/Pgsql/PgsqlPreparedStatementTest.php
+++ b/Tests/Pgsql/PgsqlPreparedStatementTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests\Pgsql;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Test\DatabaseTestCase;
+
+class PgsqlPreparedStatementTest extends DatabaseTestCase
+{
+    /**
+     * This method is called before the first test of this test class is run.
+     *
+     * @return  void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $manager = static::getDatabaseManager();
+
+        $connection = $manager->getConnection();
+        $manager->dropDatabase();
+        $manager->createDatabase();
+        $connection->select($manager->getDbName());
+
+        static::$connection = $connection;
+    }
+
+    /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/pgsql.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load PostgreSQL database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
+     * Tears down the fixture.
+     *
+     * This method is called after a test is executed.
+     */
+    protected function tearDown(): void
+    {
+        foreach (static::$connection->getTableList() as $table) {
+            static::$connection->dropTable($table);
+        }
+    }
+
+    /**
+     * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithDuplicateKey()
+    {
+        $dummyValue = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search',
+            ], 'OR')
+            ->bind(':search', $dummyValue);
+
+        static::$connection->setQuery($query)->execute();
+    }
+
+    /**
+     * Regression test to ensure running queries with named parameters appearing once didn't break.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithSingleKey()
+    {
+        $dummyValue = 'test';
+        $dummyValue2 = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search2',
+            ])
+            ->bind(':search', $dummyValue)
+            ->bind(':search2', $dummyValue2);
+
+        static::$connection->setQuery($query)->execute();
+    }
+}

--- a/Tests/Sqlite/SqlitePreparedStatementTest.php
+++ b/Tests/Sqlite/SqlitePreparedStatementTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests\Sqlite;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Test\DatabaseTestCase;
+
+class SqlitePreparedStatementTest extends DatabaseTestCase
+{
+    /**
+     * This method is called before the first test of this test class is run.
+     *
+     * @return  void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $manager = static::getDatabaseManager();
+
+        $connection = $manager->getConnection();
+        $manager->dropDatabase();
+        $manager->createDatabase();
+        $connection->select($manager->getDbName());
+
+        static::$connection = $connection;
+    }
+
+    /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/sqlite.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load SQLite database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
+     * Tears down the fixture.
+     *
+     * This method is called after a test is executed.
+     */
+    protected function tearDown(): void
+    {
+        $tables = array_filter(
+            static::$connection->getTableList(),
+            function (string $table): bool {
+                return $table !== 'sqlite_sequence';
+            }
+        );
+
+        foreach ($tables as $table) {
+            static::$connection->dropTable($table);
+        }
+    }
+
+    /**
+     * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithDuplicateKey()
+    {
+        $dummyValue = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search',
+            ], 'OR')
+            ->bind(':search', $dummyValue);
+
+        static::$connection->setQuery($query)->execute();
+    }
+
+    /**
+     * Regression test to ensure running queries with named parameters appearing once didn't break.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithSingleKey()
+    {
+        $dummyValue = 'test';
+        $dummyValue2 = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search2',
+            ])
+            ->bind(':search', $dummyValue)
+            ->bind(':search2', $dummyValue2);
+
+        static::$connection->setQuery($query)->execute();
+    }
+}

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2021 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Database\Tests\Sqlsrv;
+
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
+use Joomla\Test\DatabaseTestCase;
+
+class SqlsrvPreparedStatementTest extends DatabaseTestCase
+{
+    /**
+     * This method is called before the first test of this test class is run.
+     *
+     * @return  void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        $manager = static::getDatabaseManager();
+
+        $connection = $manager->getConnection();
+        $manager->dropDatabase();
+        $manager->createDatabase();
+        $connection->select($manager->getDbName());
+
+        static::$connection = $connection;
+    }
+
+    /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/sqlsrv.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load MS SQL Server database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
+     * Tears down the fixture.
+     *
+     * This method is called after a test is executed.
+     */
+    protected function tearDown(): void
+    {
+        foreach (static::$connection->getTableList() as $table) {
+            static::$connection->dropTable($table);
+        }
+    }
+
+    /**
+     * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithDuplicateKey()
+    {
+        $dummyValue = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search',
+            ], 'OR')
+            ->bind(':search', $dummyValue);
+
+        static::$connection->setQuery($query)->execute();
+    }
+
+    /**
+     * Regression test to ensure running queries with named parameters appearing once didn't break.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testPreparedStatementWithSingleKey()
+    {
+        $dummyValue = 'test';
+        $dummyValue2 = 'test';
+        $query = static::$connection->getQuery(true);
+        $query->select('*')
+            ->from($query->quoteName('dbtest'))
+            ->where([
+                $query->quoteName('title') . ' LIKE :search',
+                $query->quoteName('description') . ' LIKE :search2',
+            ])
+            ->bind(':search', $dummyValue)
+            ->bind(':search2', $dummyValue2);
+
+        static::$connection->setQuery($query)->execute();
+    }
+}

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -199,8 +199,7 @@ class MysqliStatement implements StatementInterface
 
                     if (isset($mapping[$match[0]])) {
                         $mapping[$match[0]] = is_array($mapping[$match[0]]) ? $mapping[$match[0]] : [$mapping[$match[0]]];
-
-                        array_push($mapping[$match[0]], \count($mapping));
+                        $mapping[$match[0]][] = \count($mapping);
 
                     } else {
                         $mapping[$match[0]] = \count($mapping);

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -197,8 +197,15 @@ class MysqliStatement implements StatementInterface
                         $literal .= substr($substring, 0, $match[1]);
                     }
 
-                    $mapping[$match[0]]     = \count($mapping);
-                    $endOfPlaceholder       = $match[1] + strlen($match[0]);
+                    if (isset($mapping[$match[0]])) {
+                        $mapping[$match[0]] = is_array($mapping[$match[0]]) ? $mapping[$match[0]] : [$mapping[$match[0]]];
+
+                        array_push($mapping[$match[0]], \count($mapping));
+
+                    } else {
+                        $mapping[$match[0]] = \count($mapping);
+                    }
+                    $endOfPlaceholder = $match[1] + strlen($match[0]);
                     $beginOfNextPlaceholder = $matches[0][$i + 1][1] ?? strlen($substring);
                     $beginOfNextPlaceholder -= $endOfPlaceholder;
                     $literal .= '?' . substr($substring, $endOfPlaceholder, $beginOfNextPlaceholder);
@@ -371,8 +378,17 @@ class MysqliStatement implements StatementInterface
 
             if (!empty($this->parameterKeyMapping)) {
                 foreach ($this->bindedValues as $key => &$value) {
-                    $params[$this->parameterKeyMapping[$key]] =& $value;
-                    $types[$this->parameterKeyMapping[$key]]  = $this->typesKeyMapping[$key];
+                    $paramKey = $this->parameterKeyMapping[$key];
+
+                    if (is_scalar($this->parameterKeyMapping[$key])) {
+                        $params[$paramKey] =& $value;
+                        $types[$paramKey]  = $this->typesKeyMapping[$key];
+                    } else {
+                        foreach ($paramKey as $currentKey) {
+                            $params[$currentKey] =& $value;
+                            $types[$currentKey]  = $this->typesKeyMapping[$key];
+                        }
+                    }
                 }
             } else {
                 foreach ($this->bindedValues as $key => &$value) {

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -88,6 +88,7 @@ class SqlsrvDriver extends DatabaseDriver
         $options['password'] = $options['password'] ?? '';
         $options['database'] = $options['database'] ?? '';
         $options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
+        $options['encrypt']  = isset($options['encrypt']) ? (bool) $options['encrypt'] : true;
 
         // Finalize initialisation
         parent::__construct($options);
@@ -119,6 +120,7 @@ class SqlsrvDriver extends DatabaseDriver
             'pwd'                  => $this->options['password'],
             'CharacterSet'         => 'UTF-8',
             'ReturnDatesAsStrings' => true,
+            'Encrypt'              => $this->options['encrypt']
         ];
 
         // Attempt to connect to the server.

--- a/src/Sqlsrv/SqlsrvStatement.php
+++ b/src/Sqlsrv/SqlsrvStatement.php
@@ -202,7 +202,14 @@ class SqlsrvStatement implements StatementInterface
                         $literal .= substr($substring, 0, $match[1]);
                     }
 
-                    $mapping[$match[0]]     = \count($mapping);
+                    if (isset($mapping[$match[0]])) {
+                        $mapping[$match[0]] = is_array($mapping[$match[0]]) ? $mapping[$match[0]] : [$mapping[$match[0]]];
+                        $mapping[$match[0]][] = \count($mapping);
+
+                    } else {
+                        $mapping[$match[0]] = \count($mapping);
+                    }
+
                     $endOfPlaceholder       = $match[1] + strlen($match[0]);
                     $beginOfNextPlaceholder = $matches[0][$i + 1][1] ?? strlen($substring);
                     $beginOfNextPlaceholder -= $endOfPlaceholder;
@@ -484,7 +491,15 @@ class SqlsrvStatement implements StatementInterface
             }
 
             if (isset($this->parameterKeyMapping[$key])) {
-                $params[$this->parameterKeyMapping[$key]] = $variable;
+                $paramKey = $this->parameterKeyMapping[$key];
+
+                if (is_scalar($this->parameterKeyMapping[$key])) {
+                    $params[$paramKey] = $variable;
+                } else {
+                    foreach ($paramKey as $currentKey) {
+                        $params[$currentKey] = $variable;
+                    }
+                }
             } else {
                 $params[] = $variable;
             }


### PR DESCRIPTION
### Summary of Changes

Added support for duplicate named query parameters to the `mysqli` and `sqlsrv` drivers. What I mean is something like this:

```mysql
SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search
```

Note how `:search` is used _twice_ in the above query.

This had always worked with all PDO-based drivers: `mysql`, `pgsql`, and `sqlite`. This feature was added to PDO back in PHP 5.2.1.

The two non-PDO drivers use userland code to emulate prepared statements, but the userland code didn't support multiple uses of the same named parameter.

### Testing Instructions

Run the tests contained in this PR before and after applying the patch for each of the `mysql`, `mysqli`, `sqlite`, `sqlsrv`, and `pgsql` database drivers.

Before the PR changes are applied:

* `mysql`: Fails with an exception about mismatched number of arguments
* `mysqli`: Works
* `pgsql`: Works
* `sqlite`: Works
* `sqlsrv`: Fails with an exception about mismatched number of arguments

After the PR changes are applied:

* `mysql`: **Works**
* `mysqli`: Works
* `pgsql`: Works
* `sqlite`: Works
* `sqlsrv`: **Works**

### Documentation Changes Required

None.

### Notes

I have inadvertently been using this feature since Joomla! 4.0 beta 2 was released with the `mysql` driver. It was only when I received bug reports from users using the `mysqli` driver I figured out something is wrong, which is how I ended up with this PR.

PDO has supported multiple uses of the same named parameter since PHP 5.2.1. However, because many people remembered the _prior_ situation you will see a lot of wrong information online stating that PDO does not support this feature.

I have tested the `mysql` and `mysqli` drivers using MySQL 8 installed directly on my host OS. I tested `sqlite` directly, using an in-memory database as per the default configuration. I tested `pgsql` against a Dockerized PostgreSQL server, using the `postgresql:latest` image. I tested `sqlsrv` against a Dockerized Microsoft SQL Server Express 2019 installation -- but I had to change `\Joomla\Database\Sqlsrv\SqlsrvDriver::connect` to set `Encrypt` to `false`, since the Dockerized server does not have a valid TLS certificate. All my tests have been against PHP 8.3 using the PHPUnit version pulled into the `vendor` folder on `composer install` to keep things clean and simple.

The current MS SQL Server driver uses the `sqlsrv` PHP extension. If it used the `pdo_sqlsrv` extension, available since PHP 7.1, it wouldn't need a custom SqlsrvStatement class, nor would it have a problem with this feature to begin with. Maybe it's worth adding a `pdosqlsrv` driver?