### PR TITLE
[3.x] Use directory Tests/Sqlsrv in phpunit.appveyor_sql2017.xml.dist to fix failing AppVeyor

### DIFF
--- a/phpunit.appveyor_sql2017.xml.dist
+++ b/phpunit.appveyor_sql2017.xml.dist
@@ -13,7 +13,7 @@
 	</php>
 	<testsuites>
 		<testsuite name="Unit">
-			<directory>Tests</directory>
+			<directory>Tests/Sqlsrv</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

This pull request (PR) fixes the currently failing unit tests in AppVeyor in the 3.x-dev branch by changing the folder to be used for the tests from "Tests" to "Tests/Sqlsrv" in the "phpunit.appveyor_sql2017.xml.dist" file.

This is consistent with the other "phpunit.*.xml.dist" files, where the driver-specific folder is used:
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.mariadb.xml.dist#L16
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.mysql.xml.dist#L16
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.mysqli.xml.dist#L16
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.pgsql.xml.dist#L17
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.sqlite.xml.dist#L16
- https://github.com/joomla-framework/database/blob/3.x-dev/phpunit.sqlsrv.xml.dist#L16

Tests from base classes like e.g. AbstractDatabaseDriverTestCase or DatabaseTestCase are inhertited. If you would change that back to folder "Test" for these other configurations, the corresponding tests would also fail, so the change from this PR here seems to be the right change.

### Testing Instructions

Check the AppVeyor log of this PR and compare with the log of some other open PR for the 3.x-dev branch.

Result:
- In the 3.x-dev branch, all three AppVeyor tests for PHP 8.1, 8.2 and 8.3 are failing.
- For this PR, all three AppVeyor tests for PHP 8.1, 8.2 and 8.3 are successful.

Compare the bottom of the log of e.g. the PHP 8.1 test in AppVeyor with the log for the same test in Drone , e.g. "PHP 8.1 with MS SQL Server 2017-latest (sqlsrv)".

Result:
The AppVeyor tests for this PR show the same result as the corresponding tests in Drone for the same MS SQL Server and PHP versions.
```
OK, but incomplete, skipped, or risky tests!
Tests: 84, Assertions: 13, Skipped: 62.
```

### Documentation Changes Required

None.