### PR TITLE
[4.0] Deprecated class attribute

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -1228,6 +1228,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      * Method to get the first row of the result set from the database query as an object.
      *
      * @param   string  $class  The class name to use for the returned row object.
+     *                          The $class parameter is deprecated in 4.x and will be removed in 6.0 without a replacement.
      *
      * @return  mixed  The return value or null if the query failed.
      *
@@ -1275,6 +1276,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
      *
      * @param   string  $key    The name of a field on which to key the result array.
      * @param   string  $class  The class name to use for the returned row objects.
+     *                          The $class parameter is deprecated in 4.x and will be removed in 6.0 without a replacement.
      *
      * @return  mixed  The return value or null if the query failed.
      *

--- a/src/DatabaseIterator.php
+++ b/src/DatabaseIterator.php
@@ -70,9 +70,11 @@ class DatabaseIterator implements \Countable, \Iterator
      * @param   StatementInterface  $statement  The statement holding the result set to iterate.
      * @param   string              $column     An option column to use as the iterator key.
      * @param   string              $class      The class of object that is returned.
+     *                                          The $class parameter is deprecated in 4.x and will be removed in 6.0
+     *                                          without a replacement.
      *
-     * @since   1.0
      * @throws  \InvalidArgumentException
+     *@since   1.0
      */
     public function __construct(StatementInterface $statement, $column = null, $class = \stdClass::class)
     {

--- a/src/DatabaseIterator.php
+++ b/src/DatabaseIterator.php
@@ -74,7 +74,7 @@ class DatabaseIterator implements \Countable, \Iterator
      *                                          without a replacement.
      *
      * @throws  \InvalidArgumentException
-     *@since   1.0
+     * @since   1.0
      */
     public function __construct(StatementInterface $statement, $column = null, $class = \stdClass::class)
     {


### PR DESCRIPTION
Pull Request for Issue #254 

### Summary of Changes
In Meeting 106 of the maintainers team the team decided to remove the class parameter from loadObject, loadObjectList and DatabaseIterator. 

This way (ussing a custom class as result) of fetching data is not supported over all database drivers so it can lead to problems in the development and using the database package.

### Testing Instructions
No tests possible it is ony documenting that the parameter is deprecated and will be removed with version 6 of the package.

### Documentation Changes Required
No changes needed it is so widly used that it wasn't part of the documentation ;-)