### PR TITLE
Remove escape when not with string

### DIFF
--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -509,7 +509,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 
         foreach ($tables as $table) {
             // Set the query to get the table CREATE statement.
-            $row = $this->setQuery('SHOW CREATE TABLE ' . $this->quoteName($this->escape($table)))->loadRow();
+            $row = $this->setQuery('SHOW CREATE TABLE ' . $this->quoteName($table))->loadRow();
 
             // Populate the result array based on the create statements.
             $result[$table] = $row[1];
@@ -536,7 +536,7 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
         $result = [];
 
         // Set the query to get the table fields statement.
-        $fields = $this->setQuery('SHOW FULL COLUMNS FROM ' . $this->quoteName($this->escape($table)))->loadObjectList();
+        $fields = $this->setQuery('SHOW FULL COLUMNS FROM ' . $this->quoteName($table))->loadObjectList();
 
         // If we only want the type as the value add just that to the list.
         if ($typeOnly) {


### PR DESCRIPTION
Methods `quoteName` and `escape` cannot be used together as they serve different purposes. `escape` is for formatting strings in SQL, whereas `quoteName` is for formatting identifiers. Using both of them at the same time will lead to incorrect results. 