### PR TITLE
[4.x] fix install sqlsrv driver in linux unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,19 +160,18 @@ jobs:
                 php_version: ['8.3', '8.4']
         steps:
             - uses: actions/checkout@v4
-            - name: Run Unit tests
+            - name: Prepare SQLSRV environment
               run: |
-                  git config --global --add safe.directory $GITHUB_WORKSPACE
-                  apt-get update
-                  apt-get install -y software-properties-common lsb-release gnupg
-                  curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-                  echo "deb [arch=amd64,armhf,arm64] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" >> /etc/apt/sources.list
+                  curl -sSL -O https://packages.microsoft.com/config/debian/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2 | cut -d '.' -f 1)/packages-microsoft-prod.deb
+                  dpkg -i packages-microsoft-prod.deb
+                  rm packages-microsoft-prod.deb
                   apt-get update
                   ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
                   pecl install sqlsrv && docker-php-ext-enable sqlsrv
-                  pecl install pdo_sqlsrv && docker-php-ext-enable pdo_sqlsrv
                   php --ri sqlsrv
-                  php --ri pdo_sqlsrv
+            - name: Run Unit tests
+              run: |
+                  git config --global --add safe.directory $GITHUB_WORKSPACE
                   composer update
                   ./vendor/bin/phpunit --configuration phpunit.sqlsrv.xml.dist
         services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
             sqlsrv:
                 image: mcr.microsoft.com/mssql/server:2017-latest
                 env:
-                    SA_PASSWORD: Password12!
                     ACCEPT_EULA: Y
+                    MSSQL_SA_PASSWORD: Password12!
                     MSSQL_PID: Developer
 
     tests-unit-windows:

--- a/phpunit.sqlsrv.xml.dist
+++ b/phpunit.sqlsrv.xml.dist
@@ -5,7 +5,7 @@
 		<env name="JOOMLA_TEST_DB_HOST" value="sqlsrv" />
 		<env name="JOOMLA_TEST_DB_PORT" value="1433" />
 		<env name="JOOMLA_TEST_DB_USER" value="sa" />
-		<env name="JOOMLA_TEST_DB_PASSWORD" value="JoomlaFramework123" />
+		<env name="JOOMLA_TEST_DB_PASSWORD" value="Password12!" />
 		<env name="JOOMLA_TEST_DB_DATABASE" value="joomla_ut" />
 		<env name="JOOMLA_TEST_DB_PREFIX" value="" />
 


### PR DESCRIPTION
Pull Request for Issue #

### Issue

sqlsrv unit tests (linux) failing between May 11 and May 18
<img width="500" height="172" alt="image" src="https://github.com/user-attachments/assets/d67c4bfa-b60e-4031-8192-2834a8de8114" />
due missing package
<img width="500" height="244" alt="image" src="https://github.com/user-attachments/assets/b7b02a70-665a-4a82-b3a4-be5165f54e32" />
on May 14 the docker images were updated
<img width="314" height="157" alt="image" src="https://github.com/user-attachments/assets/6f1af797-bc75-4ff1-be14-d6d5890ba15e" />

### Summary of Changes

update installation of microsoft driver (image is debian based)
https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server

replace deprecated environment variable `SA_PASSWORD`
https://learn.microsoft.com/en-us/sql/linux/configure/environment-variables

### Testing Instructions

ci/cd

### Documentation Changes Required

no