### PR TITLE
[2.0] Backport PR #300 for MariaDB >= 11.0 compatibility

### DIFF
--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -220,6 +220,11 @@ trait MysqlQueryBuilder
 	 */
 	public function selectRowNumber($orderBy, $orderColumnAlias)
 	{
+		// Use parent method with ROW_NUMBER() window function on MariaDB 11.0.0 and newer.
+		if ($this->db->isMariaDb() && version_compare($this->db->getVersion(), '11.0.0', '>=')) {
+			return parent::selectRowNumber($orderBy, $orderColumnAlias);
+		}
+
 		$this->validateRowNumber($orderBy, $orderColumnAlias);
 
 		return $this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");


### PR DESCRIPTION
Pull Request for Issue #290 .

See also https://github.com/joomla/joomla-cms/issues/42333 .

### Summary of Changes

Backport PR #300 from 3.x-dev:

Use the `ROW_NUMBER()` window function for MariaDB 11.0.0 and newer.

That function is supported on MySQL since version 8.0.0, too, and on MariaDB since version 10.2.0, but in order to play safe this PR only changes that for MariaDB 11.0.0 and newer, as for older MariaDB versions or MySQL the old code still seems to work. I've added a `@todo` comment to the `selectRowNumber` method and a comment to the version check for MariaDB 11.0.0 to make that clear.

I could not find any unit tests for the `selectRowNumber` method, so no changes on unit tests with this PR.

### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/42333 :

1. Installation of MariaDB Version 11.1.2 (active Arch Linux),
2. Goto backend (Administrator),
3. Open Components > Banners > Banners,
4. Create three new banners named 1st_banner, 2nd_banner, 3rd_banner,
5. Click on Sort By "Ordering ascending",
6. "Drag and Drop" the second banner to the first position - ordering now: 2 - 1 - 3,
7. Click on the search magnifying glass to reload the banner or reload page.

Without this PR, ordering of the banners is reordered to 1 - 2 - 3, and you cannot change the ordering with "Drag and Drop".

With this PR, ordering of the banners is 2 - 1 - 3, and you can change the ordering with "Drag and Drop".

The issue has been reported for Joomla 4.4 and 5.

### Documentation Changes Required

None.