### PR TITLE
Allow IPv6 addresses with brackets for pgsql

### DIFF
--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -261,6 +261,12 @@ abstract class PdoDriver extends DatabaseDriver
                 // Extract host and port or socket from host option
                 $this->setHostPortSocket(5432);
 
+                // PostgreSQL (in difference to MariaDB and MySQL) does not work with
+                // IPv6 addresses enclosed in square brackets, so we simply remove them here.
+                if (isset($this->options['host']) && substr($this->options['host'], 0, 1) === '[' && substr($this->options['host'], -1) === ']') {
+                    $this->options['host'] = trim($this->options['host'], '[]');
+                }
+
                 if ($this->options['socket'] !== null) {
                     $format = 'pgsql:host=#SOCKET#;dbname=#DBNAME#';
                 } else {


### PR DESCRIPTION
:construction: **DRAFT** as to be extended by unit tests and documentation
 
### Summary of Changes

IPv6 addresses are used with square brackets for MySQL and MariaDB and allowing the configuration of a non-default port number for the IPv6 address. However, with PostgreSQL, square brackets around IPv6 addresses are not usable, and setting a port is not possible.

Since it was decided to have only a single host field without a separate port number field in Joomla Web Installer (see [issue #43902](https://github.com/joomla/joomla-cms/issues/43902#issuecomment-2323932206)), there is a need to use square brackets to distinguish between the IPv6 host address and a port number.

This PR removes the square brackets somewhere in the middle, after separating a possible port number, but before continuing with PostgreSQL:
* PostgreSQL can now use IPv6 addresses with square brackets, just like MariaDB and MySQL → simplifies/unifies documentation and [joomla-cypress-36](https://github.com/joomla-projects/joomla-cypress/pull/36) implementation
* For the first time, it is possible to configure a port number together with an IPv6 address for PostgreSQL.
* The change is fully backward compatible. In the past, IPv6 addresses were accepted without square brackets, and this will continue to be supported in the future as well.

### Testing Instructions

:construction: **DRAFT** For the moment together with and will be added to [joomla-cypress-36](https://github.com/joomla-projects/joomla-cypress/pull/36) 

### Documentation Changes Required

TODO