### PR TITLE
[3.x] Add collation to getAlterDbCharacterSet method of MySQLi and MySQL (PDO) drivers

### DIFF
--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -296,9 +296,10 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
      */
     public function getAlterDbCharacterSet($dbName)
     {
-        $charset = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
+        $charset   = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
+        $collation = $charset . '_unicode_ci';
 
-        return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset . '`';
+        return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset . '` COLLATE `' . $collation . '`';
     }
 
     /**

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -392,9 +392,10 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
      */
     public function getAlterDbCharacterSet($dbName)
     {
-        $charset = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
+        $charset   = $this->utf8mb4 ? 'utf8mb4' : 'utf8';
+        $collation = $charset . '_unicode_ci';
 
-        return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset . '`';
+        return 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `' . $charset . '` COLLATE `' . $collation . '`';
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/45112

### Summary of Changes

This pull request (PR) changes the `getAlterDbCharacterSet` method of the MySQLi and MySQL (PDO) drivers to add a `COLLATE` clause to the `ALTER DATABASE ... CHARACTER SET ...` statement.

This is consistent with the method `getCreateDatabaseQuery` of the same drivers, see
- https://github.com/joomla-framework/database/blob/3.x-dev/src/Mysqli/MysqliDriver.php#L478-L488
- https://github.com/joomla-framework/database/blob/3.x-dev/src/Mysql/MysqlDriver.php#L382-L392

Both methods are made to be used by the CMS installation and not for specifying any possible character set. They either use `utf8mb4`or `utf8` depending on `utf8mb4` support of the database connection.

The default character set and collation of the database are only used as default values when a `CREATE TABLE` statement does not specify character set and collation.

The CMS does that always, so the database defaults do not have any impact on the CMS tables.

However, if you install a 3rd party extension which does not specify character set and collation in the `CREATE TABLE` statements in its installation SQL script, then these tables are created with a default collation which seems to depend on the MySQL or MariaDB server version (on older ones e.g. `utf8mb4_general_ci`, on newer ones e.g. `utf8mb4_0900_ai_ci`).

This can lead to "Illegal mix of collations" (or so) errors when joining text columns of these tables with text columns of core tables, or when using them in a `UNION` clause of a query.

### Request for Comments

When this PR here is merged and the change is pulled into the CMS, tables of 3rd party extensions which do not specify character set and collation in their `CREATE TABLE` statements will be created with collation `utf8mb4_unicode_ci` (or `utf8_unicode_ci` if the database doesn't support `utf8mb4`).

If this is considered a b/c break then I can move this PR to 4.x-dev.

### More to be done in a future PR

Since MySQL version 8.0.0 and MariaDB version 10.6.1, `utf8` is replaced by `utf8mb3`, `utf8` is a an alias for `utf8mb3`, and that alias is deprecated and might be removed in future.

### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/45112 .

### Documentation Changes Required

None.