### PR TITLE
feature: Update DatabaseFactory.php to allow external DB

### DIFF
--- a/src/DatabaseFactory.php
+++ b/src/DatabaseFactory.php
@@ -25,12 +25,12 @@ class DatabaseFactory
      * @param   string  $name     Name of the database driver you'd like to instantiate
      * @param   array   $options  Parameters to be passed to the database driver.
      *
-     * @return  DatabaseInterface
+     * @return  DatabaseInterface|DatabaseDriver
      *
      * @since   1.0
      * @throws  Exception\UnsupportedAdapterException if there is not a compatible database driver
      */
-    public function getDriver(string $name = 'mysqli', array $options = []): DatabaseInterface
+    public function getDriver(string $name = 'mysqli', array $options = []): DatabaseInterface|DatabaseDriver
     {
         // Sanitize the database connector options.
         $options['driver']   = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);


### PR DESCRIPTION
Hey Joomla Team!
As I stumble on this problem, I would like to contribute with this tiny PR. TLDR; It allows to use the DatabaseFactory to inject external database for example in Joomla Tables e.g. ` $this->setDbo($externalDatabaseDriver);` 

*Before* this change it was not possible due to the fact that the return type of getDriver method required `DatabaseInterface` and the Parameter type of `setDbo` is exactly DatabaseDriver only. Maybe due to something related to Covariance and Contra-Variance in PHP.

*After* This change, since DatabaseDriver is an Abstract Class that implements DatabaseInterface it does not break the contract and normally everything should still work fine. But with the befenit for developers to use the full power of Joomla and the hard work of other Joomla Framework maintainers.

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
