### PR TITLE
[2.0] Backport PR #295 from 3.x-dev for PostgreSQL >= 16.0 compatibility

### DIFF
--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -111,7 +111,13 @@ class PgsqlDriver extends PdoDriver
 	 */
 	public function getCollation()
 	{
-		$this->setQuery('SHOW LC_COLLATE');
+		// https://www.postgresql.org/docs/current/release-16.html
+		if (version_compare($this->getVersion(), '16.0', '>=')) {
+			$this->setQuery('SELECT datcollate AS lc_collate FROM pg_database WHERE datname = current_database()');
+		} else {
+			$this->setQuery('SHOW LC_COLLATE');
+		}
+
 		$array = $this->loadAssocList();
 
 		return $array[0]['lc_collate'];
@@ -127,7 +133,13 @@ class PgsqlDriver extends PdoDriver
 	 */
 	public function getConnectionCollation()
 	{
-		$this->setQuery('SHOW LC_COLLATE');
+		// https://www.postgresql.org/docs/current/release-16.html
+		if (version_compare($this->getVersion(), '16.0', '>=')) {
+			$this->setQuery('SELECT datcollate AS lc_collate FROM pg_database WHERE datname = current_database()');
+		} else {
+			$this->setQuery('SHOW LC_COLLATE');
+		}
+
 		$array = $this->loadAssocList();
 
 		return $array[0]['lc_collate'];


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/42335

### Summary of Changes

Backport PR #295 from 3.x-dev:

Don't use read-only server variable lc_collate as that raises an error on PostgreSQL versions >= 16.0, see https://www.postgresql.org/docs/current/release-16.html .

### Testing Instructions

See #295 and https://github.com/joomla/joomla-cms/issues/42335 :

Go to admin area.
Try to show system info.

Without this PR: ERROR: unrecognized configuration parameter "lc_collate".

With this PR system information is shown.

The issue was reported for Joomla 5 but also applies to 4.4.

### Documentation Changes Required

None.