### PR TITLE
[3.x] PR 300 follow up - Use ROW_NUMBER() windows function whenever supported

### DIFF
--- a/src/Query/MysqlQueryBuilder.php
+++ b/src/Query/MysqlQueryBuilder.php
@@ -217,8 +217,8 @@ trait MysqlQueryBuilder
      */
     public function selectRowNumber($orderBy, $orderColumnAlias)
     {
-        // Use parent method with ROW_NUMBER() window function on MariaDB 11.0.0 and newer.
-        if ($this->db->isMariaDb() && version_compare($this->db->getVersion(), '11.0.0', '>=')) {
+        // Use parent method with ROW_NUMBER() window function on MariaDB >= 10.2.0 and MySQL >= 8.0.0.
+        if (version_compare($this->db->getVersion(), $this->mariadb ? '10.2.0' : '8.0.0', '>=')) {
             return parent::selectRowNumber($orderBy, $orderColumnAlias);
         }
 


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/issues/45236 and https://github.com/joomla/joomla-cms/issues/44545 

### Summary of Changes

This pull request (PR) changes the fix from PR #300 to use the `ROW_NUMBER()` window function instead of the unreliable SQL variable incrementation so that it is applied on MariaDB >= 10.2.0 and MySQL >= 8.0.0 and now only on MariaDB 11.0.0 and newer.

When I had made my PR #300 I was advised to play safe and do it only for MariaDB 11 because the issue was only reported for that version.

But meanwhile the same issue has also been reported for MariaDB versions 10.4.32 and 10.11.11, see e.g, https://github.com/joomla/joomla-cms/issues/45236 .

For MySQL the issues has not been reported, so it seems the ugly old "hack" with incrementing an SQL variable still works, but who knows if this will be the case forever.

The `ROW_NUMBER()` window function meanwhile has become an SQL standard and is supported by all kinds of databases supported by the database framework here, only not for the old MySQL and MariaDB versions. It is more reliable than any SQL variable, and it might also be better regarding performance.

Therefore I think `ROW_NUMBER()` window function should be used whenever supported, and this is what this PR here does.

### Testing Instructions

On a Joomla 5.2 or 5.3 with a MariaDB database version 10.2.0 or newer, but is must be a 10.x, not an 11.x, reproduce https://github.com/joomla/joomla-cms/issues/45236 .

Then apply the changes from this PR to file `libraries/vendor/joomla/database/src/Query/MysqlQueryBuilder.php` on the CMS.

Then try again with the same starting conditions, i.e. the ordering not being messed up by the previous test, e.g. by making a new installation again before this test.

Result: Issue should be fixed by this PR also for MariaDB 10.x >= 10.2.0.

**If you also have a MySQL 8.x database available:**

Try to reproduce https://github.com/joomla/joomla-cms/issues/45236 .

Result: Issue does not happen.

Apply the changes from this PR as described before.

Try again to reproduce https://github.com/joomla/joomla-cms/issues/45236 .

Result: Issue still does not happen, ordering works as well as before.

### Documentation Changes Required

None.