### PR TITLE
[3.x] Use row_number window function on MySQL and MariaDB if supported

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -134,6 +134,14 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     protected $options;
 
     /**
+     * True if the database engine supports the ROW_NUMBER() window function.
+     *
+     * @var    boolean
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $rownum = true;
+
+    /**
      * The current SQL statement to execute.
      *
      * @var    mixed
@@ -1039,6 +1047,19 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      * @throws  \RuntimeException
      */
     abstract public function getTableCreate($tables);
+
+   /**
+     * Determine whether or not the database engine supports the ROW_NUMBER() window function.
+     *
+     * @return  boolean  True if the database engine supports supports the ROW_NUMBER()
+     *                   window function, false if not.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function hasRowNumberSupport(): bool
+    {
+        return $this->rownum;
+    }
 
     /**
      * Determine whether or not the database engine supports UTF-8 character encoding.

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -297,6 +297,16 @@ interface DatabaseInterface
     public function getVersion();
 
     /**
+     * Determine whether or not the database engine supports the ROW_NUMBER() window function.
+     *
+     * @return  boolean  True if the database engine supports supports the ROW_NUMBER()
+     *                   window function, false if not.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function hasRowNumberSupport(): bool;
+
+    /**
      * Determine whether or not the database engine supports UTF-8 character encoding.
      *
      * @return  boolean  True if the database engine supports UTF-8 character encoding.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -200,6 +200,11 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 
         $this->mariadb = stripos($serverVersion, 'mariadb') !== false;
 
+        // The ROW_NUMBER() window function is supported on MariaDB >= 10.2.0 and MySQL >= 8.0.0
+        $this->rownum
+            = $this->mariadb && version_compare($serverVersion, '10.2.0', '>=')
+            || !$this->mariadb && version_compare($serverVersion, '8.0.0', '>=');
+
         if ($this->utf8mb4) {
             // At this point we know the client supports utf8mb4.  Now we must check if the server supports utf8mb4 as well.
             $this->utf8mb4 = version_compare($serverVersion, '5.5.3', '>=');

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -314,6 +314,13 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
         $this->mariadb = stripos($this->connection->server_info, 'mariadb') !== false;
 
+        $serverVersion = $this->getVersion();
+
+        // The ROW_NUMBER() window function is supported on MariaDB >= 10.2.0 and MySQL >= 8.0.0
+        $this->rownum
+            = $this->mariadb && version_compare($serverVersion, '10.2.0', '>=')
+            || !$this->mariadb && version_compare($serverVersion, '8.0.0', '>=');
+
         $this->utf8mb4 = $this->serverClaimsUtf8mb4Support();
 
         // Set character sets (needed for MySQL 4.1.2+ and MariaDB).

--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -210,9 +210,18 @@ trait MysqlQueryBuilder
      *
      * @since   2.0.0
      * @throws  \RuntimeException
+     *
+     * @todo  Remove this method when the database version requirements have been raised
+     *        to >= 8.0.0 for MySQL and >= 10.2.0 for MariaDB so the ROW_NUMBER() window
+     *        function can be used in any case.
      */
     public function selectRowNumber($orderBy, $orderColumnAlias)
     {
+        // Use parent method with ROW_NUMBER() window function if supported by the database engine.
+        if ($this->db->hasRowNumberSupport()) {
+            return parent::selectRowNumber($orderBy, $orderColumnAlias);
+        }
+
         $this->validateRowNumber($orderBy, $orderColumnAlias);
 
         return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");


### PR DESCRIPTION
Pull Request for Issue #290 .

Alternative to PRs #291 and #300 .

See also https://github.com/joomla/joomla-cms/issues/42333 .

### Summary of Changes

Use the `ROW_NUMBER()` window function in the `selectRowNumber` method on MySQL >= 8.0.0 and MariaDB >= 10.2.0.

Different to PR #300 , this one here extends the database driver and database interface by the new method `hasRowNumberSupport` to tell if the database engine supports the `ROW_NUMBER()` window function, and the `MysqlQueryBuilder` uses that method. The new method might be used by 3rd party extensions of the CMS, too.

The MySQL drivers set a new property `rownum` when connecting to the database, and the new `hasRowNumberSupport` method just returns the value of that property, so the checks for MariaDB and the version are not done with every call to the `selectRowNumber` query method like it is done in PR #300 , so it should be a bit faster.

Also different to PR #300 , this one here uses the `ROW_NUMBER()` window function whenever supported, i.e. as said with MySQL >= 8.0.0 and MariaDB >= 10.2.0. The other PR #300 does that only for MariaDB >= 11.0.0 in order to play safe and because issues where only reported for MariaDB 11, but I think that's not really necessary. Using the `ROW_NUMBER()` is more reliable than the "hack" with the SQL variable (`@rownum`).

I could not find any unit tests for the `selectRowNumber` method, so no changes on unit tests with this PR.

### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/42333 .

### Documentation Changes Required

None.