### PR TITLE
[3.x] mysqli::ping is deprecated since php8.4

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -375,7 +375,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
     public function connected()
     {
         if (\is_object($this->connection)) {
-            return $this->connection->ping();
+            return $this->connection->stat() !== false;
         }
 
         return false;


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
replace `ping()` with `stat() !== false`.
### Testing Instructions
MysqliDriver::connected() should work.
### Documentation Changes Required
