### PR TITLE
Add bindValue method to DatabaseQuery

### DIFF
--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -963,6 +963,30 @@ class DatabaseQueryTest extends TestCase
     }
 
     /**
+     * @testdox  The bind method records a bound parameter for the query
+     *
+     * @param   array|string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+     *                                                the form ':key', but can also be an integer.
+     * @param   mixed                 $value          The value that will be bound. It can be an array, in this case it has to be
+     *                                                same length of $key; The value is passed by reference to support output
+     *                                                parameters such as those possible with stored procedures.
+     * @param   array|string          $dataType       Constant corresponding to a SQL datatype. It can be an array, in this case it
+     *                                                has to be same length of $key
+     * @param   array                 $expected       The expected structure of `$bounded`
+     */
+    public function testBindValue()
+    {
+        $this->assertSame($this->query, $this->query->bindValue(':bindValue', 'JustValueNoReference', ParameterType::STRING), 'The query builder supports method chaining');
+
+        $this->assertEquals(
+            [
+                ':bindValue' => (object) ['value' => 'JustValueNoReference', 'dataType' => 'string', 'length' => 0, 'driverOptions' => []],
+            ],
+            $this->query->bounded
+        );
+    }
+
+    /**
      * @testdox  The bind method does not record bound parameters when the keys and values are an unbalanced number of items
      */
     public function testBindUnbalancedKeyValue()

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1940,6 +1940,30 @@ abstract class DatabaseQuery implements QueryInterface
     }
 
     /**
+     * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution.
+     * 
+     * Proxy method to self::bind() without the need to provide a referenceable input for value
+     *
+     * @param   array|string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+     *                                                the form ':key', but can also be an integer.
+     * @param   mixed                 $value          The value that will be bound. It can be an array, in this case it has to be
+     *                                                same length of $key
+     * @param   array|string          $dataType       Constant corresponding to a SQL datatype. It can be an array, in this case it
+     *                                                has to be same length of $key
+     * @param   integer               $length         The length of the variable. Usually required for OUTPUT parameters.
+     * @param   array                 $driverOptions  Optional driver options to be used.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \InvalidArgumentException
+     */
+    public function bindValue($key, $value, $dataType = ParameterType::STRING, $length = 0, $driverOptions = [])
+    {
+        return $this->bind($key, $value, $dataType, $length, $driverOptions);
+    }
+
+    /**
      * Method to unbind a bound variable.
      *
      * @param   array|string|integer  $key  The key or array of keys to unbind.

--- a/src/DatabaseQuery.php
+++ b/src/DatabaseQuery.php
@@ -1941,7 +1941,7 @@ abstract class DatabaseQuery implements QueryInterface
 
     /**
      * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution.
-     * 
+     *
      * Proxy method to self::bind() without the need to provide a referenceable input for value
      *
      * @param   array|string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of


### PR DESCRIPTION
You can't bind a literal or function result directly to the bind value method because it expects a variable.

### Summary of Changes
Add `bindValue` method which is a proxy to the `bind method.

### Testing Instructions
Only a function has been added, test the `bindValue` if it works as you expect `bind` to work without the reference part.

### Documentation Changes Required
Not sure if we have a proper database documentation already, if yes it needs to be added

### Future
Add this method to the `DatabaseQueryInterface`
