### PR TITLE
[4.x] add createQuery to DatabaseInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The `Database\DatabaseIterator` class allows iteration over database results
 ```php
 $db = DatabaseDriver::getInstance($options);
 $iterator = $db->setQuery(
-	$db->getQuery(true)->select('*')->from('#__content')
+	$db->createQuery()->select('*')->from('#__content')
 )->getIterator();
 
 foreach ($iterator as $row)

--- a/Tests/Mysql/MysqlExporterTest.php
+++ b/Tests/Mysql/MysqlExporterTest.php
@@ -43,7 +43,7 @@ class MysqlExporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqlQuery($this->db);
             });

--- a/Tests/Mysql/MysqlImporterTest.php
+++ b/Tests/Mysql/MysqlImporterTest.php
@@ -69,7 +69,7 @@ class MysqlImporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqlQuery($this->db);
             });

--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -72,7 +72,7 @@ class MysqlPreparedStatementTest extends DatabaseTestCase
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([
@@ -93,7 +93,7 @@ class MysqlPreparedStatementTest extends DatabaseTestCase
     {
         $dummyValue = 'test';
         $dummyValue2 = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([

--- a/Tests/Mysqli/MysqliExporterTest.php
+++ b/Tests/Mysqli/MysqliExporterTest.php
@@ -43,7 +43,7 @@ class MysqliExporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqliQuery($this->db);
             });

--- a/Tests/Mysqli/MysqliImporterTest.php
+++ b/Tests/Mysqli/MysqliImporterTest.php
@@ -69,7 +69,7 @@ class MysqliImporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqliQuery($this->db);
             });

--- a/Tests/Pgsql/PgsqlExporterTest.php
+++ b/Tests/Pgsql/PgsqlExporterTest.php
@@ -43,7 +43,7 @@ class PgsqlExporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new PgsqlQuery($this->db);
             });

--- a/Tests/Pgsql/PgsqlImporterTest.php
+++ b/Tests/Pgsql/PgsqlImporterTest.php
@@ -69,7 +69,7 @@ class PgsqlImporterTest extends TestCase
             ->willReturn('jos_');
 
         $this->db->expects($this->any())
-            ->method('getQuery')
+            ->method('createQuery')
             ->willReturnCallback(function () {
                 return new PgsqlQuery($this->db);
             });

--- a/Tests/Pgsql/PgsqlPreparedStatementTest.php
+++ b/Tests/Pgsql/PgsqlPreparedStatementTest.php
@@ -75,7 +75,7 @@ class PgsqlPreparedStatementTest extends DatabaseTestCase
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([
@@ -96,7 +96,7 @@ class PgsqlPreparedStatementTest extends DatabaseTestCase
     {
         $dummyValue = 'test';
         $dummyValue2 = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([

--- a/Tests/Sqlite/SqlitePreparedStatementTest.php
+++ b/Tests/Sqlite/SqlitePreparedStatementTest.php
@@ -82,7 +82,7 @@ class SqlitePreparedStatementTest extends DatabaseTestCase
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([
@@ -103,7 +103,7 @@ class SqlitePreparedStatementTest extends DatabaseTestCase
     {
         $dummyValue = 'test';
         $dummyValue2 = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -133,7 +133,7 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([
@@ -154,7 +154,7 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
     {
         $dummyValue = 'test';
         $dummyValue2 = 'test';
-        $query = static::$connection->getQuery(true);
+        $query = static::$connection->createQuery();
         $query->select('*')
             ->from($query->quoteName('dbtest'))
             ->where([

--- a/docs/v3-to-v4-update.md
+++ b/docs/v3-to-v4-update.md
@@ -17,3 +17,8 @@ The following are the minimum supported database versions:
 ### Removed quoteNameStr
 
 The deprecated method `quoteNameStr` has been removed. Use `quoteNameString` instead.
+
+### DatabaseInterface: `createQuery` method
+
+`DatabaseInterface` adds a `createQuery` method for creating query objects. Use `createQuery()` instead of `getQuery(true)`.
+If you have a custom query class update your adapter's `createQuery()` method to return your custom query class.

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1748,7 +1748,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
 
         if (\is_string($query)) {
             // Allows taking advantage of bound variables in a direct query:
-            $query = $this->getQuery(true)->setQuery($query);
+            $query = $this->createQuery()->setQuery($query);
         } elseif (!($query instanceof QueryInterface)) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -979,7 +979,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
     * Get the current query object or a new DatabaseQuery object.
     *
     * @param   boolean  $new  False to return the current query object, True to return a new DatabaseQuery object.
-    *                         The $new parameter is deprecated in 2.2 and will be removed in 4.0, use createQuery() instead.
+    *                         The $new parameter is deprecated in 2.2 and will be removed in 5.0, use createQuery() instead.
     *
     * @return  DatabaseQuery
     *
@@ -991,7 +991,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
             trigger_deprecation(
                 'joomla/database',
                 '2.2.0',
-                'The parameter $new is deprecated and will be removed in 4.0, use %s::createQuery() instead.',
+                'The parameter $new is deprecated and will be removed in 5.0, use %s::createQuery() instead.',
                 self::class
             );
 

--- a/src/DatabaseExporter.php
+++ b/src/DatabaseExporter.php
@@ -269,7 +269,7 @@ abstract class DatabaseExporter
             }
 
             $this->db->setQuery(
-                $this->db->getQuery(true)
+                $this->db->createQuery()
                     ->select($this->db->quoteName(array_keys($fields)))
                     ->from($this->db->quoteName($table))
             );

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -49,6 +49,15 @@ interface DatabaseInterface
     public function createDatabase($options, $utf = true);
 
     /**
+     * Create a new DatabaseQuery object.
+     *
+     * @return  QueryInterface
+     *
+     * @since   4.0.0
+     */
+    public function createQuery(): QueryInterface;
+
+    /**
      * Replace special placeholder representing binary field with the original string.
      *
      * @param   string|resource  $data  Encoded string or resource.

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -241,9 +241,10 @@ interface DatabaseInterface
     public function getNumRows();
 
     /**
-     * Get the current query object or a new QueryInterface object.
-     *
-     * @param   boolean  $new  False to return the current query object, True to return a new QueryInterface object.
+     * Get the current query object. (Deprecated: Or a new QueryInterface object).
+     * 
+     * @param   boolean  $new  False to return the current query object, True to return a new DatabaseQuery object.
+     *                         The $new parameter is deprecated in 2.2 and will be removed in 5.0, use createQuery() instead.
      *
      * @return  QueryInterface
      *

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -242,7 +242,7 @@ interface DatabaseInterface
 
     /**
      * Get the current query object. (Deprecated: Or a new QueryInterface object).
-     * 
+     *
      * @param   boolean  $new  False to return the current query object, True to return a new DatabaseQuery object.
      *                         The $new parameter is deprecated in 2.2 and will be removed in 5.0, use createQuery() instead.
      *

--- a/src/Pgsql/PgsqlExporter.php
+++ b/src/Pgsql/PgsqlExporter.php
@@ -126,7 +126,7 @@ class PgsqlExporter extends DatabaseExporter
                 }
             }
 
-            $query = $this->db->getQuery(true);
+            $query = $this->db->createQuery();
             $query->select($query->quoteName(array_keys($fields)))
                 ->from($query->quoteName($table));
             $this->db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

adds `createQuery` to `DatabaseInterface`

### Testing Instructions

- only interface updated
- check every class which implements `DatabaseInterface` must contain `createQuery`

### Documentation Changes Required

Every class which implements `DatabaseInterface` must contain `createQuery`
