### PR TITLE
[3.x] UPD deprecated getQuery(true)

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -988,10 +988,12 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     public function getQuery($new = false)
     {
         if ($new) {
+            $key = array_search(__FUNCTION__, array_column(debug_backtrace(), 'function'));
+            $btfile = 'Found in: ' . debug_backtrace()[$key]['file'] . ':' . debug_backtrace()[$key]['line'];
             trigger_deprecation(
                 'joomla/database',
                 '2.2.0',
-                'The parameter $new is deprecated and will be removed in 4.0, use %s::createQuery() instead.',
+                __FUNCTION__ . " with a \$new (true) parameter is deprecated and will be removed in 4.0, use %s::createQuery() instead. $btfile",
                 self::class
             );
 
@@ -1748,7 +1750,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 
         if (\is_string($query)) {
             // Allows taking advantage of bound variables in a direct query:
-            $query = $this->getQuery(true)->setQuery($query);
+            $query = $this->createQuery()->setQuery($query);
         } elseif (!($query instanceof QueryInterface)) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -48,6 +48,16 @@ interface DatabaseInterface
      */
     public function createDatabase($options, $utf = true);
 
+     /**
+     * Create a new QueryInterface object.
+     *
+     * @return  QueryInterface
+     *
+     * @since   3.0
+     * @throws  \RuntimeException
+     */
+    public function createQuery();
+
     /**
      * Replace special placeholder representing binary field with the original string.
      *
@@ -232,9 +242,10 @@ interface DatabaseInterface
     public function getNumRows();
 
     /**
-     * Get the current query object or a new QueryInterface object.
+     * Get the current query object. (Deprecated: Or a new QueryInterface object).
      *
-     * @param   boolean  $new  False to return the current query object, True to return a new QueryInterface object.
+     * @param   boolean  $new  False to return the current query object,{@deprecated 3.0 Use DatabaseInterface::getQuery() instead}
+     *                         True to return a new QueryInterface object.{@deprecated 3.0 Use DatabaseInterface::createQuery() instead}
      *
      * @return  QueryInterface
      *


### PR DESCRIPTION
I am currently in the process of replacing the obsolete function getQuery(true) with createQuery() in Joomla CMS, see https://github.com/joomla/joomla-cms/pull/42344 (work in progress, at the meantime it is a closed PR, but open again after testing here).
To make my life easier, I have added the interface to the database with the createQuery() on the one hand, on the other hand you can use a little trick to build in a backtrace in the output via trigger_deprecated(), so that with the help (I use code OSS under Linux Arch) of the debugger (DEBUG CONSOLE) you can immediately jump to the calling file. See attached screenshot.
![Screenshot from 2024-09-08 09-22-00](https://github.com/user-attachments/assets/24a1e757-880f-401f-81c6-eb04b51554a3)

The former deprecated message was also very unclear and I have reworded it.
Perhaps other deprecated messages can also be modified accordingly?

### Summary of Changes
1. Rewording of debug message for deprecation of getQuery() with $new parameter.
2. Add the function createQuery() to the DatabaseInterface, also comment the deprecation there.
### Testing Instructions
Debug messages at the DEBUG CONSOLE or log file for Deprecated API in Joomla CMS.
### Documentation Changes Required
I don't know if this is not already sufficiently documented.