### PR TITLE
Remove reference from return of getBounded

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -629,7 +629,7 @@ abstract class DatabaseDriver implements DatabaseInterface, DispatcherAwareInter
         $this->count++;
 
         // Get list of bound parameters
-        $bounded =& $this->sql->getBounded();
+        $bounded = $this->sql->getBounded();
 
         // If there is a monitor registered, let it know we are starting this query
         if ($this->monitor) {

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -2049,7 +2049,7 @@ abstract class DatabaseQuery implements QueryInterface
      *
      * @since   1.5.0
      */
-    public function &getBounded($key = null)
+    public function getBounded($key = null)
     {
         if (empty($key)) {
             return $this->bounded;

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -432,7 +432,7 @@ abstract class PdoDriver extends DatabaseDriver
         $this->count++;
 
         // Get list of bounded parameters
-        $bounded =& $this->sql->getBounded();
+        $bounded = $this->sql->getBounded();
 
         // If there is a monitor registered, let it know we are starting this query
         if ($this->monitor) {

--- a/src/Query/PreparableInterface.php
+++ b/src/Query/PreparableInterface.php
@@ -71,5 +71,5 @@ interface PreparableInterface
      *
      * @since   1.0
      */
-    public function &getBounded($key = null);
+    public function getBounded($key = null);
 }

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -577,7 +577,7 @@ class SqlsrvDriver extends DatabaseDriver
         $this->count++;
 
         // Get list of bounded parameters
-        $bounded =& $this->sql->getBounded();
+        $bounded = $this->sql->getBounded();
 
         // If there is a monitor registered, let it know we are starting this query
         if ($this->monitor) {


### PR DESCRIPTION
From what I can see the reference is unused. It might be a leftover from some old code. 

Reasoning:
- Array is a zval, every element in the array is a separate zval, and every property of the object is a zval. 
- Only the property zvals are passed by reference to another function.
- You can replace the array and it won't change the binding. You can replace an element in the array and it won't change the binding. Only changing the `value` property would change the binding.
- `startQuery` is the only method which uses the referenced array but it doesn't take a referenced parameter, so it cannot change the referenced array. 
- Therefore, there is no place in the code currently where this reference is used. It can be safely removed. 

https://www.php.net/manual/en/features.gc.refcounting-basics.php#features.gc.compound-types

Technically, this is an ABI break, so I understand if you may not want to merge it because of that. 

<details>
<summary>Code to test it and play around locally without DB:</summary>

```
<?php

class Sample
{
    private array $data = [];

    public function getBounded(): array
    {
        return $this->data;
    }

    public function passArray(array &$input)
    {
        $this->data = $input;
        $arr = $this->getBounded();
        $this->startQuery($arr);
        foreach ($arr as $i => $item) {
            $this->bindSingle($item->value, $i);
        }

        $this->data[0]->value = 10;
        $this->data[1] = new Dummy(20);
        $this->data = [new Dummy(30), new Dummy(40), new Dummy(50)];
    }

    private int $singleItem0 = 0;

    private int $singleItem1 = 0;

    private int $singleItem2 = 0;

    private function bindSingle(int &$item, int $index = 0)
    {
        $this->{"singleItem$index"} = &$item;
    }

    public function startQuery(array $items)
    {
        $items[1]->value = 99;
    }

    public function debugOutput()
    {
        var_dump($this->data);
        var_dump($this->singleItem0);
        var_dump($this->singleItem1);
        var_dump($this->singleItem2);
    }
}

$sample = new Sample();

class Dummy
{
    public function __construct(public int $value = 0)
    {
    }
}

$testDummy = new Dummy(3);
$input = [new Dummy(1), new Dummy(2), $testDummy];
$sample->passArray($input);
$testDummy->value = 555;
$sample->debugOutput();
```
</details>