### PR TITLE
[3.x] Remove square brackets from ipv6 host on PostgreSQL and refactor changes from PR 310

### DIFF
--- a/Tests/AbstractDatabaseDriverTestCase.php
+++ b/Tests/AbstractDatabaseDriverTestCase.php
@@ -1056,6 +1056,16 @@ abstract class AbstractDatabaseDriverTestCase extends DatabaseTestCase
         );
 
         $this->assertSame(
+            [null, null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, null, null, '/path/to/unix/socket.sock', 3306)
+        );
+
+        $this->assertSame(
+            [null, 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, null, 3307, '/path/to/unix/socket.sock', 3306)
+        );
+
+        $this->assertSame(
             [null, 3306, '/path/to/unix/socket.sock'],
             $refMethod->invoke(static::$connection, 'unix:/path/to/unix/socket.sock', null, null, 3306)
         );

--- a/Tests/AbstractDatabaseDriverTestCase.php
+++ b/Tests/AbstractDatabaseDriverTestCase.php
@@ -1036,4 +1036,193 @@ abstract class AbstractDatabaseDriverTestCase extends DatabaseTestCase
             $params
         );
     }
+
+    /**
+     * @testdox  Pure host name or IP address and port or socket can be extracted from the host name option
+     */
+    public function testExtractHostPortSocket()
+    {
+        $refObject = new \ReflectionObject(static::$connection);
+        $refMethod = $refObject->getMethod('extractHostPortSocket');
+
+        $this->assertSame(
+            ['', 3306, null],
+            $refMethod->invoke(static::$connection, '', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['', 3307, null],
+            $refMethod->invoke(static::$connection, '', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            [null, 3306, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, 'unix:/path/to/unix/socket.sock', null, null, 3306)
+        );
+
+        $this->assertSame(
+            [null, 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, 'unix:/path/to/unix/socket.sock', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', 3306, null],
+            $refMethod->invoke(static::$connection, '192.168.67.254', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', 3307, null],
+            $refMethod->invoke(static::$connection, '192.168.67.254', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', 3308, null],
+            $refMethod->invoke(static::$connection, '192.168.67.254:3308', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', 3308, null],
+            $refMethod->invoke(static::$connection, '192.168.67.254:3308', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', 3306, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', 3307, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', 3308, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:3308', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', 3308, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:3308', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', 3306, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]', null, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', 3307, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]', 3307, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', 3308, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:3308', null, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', 3308, null],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:3308', 3307, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['somehost', 3306, null],
+            $refMethod->invoke(static::$connection, 'somehost', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost', 3307, null],
+            $refMethod->invoke(static::$connection, 'somehost', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost', 3308, null],
+            $refMethod->invoke(static::$connection, 'somehost:3308', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost', 3308, null],
+            $refMethod->invoke(static::$connection, 'somehost:3308', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost.example.com', 3306, null],
+            $refMethod->invoke(static::$connection, 'somehost.example.com', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost.example.com', 3307, null],
+            $refMethod->invoke(static::$connection, 'somehost.example.com', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost.example.com', 3308, null],
+            $refMethod->invoke(static::$connection, 'somehost.example.com:3308', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost.example.com', 3308, null],
+            $refMethod->invoke(static::$connection, 'somehost.example.com:3308', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['localhost', 3308, null],
+            $refMethod->invoke(static::$connection, ':3308', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['localhost', 3308, null],
+            $refMethod->invoke(static::$connection, ':3308', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost', null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, 'somehost:/path/to/unix/socket.sock', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['somehost', 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, 'somehost:/path/to/unix/socket.sock', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '192.168.67.254:/path/to/unix/socket.sock', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['192.168.67.254', 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '192.168.67.254:/path/to/unix/socket.sock', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:/path/to/unix/socket.sock', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['[fe80:102::2%eth1]', 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:/path/to/unix/socket.sock', 3307, null, 3306)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:/path/to/unix/socket.sock', null, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['fe80:102::2%eth1', 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, '[fe80:102::2%eth1]:/path/to/unix/socket.sock', 3307, null, 3306, false)
+        );
+
+        $this->assertSame(
+            ['localhost', null, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, ':/path/to/unix/socket.sock', null, null, 3306)
+        );
+
+        $this->assertSame(
+            ['localhost', 3307, '/path/to/unix/socket.sock'],
+            $refMethod->invoke(static::$connection, ':/path/to/unix/socket.sock', 3307, null, 3306)
+        );
+    }
 }

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1907,7 +1907,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true)
+    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true) : array
     {
         $portNew = $port ?? $defaultPort;
 

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1907,7 +1907,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true) : array
+    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true): array
     {
         $portNew = $port ?? $defaultPort;
 

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1897,60 +1897,68 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     /**
      * Extract pure host name (or IP address) and port or socket from host name option.
      *
+     * @param  string   $host                Host given in options used to configure the connection.
+     * @param  int      $port                Port given in options used to configure the connection, null if none.
+     * @param  array    $socket              Socket given in options used to configure the connection, null if none.
      * @param  integer  $defaultPort         The default port number to be used if no port is given.
      * @param  boolean  $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
      *
-     * @since  __DEPLOY_VERSION__
+     * @return  array  Array with host, port and socket.
+     *
+     * @since   __DEPLOY_VERSION__
      */
-    protected function setHostPortSocket($defaultPort, $ipv6SquareBrackets = true)
+    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true)
     {
-        $port = $this->options['port'] ?? $defaultPort;
-
-        if (preg_match('/^unix:(?P<socket>[^:]+)$/', $this->options['host'], $matches)) {
+        if (preg_match('/^unix:(?P<socket>[^:]+)$/', $host, $matches)) {
             // UNIX socket URI, e.g. 'unix:/path/to/unix/socket.sock'
-            $this->options['host']   = null;
-            $this->options['socket'] = $matches['socket'];
-            $this->options['port']   = null;
-        } elseif (
+            return [null, null, $matches['socket']];
+        }
+
+        $port = $port ?? $defaultPort;
+
+        if (
             preg_match(
                 '/^(?P<host>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(:(?P<port>.+))?$/',
-                $this->options['host'],
+                $host,
                 $matches
             )
         ) {
             // It's an IPv4 address with or without port
-            $this->options['host'] = $matches['host'];
+            $host = $matches['host'];
 
             if (!empty($matches['port'])) {
                 $port = $matches['port'];
             }
-        } elseif (preg_match('/^(?P<host>\[.*\])(:(?P<port>.+))?$/', $this->options['host'], $matches)) {
+        } elseif (preg_match('/^(?P<host>\[.*\])(:(?P<port>.+))?$/', $host, $matches)) {
             // We assume square-bracketed IPv6 address with or without port, e.g. [fe80:102::2%eth1]:3306
-            $this->options['host'] = $ipv6SquareBrackets ? $matches['host'] : rtrim(ltrim($matches['host'], '['), ']');
+            $host = $ipv6SquareBrackets ? $matches['host'] : rtrim(ltrim($matches['host'], '['), ']');
 
             if (!empty($matches['port'])) {
                 $port = $matches['port'];
             }
-        } elseif (preg_match('/^(?P<host>(\w+:\/{2,3})?[a-z0-9\.\-]+)(:(?P<port>[^:]+))?$/i', $this->options['host'], $matches)) {
+        } elseif (preg_match('/^(?P<host>(\w+:\/{2,3})?[a-z0-9\.\-]+)(:(?P<port>[^:]+))?$/i', $host, $matches)) {
             // Named host (e.g example.com or localhost) with or without port
-            $this->options['host'] = $matches['host'];
+            $host = $matches['host'];
 
             if (!empty($matches['port'])) {
                 $port = $matches['port'];
             }
-        } elseif (preg_match('/^:(?P<port>[^:]+)$/', $this->options['host'], $matches)) {
+        } elseif (preg_match('/^:(?P<port>[^:]+)$/', $host, $matches)) {
             // Empty host, just port, e.g. ':3306'
-            $this->options['host'] = 'localhost';
-            $port                  = $matches['port'];
+            $host = 'localhost';
+            $port = $matches['port'];
         }
 
         // ... else we assume normal (naked) IPv6 address, so host and port stay as they are or default
 
         // Get the port number or socket name
         if (is_numeric($port)) {
-            $this->options['port'] = (int) $port;
+            $port = (int) $port;
         } else {
-            $this->options['socket'] = $port;
+            $socket = $port;
+	    $port   = null;
         }
+
+        return [$host, $port, $socket];
     }
 }

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1897,11 +1897,11 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     /**
      * Extract pure host name (or IP address) and port or socket from host name option.
      *
-     * @param  string       $host                Host given in options used to configure the connection.
-     * @param  int|null     $port                Port given in options used to configure the connection, null if none.
-     * @param  string|null  $socket              Socket given in options used to configure the connection, null if none.
-     * @param  integer      $defaultPort         The default port number to be used if no port is given.
-     * @param  boolean      $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
+     * @param  string        $host                Host given in options used to configure the connection.
+     * @param  integer|null  $port                Port given in options used to configure the connection, null if none.
+     * @param  string|null   $socket              Socket given in options used to configure the connection, null if none.
+     * @param  integer       $defaultPort         The default port number to be used if no port is given.
+     * @param  boolean       $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
      *
      * @return  array  Array with host, port and socket.
      *

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1897,11 +1897,12 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     /**
      * Extract pure host name (or IP address) and port or socket from host name option.
      *
-     * @param  integer  $defaultPort  The default port number to be used if no port is given.
+     * @param  integer  $defaultPort         The default port number to be used if no port is given.
+     * @param  boolean  $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
      *
      * @since  __DEPLOY_VERSION__
      */
-    protected function setHostPortSocket($defaultPort)
+    protected function setHostPortSocket($defaultPort, $ipv6SquareBrackets = true)
     {
         $port = $this->options['port'] ?? $defaultPort;
 
@@ -1925,7 +1926,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
             }
         } elseif (preg_match('/^(?P<host>\[.*\])(:(?P<port>.+))?$/', $this->options['host'], $matches)) {
             // We assume square-bracketed IPv6 address with or without port, e.g. [fe80:102::2%eth1]:3306
-            $this->options['host'] = $matches['host'];
+            $this->options['host'] = $ipv6SquareBrackets ? $matches['host'] : rtrim(ltrim($matches['host'], '['), ']');
 
             if (!empty($matches['port'])) {
                 $port = $matches['port'];

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1909,14 +1909,14 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      */
     protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true)
     {
+        $portNew = $port ?? $defaultPort;
+
         if (preg_match('/^unix:(?P<socket>[^:]+)$/', $host, $matches)) {
             // UNIX socket URI, e.g. 'unix:/path/to/unix/socket.sock'
-            return [null, null, $matches['socket']];
-        }
-
-        $port = $port ?? $defaultPort;
-
-        if (
+            $host   = null;
+            $socket = $matches['socket'];
+            $port   = null;
+        } elseif (
             preg_match(
                 '/^(?P<host>((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(:(?P<port>.+))?$/',
                 $host,
@@ -1927,36 +1927,35 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
             $host = $matches['host'];
 
             if (!empty($matches['port'])) {
-                $port = $matches['port'];
+                $portNew = $matches['port'];
             }
         } elseif (preg_match('/^(?P<host>\[.*\])(:(?P<port>.+))?$/', $host, $matches)) {
             // We assume square-bracketed IPv6 address with or without port, e.g. [fe80:102::2%eth1]:3306
             $host = $ipv6SquareBrackets ? $matches['host'] : rtrim(ltrim($matches['host'], '['), ']');
 
             if (!empty($matches['port'])) {
-                $port = $matches['port'];
+                $portNew = $matches['port'];
             }
         } elseif (preg_match('/^(?P<host>(\w+:\/{2,3})?[a-z0-9\.\-]+)(:(?P<port>[^:]+))?$/i', $host, $matches)) {
             // Named host (e.g example.com or localhost) with or without port
             $host = $matches['host'];
 
             if (!empty($matches['port'])) {
-                $port = $matches['port'];
+                $portNew = $matches['port'];
             }
         } elseif (preg_match('/^:(?P<port>[^:]+)$/', $host, $matches)) {
             // Empty host, just port, e.g. ':3306'
-            $host = 'localhost';
-            $port = $matches['port'];
+            $host    = 'localhost';
+            $portNew = $matches['port'];
         }
 
         // ... else we assume normal (naked) IPv6 address, so host and port stay as they are or default
 
         // Get the port number or socket name
-        if (is_numeric($port)) {
-            $port = (int) $port;
+        if (is_numeric($portNew)) {
+            $port = (int) $portNew;
         } else {
-            $socket = $port;
-	    $port   = null;
+            $socket = $portNew;
         }
 
         return [$host, $port, $socket];

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1897,7 +1897,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     /**
      * Extract pure host name (or IP address) and port or socket from host name option.
      *
-     * @param  string        $host                Host given in options used to configure the connection.
+     * @param  string        $host                Host given in options used to configure the connection, null if none.
      * @param  integer|null  $port                Port given in options used to configure the connection, null if none.
      * @param  string|null   $socket              Socket given in options used to configure the connection, null if none.
      * @param  integer       $defaultPort         The default port number to be used if no port is given.
@@ -1907,8 +1907,13 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function extractHostPortSocket(string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true): array
+    protected function extractHostPortSocket(string ?$host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true): array
     {
+        // Do nothing if a socket is given and no host
+        if ($host === null && $socket !== null) {
+            return [$host, $port, $socket];
+        }
+
         $portNew = $port ?? $defaultPort;
 
         if (preg_match('/^unix:(?P<socket>[^:]+)$/', $host, $matches)) {

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1897,11 +1897,11 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     /**
      * Extract pure host name (or IP address) and port or socket from host name option.
      *
-     * @param  string   $host                Host given in options used to configure the connection.
-     * @param  int      $port                Port given in options used to configure the connection, null if none.
-     * @param  array    $socket              Socket given in options used to configure the connection, null if none.
-     * @param  integer  $defaultPort         The default port number to be used if no port is given.
-     * @param  boolean  $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
+     * @param  string       $host                Host given in options used to configure the connection.
+     * @param  int|null     $port                Port given in options used to configure the connection, null if none.
+     * @param  string|null  $socket              Socket given in options used to configure the connection, null if none.
+     * @param  integer      $defaultPort         The default port number to be used if no port is given.
+     * @param  boolean      $ipv6SquareBrackets  True if database connector uses ipv6 address with square brackets, false if not.
      *
      * @return  array  Array with host, port and socket.
      *

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1907,7 +1907,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function extractHostPortSocket(string ?$host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true): array
+    protected function extractHostPortSocket(?string $host, ?int $port, ?string $socket, int $defaultPort, bool $ipv6SquareBrackets = true): array
     {
         // Do nothing if a socket is given and no host
         if ($host === null && $socket !== null) {

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -199,7 +199,8 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         }
 
         // Extract host and port or socket from host option
-        $this->setHostPortSocket(3306);
+        [$this->options['host'], $this->options['port'], $this->options['socket']]
+            = $this->extractHostPortSocket($this->options['host'], $this->options['port'], $this->options['socket'], 3306);
 
         $this->connection = mysqli_init();
 

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -259,7 +259,7 @@ abstract class PdoDriver extends DatabaseDriver
 
             case 'pgsql':
                 // Extract host and port or socket from host option
-                $this->setHostPortSocket(5432);
+                $this->setHostPortSocket(5432, false);
 
                 if ($this->options['socket'] !== null) {
                     $format = 'pgsql:host=#SOCKET#;dbname=#DBNAME#';

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -210,23 +210,17 @@ abstract class PdoDriver extends DatabaseDriver
 
             case 'mysql':
                 // Extract host and port or socket from host option
-                [$this->options['host'], $this->options['port'], $this->options['socket']]
+                [$host, $port, $socket]
                     = $this->extractHostPortSocket($this->options['host'], $this->options['port'], $this->options['socket'], 3306);
 
-                if ($this->options['socket'] !== null) {
+                if ($socket !== null) {
                     $format = 'mysql:unix_socket=#SOCKET#;dbname=#DBNAME#;charset=#CHARSET#';
                 } else {
                     $format = 'mysql:host=#HOST#;port=#PORT#;dbname=#DBNAME#;charset=#CHARSET#';
                 }
 
                 $replace = ['#HOST#', '#PORT#', '#SOCKET#', '#DBNAME#', '#CHARSET#'];
-                $with    = [
-                    $this->options['host'],
-                    $this->options['port'],
-                    $this->options['socket'],
-                    $this->options['database'],
-                    $this->options['charset'],
-                ];
+                $with    = [$host, $port, $socket, $this->options['database'], $this->options['charset']];
 
                 break;
 
@@ -260,17 +254,17 @@ abstract class PdoDriver extends DatabaseDriver
 
             case 'pgsql':
                 // Extract host and port or socket from host option and remove square brackets around ipv6 address
-                [$this->options['host'], $this->options['port'], $this->options['socket']]
+                [$host, $port, $socket]
                     = $this->extractHostPortSocket($this->options['host'], $this->options['port'], $this->options['socket'], 5432, false);
 
-                if ($this->options['socket'] !== null) {
+                if ($socket !== null) {
                     $format = 'pgsql:host=#SOCKET#;dbname=#DBNAME#';
                 } else {
                     $format = 'pgsql:host=#HOST#;port=#PORT#;dbname=#DBNAME#';
                 }
 
                 $replace = ['#HOST#', '#PORT#', '#SOCKET#', '#DBNAME#'];
-                $with    = [$this->options['host'], $this->options['port'], $this->options['socket'], $this->options['database']];
+                $with    = [$host, $port, $socket, $this->options['database']];
 
                 // For data in transit TLS encryption.
                 if ($this->options['ssl'] !== [] && $this->options['ssl']['enable'] === true) {

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -210,7 +210,8 @@ abstract class PdoDriver extends DatabaseDriver
 
             case 'mysql':
                 // Extract host and port or socket from host option
-                $this->setHostPortSocket(3306);
+                [$this->options['host'], $this->options['port'], $this->options['socket']]
+                    = $this->extractHostPortSocket($this->options['host'], $this->options['port'], $this->options['socket'], 3306);
 
                 if ($this->options['socket'] !== null) {
                     $format = 'mysql:unix_socket=#SOCKET#;dbname=#DBNAME#;charset=#CHARSET#';
@@ -258,8 +259,9 @@ abstract class PdoDriver extends DatabaseDriver
                 break;
 
             case 'pgsql':
-                // Extract host and port or socket from host option
-                $this->setHostPortSocket(5432, false);
+                // Extract host and port or socket from host option and remove square brackets around ipv6 address
+                [$this->options['host'], $this->options['port'], $this->options['socket']]
+                    = $this->extractHostPortSocket($this->options['host'], $this->options['port'], $this->options['socket'], 5432, false);
 
                 if ($this->options['socket'] !== null) {
                     $format = 'pgsql:host=#SOCKET#;dbname=#DBNAME#';


### PR DESCRIPTION
Pull Request for Issue #

Alternative to #315 .

### Summary of Changes

This pull request (PR) adds an option to the `setHostPortSocket` method, which was added with PR #310 , to control if the square brackets around an IP v6 address in the `host` parameter should be kept ("MySQLi" and "MySQL (PDO)") or if they should be removed ("PostgreSQL (PDO)") in the connection parameters.

The default is true to keep the square brackets. For "PosgreSQL (PDO)" it is set to false so the quare brackets are removed.

This makes it possible to specify an IP v6 address together with a port number for "PostgreSQL (PDO)" in the same way as it already works for "MySQLi" and "MySQL (PDO)".

See also PR #315 for details.

In addition, this PR changes the `setHostPortSocket` method to not implicitly modify `$this->options` but to use function parameters and return value, and it renames that method to `extractHostPortSocket` to reflect that change.

The change to use function parameters and a return value makes it easier to provide unit tests for that method.

In the PDO driver, the original options are not modified but local variables are used. This makes sure that the options are not modified multiple times with each re-connect, which would cause problems with the removal of square brackets because the colons in an IP v6 address would cause wrong port number to be detected at the 2nd run.

In the MySQL driver this PR keeps it like it was so the behaviour is like before.

Finally, this PR adds a unit test for the `extractHostPortSocket` method.

### Request for comments - RFC

As the `extractHostPortSocket` method is protected, the unit test uses reflection to make it accessible.

An alternative would be to change that method to public.

@alikon @Hackwar @HLeithner @muhme and other reviewers: What do you think? Leave the unit test as it is? Or make the method public and test it without reflection?

### Testing Instructions

See CMS issue https://github.com/joomla/joomla-cms/issues/43902 and https://github.com/joomla-projects/joomla-cypress/pull/36 ,

And check in unit test logs in Drone if they contain a successful test "Pure host name or IP address and port or socket can be extracted from the host name option".

### Documentation Changes Required

Don't know.