### PR TITLE
Don't include .git-blame-ignore-revs file in distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ Tests/ export-ignore
 .drone.jsonnet export-ignore
 .drone.yml export-ignore
 .editorconfig export-ignore
+.git-blame-ignore-revs export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.*.xml.dist export-ignore


### PR DESCRIPTION
### Summary of Changes

Same as #218 .

### Testing Instructions

The zip package will not include .git-blame-ignore-revs file.

### Documentation Changes Required

None.