### PR TITLE
Add mysqli exception mode

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -202,7 +202,10 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
             throw new UnsupportedAdapterException('The MySQLi extension is not available');
         }
 
-        $this->connection = mysqli_init();
+        // Enable mysqli error reporting
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+        $this->connection = new \mysqli();
 
         $connectionFlags = 0;
 
@@ -232,21 +235,22 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
             );
         }
 
-        // Attempt to connect to the server, use error suppression to silence warnings and allow us to throw an Exception separately.
-        $connected = @$this->connection->real_connect(
-            $this->options['host'],
-            $this->options['user'],
-            $this->options['password'],
-            null,
-            $this->options['port'],
-            $this->options['socket'],
-            $connectionFlags
-        );
-
-        if (!$connected) {
+        try {
+            // Attempt to connect to the server, use error suppression to silence warnings and allow us to throw an Exception separately.
+            @$this->connection->real_connect(
+                $this->options['host'],
+                $this->options['user'],
+                $this->options['password'],
+                null,
+                $this->options['port'],
+                $this->options['socket'],
+                $connectionFlags
+            );
+        } catch (\mysqli_sql_exception $e) {
             throw new ConnectionFailureException(
-                'Could not connect to database: ' . $this->connection->connect_error,
-                $this->connection->connect_errno
+                'Could not connect to database: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
             );
         }
 
@@ -783,8 +787,10 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
             return false;
         }
 
-        if (!$this->connection->select_db($database)) {
-            throw new ConnectionFailureException('Could not connect to database.');
+        try {
+            $this->connection->select_db($database);
+        } catch (\mysqli_sql_exception $e) {
+            throw new ConnectionFailureException('Could not connect to database: ' . $e->getMessage(), $e->getCode(), $e);
         }
 
         return true;
@@ -810,20 +816,26 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         // Which charset should I use, plain utf8 or multibyte utf8mb4?
         $charset = $this->utf8mb4 && $this->options['utf8mb4'] ? 'utf8mb4' : 'utf8';
 
-        $result = @$this->connection->set_charset($charset);
-
-        /*
-         * If I could not set the utf8mb4 charset then the server doesn't support utf8mb4 despite claiming otherwise. This happens on old MySQL
-         * server versions (less than 5.5.3) using the mysqlnd PHP driver. Since mysqlnd masks the server version and reports only its own we
-         * can not be sure if the server actually does support UTF-8 Multibyte (i.e. it's MySQL 5.5.3 or later). Since the utf8mb4 charset is
-         * undefined in this case we catch the error and determine that utf8mb4 is not supported!
-         */
-        if (!$result && $this->utf8mb4 && $this->options['utf8mb4']) {
-            $this->utf8mb4 = false;
-            $result        = @$this->connection->set_charset('utf8');
+        try {
+            $this->connection->set_charset($charset);
+        } catch (\mysqli_sql_exception) {
+            /*
+            * If I could not set the utf8mb4 charset then the server doesn't support utf8mb4 despite claiming otherwise. This happens on old MySQL
+            * server versions (less than 5.5.3) using the mysqlnd PHP driver. Since mysqlnd masks the server version and reports only its own we
+            * can not be sure if the server actually does support UTF-8 Multibyte (i.e. it's MySQL 5.5.3 or later). Since the utf8mb4 charset is
+            * undefined in this case we catch the error and determine that utf8mb4 is not supported!
+            */
+            if ($this->utf8mb4 && $this->options['utf8mb4']) {
+                $this->utf8mb4 = false;
+                try {
+                    $this->connection->set_charset('utf8');
+                } catch (\mysqli_sql_exception) {
+                    return false;
+                }
+            }
         }
 
-        return $result;
+        return true;
     }
 
     /**
@@ -841,8 +853,11 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         if (!$toSavepoint || $this->transactionDepth <= 1) {
             $this->connect();
 
-            if ($this->connection->commit()) {
+            try {
+                $this->connection->commit();
                 $this->transactionDepth = 0;
+            } catch (\mysqli_sql_exception) {
+                // TODO: Handle commit failure?
             }
 
             return;
@@ -866,8 +881,11 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         if (!$toSavepoint || $this->transactionDepth <= 1) {
             $this->connect();
 
-            if ($this->connection->rollback()) {
+            try {
+                $this->connection->rollback();
                 $this->transactionDepth = 0;
+            } catch (\mysqli_sql_exception) {
+                // TODO: Handle rollback failure?
             }
 
             return;
@@ -922,12 +940,11 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
     {
         $this->connect();
 
-        $cursor = $this->connection->query($sql);
-
-        // If an error occurred handle it.
-        if (!$cursor) {
-            $errorNum = (int) $this->connection->errno;
-            $errorMsg = (string) $this->connection->error;
+        try {
+            $this->connection->query($sql);
+        } catch (\mysqli_sql_exception $e) {
+            $errorNum = $e->getCode();
+            $errorMsg = $e->getMessage();
 
             // Check if the server was disconnected.
             if (!$this->connected()) {
@@ -935,7 +952,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
                     // Attempt to reconnect.
                     $this->connection = null;
                     $this->connect();
-                } catch (ConnectionFailureException $e) {
+                } catch (ConnectionFailureException) {
                     // If connect fails, ignore that exception and throw the normal exception.
                     throw new ExecutionFailureException($sql, $errorMsg, $errorNum);
                 }
@@ -946,12 +963,6 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
             // The server was not disconnected.
             throw new ExecutionFailureException($sql, $errorMsg, $errorNum);
-        }
-
-        $this->freeResult();
-
-        if ($cursor instanceof \mysqli_result) {
-            $cursor->free_result();
         }
 
         return true;

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -236,8 +236,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         }
 
         try {
-            // Attempt to connect to the server, use error suppression to silence warnings and allow us to throw an Exception separately.
-            @$this->connection->real_connect(
+            $this->connection->real_connect(
                 $this->options['host'],
                 $this->options['user'],
                 $this->options['password'],

--- a/src/Mysqli/MysqliStatement.php
+++ b/src/Mysqli/MysqliStatement.php
@@ -135,10 +135,10 @@ class MysqliStatement implements StatementInterface
 
         $query = $this->prepareParameterKeyMapping($query);
 
-        $this->statement  = $connection->prepare($query);
-
-        if (!$this->statement) {
-            throw new PrepareStatementFailureException($this->connection->error, $this->connection->errno);
+        try {
+            $this->statement = $connection->prepare($query);
+        } catch (\mysqli_sql_exception $e) {
+            throw new PrepareStatementFailureException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -394,19 +394,21 @@ class MysqliStatement implements StatementInterface
 
             array_unshift($params, implode('', $types));
 
-            if (!\call_user_func_array([$this->statement, 'bind_param'], $params)) {
-                throw new PrepareStatementFailureException($this->statement->error, $this->statement->errno);
+            try {
+                \call_user_func_array([$this->statement, 'bind_param'], $params);
+            } catch (\Exception $e) {
+                throw new PrepareStatementFailureException($e->getMessage(), $e->getCode(), $e);
             }
         } elseif ($parameters !== null) {
-            if (!$this->bindValues($parameters)) {
-                throw new PrepareStatementFailureException($this->statement->error, $this->statement->errno);
+            try {
+                $this->bindValues($parameters);
+            } catch (\Exception $e) {
+                throw new PrepareStatementFailureException($e->getMessage(), $e->getCode(), $e);
             }
         }
 
         try {
-            if (!$this->statement->execute()) {
-                throw new ExecutionFailureException($this->query, $this->statement->error, $this->statement->errno);
-            }
+            $this->statement->execute();
         } catch (\Throwable $e) {
             throw new ExecutionFailureException($this->query, $e->getMessage(), $e->getCode(), $e);
         }
@@ -439,9 +441,7 @@ class MysqliStatement implements StatementInterface
                 $refs[$key] =& $value;
             }
 
-            if (!\call_user_func_array([$this->statement, 'bind_result'], $refs)) {
-                throw new \RuntimeException($this->statement->error, $this->statement->errno);
-            }
+            \call_user_func_array([$this->statement, 'bind_result'], $refs);
         }
 
         $this->result = true;
@@ -483,10 +483,6 @@ class MysqliStatement implements StatementInterface
 
         if ($values === null) {
             return false;
-        }
-
-        if ($values === false) {
-            throw new \RuntimeException($this->statement->error, $this->statement->errno);
         }
 
         switch ($fetchStyle) {
@@ -540,7 +536,11 @@ class MysqliStatement implements StatementInterface
      */
     private function fetchData()
     {
-        $return = $this->statement->fetch();
+        try {
+            $return = $this->statement->fetch();
+        } catch (\Throwable $e) {
+            throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
+        }
 
         if ($return === true) {
             $values = [];


### PR DESCRIPTION
This PR changes the `MysqliDriver` to use exception mode just like PDO does. I tried not to make too many changes and stick to the previous style. There was some dead code in `executeUnpreparedQuery` which I removed to make the change easier. 