### PR TITLE
[2.x] PR 281 follow up - cast boolean option and fix code style

### DIFF
--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -119,9 +119,9 @@ class SqlsrvDriver extends DatabaseDriver
 			'Database'               => $this->options['database'],
 			'uid'                    => $this->options['user'],
 			'pwd'                    => $this->options['password'],
-			'TrustServerCertificate' => $this->options['trust_certificate'],
 			'CharacterSet'           => 'UTF-8',
 			'ReturnDatesAsStrings'   => true,
+			'TrustServerCertificate' => $this->options['trust_certificate'],
 		];
 
 		// Attempt to connect to the server.

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -82,11 +82,11 @@ class SqlsrvDriver extends DatabaseDriver
 	public function __construct(array $options)
 	{
 		// Get some basic values from the options.
-		$options['host']     = $options['host'] ?? 'localhost';
-		$options['user']     = $options['user'] ?? '';
-		$options['password'] = $options['password'] ?? '';
-		$options['database'] = $options['database'] ?? '';
-		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
+		$options['host']              = $options['host'] ?? 'localhost';
+		$options['user']              = $options['user'] ?? '';
+		$options['password']          = $options['password'] ?? '';
+		$options['database']          = $options['database'] ?? '';
+		$options['select']            = isset($options['select']) ? (bool) $options['select'] : true;
 		$options['trust_certificate'] = isset($options['trust_certificate']) ? (bool) $options['trust_certificate'] : false;
 
 		// Finalize initialisation
@@ -116,12 +116,12 @@ class SqlsrvDriver extends DatabaseDriver
 
 		// Build the connection configuration array.
 		$config = [
-			'Database'             => $this->options['database'],
-			'uid'                  => $this->options['user'],
-			'pwd'                  => $this->options['password'],
+			'Database'               => $this->options['database'],
+			'uid'                    => $this->options['user'],
+			'pwd'                    => $this->options['password'],
 			'TrustServerCertificate' => $this->options['trust_certificate'],
-			'CharacterSet'         => 'UTF-8',
-			'ReturnDatesAsStrings' => true,
+			'CharacterSet'           => 'UTF-8',
+			'ReturnDatesAsStrings'   => true,
 		];
 
 		// Attempt to connect to the server.

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -87,7 +87,7 @@ class SqlsrvDriver extends DatabaseDriver
 		$options['password'] = $options['password'] ?? '';
 		$options['database'] = $options['database'] ?? '';
 		$options['select']   = isset($options['select']) ? (bool) $options['select'] : true;
-		$options['trust_certificate'] = $options['trust_certificate'] ?? false;
+		$options['trust_certificate'] = isset($options['trust_certificate']) ? (bool) $options['trust_certificate'] : false;
 
 		// Finalize initialisation
 		parent::__construct($options);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-framework/database/pull/281#discussion_r1835644852

### Summary of Changes

This pull request (PR) adds a type cast to bool to the code added with PR #281 in the constructor so that the new boolean parameter behaves like the already existing parameter `$options['select']`.

In addition it fixes code style of the parts changed by PR #281 , and it changes the order of the `$config` array in the `connect` method so it fits to the 3.x-dev branch PR #332 for merging up the change from PR #281 .

### Testing Instructions

Code review.

### Documentation Changes Required

None.