### PR TITLE
[3.x] Use $this->quoteNameString instead of quoteNameString

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1598,7 +1598,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
                 continue;
             }
 
-            $parts[] = quoteNameString($part, true);
+            $parts[] = $this->quoteNameString($part, true);
         }
 
         return implode('.', $parts);


### PR DESCRIPTION
### Summary of Changes
With the fix of the `quoteNameStr()` method, the `$this->` was forgotten. This PR fixes that.
