### PR TITLE
[3.x] Get database server version from database so it works also with ProxySQL

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -210,9 +210,9 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 
         if ($this->utf8mb4) {
             // At this point we know the client supports utf8mb4.  Now we must check if the server supports utf8mb4 as well.
-            $this->utf8mb4 = version_compare($this->serverVersion, '5.5.3', '>=');
+            $this->utf8mb4 = version_compare($serverVersion, '5.5.3', '>=');
 
-            if ($this->mariadb && version_compare($this->serverVersion, '10.0.0', '<')) {
+            if ($this->mariadb && version_compare($serverVersion, '10.0.0', '<')) {
                 $this->utf8mb4 = false;
             }
 

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -596,9 +596,9 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
     }
 
     /**
-     * Get the version of the database connector.
+     * Get the version of the database server.
      *
-     * @return  string  The database connector version.
+     * @return  string  The database server version.
      *
      * @since   1.0
      */


### PR DESCRIPTION
Pull Request for Issue #309

### Summary of Changes

This pull request (PR) changes the `getVersion` methods of the "MySQLi" and "MySQL (PDO)" drivers so that they select the version from the database after the first connection instead of relying on the connection's `server_info` in case of "MySQLi" or `PDO::ATTR_SERVER_VERSION` in case of "MySQL (PDO)".

The result is cached in a protected class variable so that the database query is only executed at the very first connection of the particular driver instance.

This makes it possible to use ProxySQL for a Joomla 5.x installation.

### Testing Instructions

With ProxySQL see issue #309 .

Otherwise (without ProxySQL) check that the version returned by `getVersion()` is the same as without this PR for the same database, e.g. something like "10.11.7-MariaDB-log" for MariaDB or "8.0.39-0ubuntu0.22.04.1" for MySQL databases.

### Documentation Changes Required

None.