### PR TITLE
[3.x] fix unit tests MSSQL (Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,6 @@ jobs:
             - name: Install Composer dependencies
               run: |
                   git config --global --add safe.directory $GITHUB_WORKSPACE
-                  composer install --no-progress --ignore-platform-reqs
+                  composer update
             - name: Run Unit tests
               run: php vendor/bin/phpunit -c phpunit.appveyor_sql2019.xml.dist


### PR DESCRIPTION
### Summary of Changes

Currently, dependencies that may be incompatible with the php version are being installed during the `MSSQL (win)` tests.

In this particular case, [doctrine/instantiator](https://github.com/doctrine/instantiator) is required by phpunit, which causes the error for php 8.1 and 8.2.
Here is the relevant commit which requires a newer php version https://github.com/doctrine/instantiator/commit/21dcb5ff46c2bfbf35dbd8ed96d4d61183c7c9cd

The new syntax requires php 8.3 https://www.php.net/releases/8.3/en.php#typed_class_constants

```php
private const SERIALIZATION_FORMAT_USE_UNSERIALIZER   = 'C';
private const SERIALIZATION_FORMAT_AVOID_UNSERIALIZER = 'O';
```

```php
private const string SERIALIZATION_FORMAT_USE_UNSERIALIZER   = 'C';
private const string SERIALIZATION_FORMAT_AVOID_UNSERIALIZER = 'O';
```

So, as at the other tests, we should use `composer update` instead of `composer install --ignore-platform-reqs`.

### Testing Instructions

unit tests

### Documentation Changes Required

no