### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -9,8 +9,8 @@ namespace Joomla\Database\Tests;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
-use Joomla\Database\ParameterType;
 use Joomla\Database\Exception\UnknownTypeException;
+use Joomla\Database\ParameterType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -8,7 +8,6 @@ namespace Joomla\Database\Tests\Mysql;
 
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
-use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
 
 class MysqlPreparedStatementTest extends DatabaseTestCase

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -16,9 +16,9 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Filesystem\File;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Console command for exporting the database

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1721,7 +1721,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @since   2.0.0
      */
-    public function setMonitor(QueryMonitorInterface $monitor = null)
+    public function setMonitor(?QueryMonitorInterface $monitor = null)
     {
         $this->monitor = $monitor;
 

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -303,7 +303,7 @@ abstract class DatabaseQuery implements QueryInterface
      *
      * @since   1.0
      */
-    public function __construct(DatabaseInterface $db = null)
+    public function __construct(?DatabaseInterface $db = null)
     {
         $this->db = $db;
     }

--- a/src/Exception/ConnectionFailureException.php
+++ b/src/Exception/ConnectionFailureException.php
@@ -25,7 +25,7 @@ class ConnectionFailureException extends \RuntimeException
      *
      * @since   2.0.0
      */
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?\Exception $previous = null)
     {
         // PDO uses strings for exception codes, PHP forces numeric codes, so "force" the string code to be used
         parent::__construct($message, 0, $previous);

--- a/src/Exception/ExecutionFailureException.php
+++ b/src/Exception/ExecutionFailureException.php
@@ -34,7 +34,7 @@ class ExecutionFailureException extends \RuntimeException
      *
      * @since   1.5.0
      */
-    public function __construct($query, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct($query, $message = '', $code = 0, ?\Exception $previous = null)
     {
         // PDO uses strings for exception codes, PHP forces numeric codes, so "force" the string code to be used
         parent::__construct($message, 0, $previous);

--- a/src/Exception/PrepareStatementFailureException.php
+++ b/src/Exception/PrepareStatementFailureException.php
@@ -25,7 +25,7 @@ class PrepareStatementFailureException extends \RuntimeException
      *
      * @since   2.0.0
      */
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?\Exception $previous = null)
     {
         // PDO uses strings for exception codes, PHP forces numeric codes, so "force" the string code to be used
         parent::__construct($message, 0, $previous);

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -10,9 +10,9 @@
 namespace Joomla\Database;
 
 use Joomla\Database\Exception\QueryTypeAlreadyDefinedException;
+use Joomla\Database\Exception\UnknownTypeException;
 use Joomla\Database\Query\LimitableInterface;
 use Joomla\Database\Query\PreparableInterface;
-use Joomla\Database\Exception\UnknownTypeException;
 
 /**
  * Joomla Framework Query Building Interface.

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -120,7 +120,7 @@ class SqlsrvDriver extends DatabaseDriver
             'pwd'                  => $this->options['password'],
             'CharacterSet'         => 'UTF-8',
             'ReturnDatesAsStrings' => true,
-            'Encrypt'              => $this->options['encrypt']
+            'Encrypt'              => $this->options['encrypt'],
         ];
 
         // Attempt to connect to the server.


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no