### PR TITLE
[4.x] fix connection pgsql (ci)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,9 @@ jobs:
             postgres:
                 image: postgres:${{ matrix.db_version }}-alpine
                 env:
-                    POSTGRES_USER: root
+                    POSTGRES_USER: joomla_ut
                     POSTGRES_PASSWORD: joomla_ut
-                    POSTGRES_DB: test_joomla
+                    POSTGRES_DB: joomla_ut
 
     tests-unit-sqlsrv:
         name: Run Unit tests on SQLsrv

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -6,6 +6,8 @@
 
 namespace Joomla\Database\Tests\Pgsql;
 
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Pgsql\PgsqlDriver;
 use Joomla\Database\Pgsql\PgsqlExporter;
@@ -37,6 +39,32 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
     }
 
     /**
+     * Sets up the fixture.
+     *
+     * This method is called before a test is executed.
+     *
+     * @return  void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            foreach (DatabaseDriver::splitSql(file_get_contents(dirname(__DIR__) . '/Stubs/Schema/pgsql.sql')) as $query) {
+                static::$connection->setQuery($query)
+                    ->execute();
+            }
+        } catch (ExecutionFailureException $exception) {
+            $this->markTestSkipped(
+                \sprintf(
+                    'Could not load PostgreSQL database: %s',
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    /**
      * Tears down the fixture.
      *
      * This method is called after a test is executed.
@@ -44,7 +72,7 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
     protected function tearDown(): void
     {
         foreach (static::$connection->getTableList() as $table) {
-            static::$connection->truncateTable($table);
+            static::$connection->dropTable($table);
         }
     }
 

--- a/Tests/Stubs/Schema/pgsql.sql
+++ b/Tests/Stubs/Schema/pgsql.sql
@@ -1,5 +1,4 @@
--- Purposefully do not add the table prefix to this file as it is mainly processed by the psql CLI or an application like pgAdmin
-CREATE TABLE "dbtest" (
+CREATE TABLE "#__dbtest" (
   "id" serial NOT NULL,
   "title" character varying(50) NOT NULL,
   "start_date" timestamp without time zone NOT NULL,

--- a/phpunit.pgsql.xml.dist
+++ b/phpunit.pgsql.xml.dist
@@ -2,10 +2,10 @@
 <phpunit bootstrap="Tests/bootstrap.php" colors="false">
 	<php>
 		<env name="JOOMLA_TEST_DB_DRIVER" value="pgsql" />
-		<env name="JOOMLA_TEST_DB_HOST" value="pgsql" />
-		<env name="JOOMLA_TEST_DB_PORT" value="5433" />
-		<env name="JOOMLA_TEST_DB_USER" value="postgres" />
-		<env name="JOOMLA_TEST_DB_PASSWORD" value="" />
+		<env name="JOOMLA_TEST_DB_HOST" value="postgres" />
+		<env name="JOOMLA_TEST_DB_PORT" value="5432" />
+		<env name="JOOMLA_TEST_DB_USER" value="joomla_ut" />
+		<env name="JOOMLA_TEST_DB_PASSWORD" value="joomla_ut" />
 		<env name="JOOMLA_TEST_DB_DATABASE" value="joomla_ut" />
 		<env name="JOOMLA_TEST_DB_PREFIX" value="" />
 		<env name="JOOMLA_TEST_DB_SELECT" value="yes" />


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

- `JOOMLA_TEST_DB_HOST` should match service name of workflow file
- `JOOMLA_TEST_DB_PORT`d efault postgres port is 5432
- `JOOMLA_TEST_DB_USER` should match environment variable `POSTGRES_USER`
- `JOOMLA_TEST_DB_PASSWORD` should match environment variable `POSTGRES_PASSWORD`

postgres was handle different in travis (drone im not sure it worked).
The database base was created with commands and manual import the test data. In GitHub Actions we set environment variable `POSTGRES_DB` to create the database.

https://github.com/joomla-framework/database/blob/194415339358b3ded43d5f68446b4fa93e18c3d3/.travis.yml#L229-L231
https://github.com/joomla-framework/database/blob/ff7ee9693fdbd0c041fb6328e457f062aab15ffc/.drone.jsonnet#L170-L173

This PR adjust the handling of test data like mysql/mysqli.

### Testing Instructions

ci/cd

### Documentation Changes Required

no