### PR TITLE
[4.x] resolve PHPUnit Notices

### DIFF
--- a/Tests/DatabaseAwareTraitTest.php
+++ b/Tests/DatabaseAwareTraitTest.php
@@ -30,7 +30,7 @@ class DatabaseAwareTraitTest extends TestCase
      */
     public function testGetSetDatabase(): void
     {
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createStub(DatabaseInterface::class);
 
         $trait = new class () {
             use DatabaseAwareTrait;

--- a/Tests/DatabaseExporterTest.php
+++ b/Tests/DatabaseExporterTest.php
@@ -7,14 +7,10 @@
 
 namespace Joomla\Database\Tests;
 
-use Joomla\Database\DatabaseExporter;
-use Joomla\Database\DatabaseImporter;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Tests\Stubs\TestDatabaseExporter;
-use Joomla\Database\Tests\Stubs\TestDatabaseImporter;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -111,12 +107,11 @@ class DatabaseExporterTest extends TestCase
     }
 
     /**
-     * @testdox  A database drier can be set to the exporter
+     * @testdox  A database driver can be set to the exporter
      */
     public function testSetDbo()
     {
-        /** @var DatabaseInterface|MockObject $db */
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createStub(DatabaseInterface::class);
 
         $this->assertSame($this->exporter, $this->exporter->setDbo($db), 'The exporter supports method chaining');
     }

--- a/Tests/DatabaseFactoryTest.php
+++ b/Tests/DatabaseFactoryTest.php
@@ -131,7 +131,7 @@ class DatabaseFactoryTest extends TestCase
         $databaseDriver = null;
 
         if ($createDb) {
-            $databaseDriver = $this->createMock(MysqliDriver::class);
+            $databaseDriver = $this->createStub(MysqliDriver::class);
         }
 
         $exporter = $this->factory->getExporter($adapter, $databaseDriver);
@@ -194,7 +194,7 @@ class DatabaseFactoryTest extends TestCase
         $databaseDriver = null;
 
         if ($createDb) {
-            $databaseDriver = $this->createMock(MysqliDriver::class);
+            $databaseDriver = $this->createStub(MysqliDriver::class);
         }
 
         $importer = $this->factory->getImporter($adapter, $databaseDriver);
@@ -239,7 +239,7 @@ class DatabaseFactoryTest extends TestCase
         $statement = null;
 
         if ($createStatement) {
-            $statement = $this->createMock(StatementInterface::class);
+            $statement = $this->createStub(StatementInterface::class);
         }
 
         $this->assertInstanceOf(
@@ -287,7 +287,7 @@ class DatabaseFactoryTest extends TestCase
         $databaseDriver = null;
 
         if ($createDb) {
-            $databaseDriver = $this->createMock(MysqliDriver::class);
+            $databaseDriver = $this->createStub(MysqliDriver::class);
         }
 
         $this->assertInstanceOf(

--- a/Tests/DatabaseImporterTest.php
+++ b/Tests/DatabaseImporterTest.php
@@ -7,12 +7,9 @@
 
 namespace Joomla\Database\Tests;
 
-use Joomla\Database\DatabaseImporter;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Tests\Stubs\TestDatabaseImporter;
-use Joomla\Database\Tests\Stubs\TestDatabaseQuery;
 use Joomla\Test\TestHelper;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -65,12 +62,11 @@ class DatabaseImporterTest extends TestCase
     }
 
     /**
-     * @testdox  A database drier can be set to the importer
+     * @testdox  A database driver can be set to the importer
      */
     public function testSetDbo()
     {
-        /** @var DatabaseInterface|MockObject $db */
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createStub(DatabaseInterface::class);
 
         $this->assertSame($this->importer, $this->importer->setDbo($db), 'The importer supports method chaining');
     }

--- a/Tests/DatabaseIteratorTest.php
+++ b/Tests/DatabaseIteratorTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseIterator;
 use Joomla\Database\FetchMode;
 use Joomla\Database\StatementInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +28,7 @@ class DatabaseIteratorTest extends TestCase
 
         $i = 0;
 
-        $statement->expects($this->any())
+        $statement->expects($this->once())
                   ->method('fetch')
                   ->willReturnCallback(
                       function () use ($i) {
@@ -229,8 +230,8 @@ class DatabaseIteratorTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        /** @var StatementInterface|MockObject $statement */
-        $statement = $this->createMock(StatementInterface::class);
+        /** @var StatementInterface|Stub $statement */
+        $statement = $this->createStub(StatementInterface::class);
 
         $iterator = new DatabaseIterator($statement, null, \NonExistingClass::class);
     }

--- a/Tests/DatabaseQueryTest.php
+++ b/Tests/DatabaseQueryTest.php
@@ -13,7 +13,7 @@ use Joomla\Database\Exception\UnknownTypeException;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Tests\Stubs\TestDatabaseQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,14 +24,14 @@ class DatabaseQueryTest extends TestCase
     /**
      * Object being tested
      *
-     * @var  MockObject|DatabaseQuery
+     * @var  DatabaseQuery
      */
     private $query;
 
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -46,7 +46,7 @@ class DatabaseQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new TestDatabaseQuery($this->db);
     }
 
@@ -168,8 +168,7 @@ class DatabaseQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -538,11 +537,14 @@ class DatabaseQueryTest extends TestCase
     #[DataProvider('dataNullDate')]
     public function testNullDate(bool $quoted, string $expected)
     {
-        $this->db->expects($this->once())
+        $db    = $this->createMock(DatabaseInterface::class);
+        $query = new TestDatabaseQuery($db);
+
+        $db->expects($this->once())
             ->method('getNullDate')
             ->willReturn('0000-00-00 00:00:00');
 
-        $this->db->expects($this->any())
+        $db->expects($this->exactly((int) $quoted))
             ->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
@@ -550,7 +552,7 @@ class DatabaseQueryTest extends TestCase
 
         $this->assertSame(
             $expected,
-            $this->query->nullDate($quoted)
+            $query->nullDate($quoted)
         );
     }
 
@@ -582,7 +584,9 @@ class DatabaseQueryTest extends TestCase
      */
     public function testIsNullDatetimeWithDates()
     {
-        $this->db->expects($this->any())
+        $db = $this->createMock(DatabaseInterface::class);
+
+        $db->expects($this->once())
             ->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 foreach ($text as $k => $v) {
@@ -592,7 +596,7 @@ class DatabaseQueryTest extends TestCase
                 return $text;
             });
 
-        $query = new class ($this->db) extends DatabaseQuery {
+        $query = new class ($db) extends DatabaseQuery {
             protected $nullDatetimeList = ['0000-00-00 00:00:00', '1000-01-01 00:00:00'];
 
             public function groupConcat($expression, $separator = ',')
@@ -643,7 +647,10 @@ class DatabaseQueryTest extends TestCase
      */
     public function testQuote()
     {
-        $this->db->expects($this->any())
+        $db    = $this->createMock(DatabaseInterface::class);
+        $query = new TestDatabaseQuery($db);
+
+        $db->expects($this->once())
             ->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
@@ -651,7 +658,7 @@ class DatabaseQueryTest extends TestCase
 
         $this->assertSame(
             "'foo'",
-            $this->query->quote('foo')
+            $query->quote('foo')
         );
     }
 
@@ -672,7 +679,10 @@ class DatabaseQueryTest extends TestCase
      */
     public function testQuoteName()
     {
-        $this->db->expects($this->any())
+        $db    = $this->createMock(DatabaseInterface::class);
+        $query = new TestDatabaseQuery($db);
+
+        $db->expects($this->once())
             ->method('quoteName')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "`" . $text . "`";
@@ -680,7 +690,7 @@ class DatabaseQueryTest extends TestCase
 
         $this->assertSame(
             "`foo`",
-            $this->query->quoteName('foo')
+            $query->quoteName('foo')
         );
     }
 
@@ -1255,13 +1265,15 @@ class DatabaseQueryTest extends TestCase
      */
     public function testCastingToStringInsertSet()
     {
-        $this->db->expects($this->any())
+        $db = $this->createMock(DatabaseInterface::class);
+
+        $db->expects($this->once())
             ->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
 
-        $query = new class ($this->db) extends DatabaseQuery {
+        $query = new class ($db) extends DatabaseQuery {
             public function groupConcat($expression, $separator = ',')
             {
                 return '';
@@ -1289,13 +1301,15 @@ class DatabaseQueryTest extends TestCase
      */
     public function testCastingToStringInsertColumnsValues()
     {
-        $this->db->expects($this->any())
+        $db = $this->createMock(DatabaseInterface::class);
+
+        $db->expects($this->once())
             ->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
 
-        $query = new class ($this->db) extends DatabaseQuery {
+        $query = new class ($db) extends DatabaseQuery {
             public function groupConcat($expression, $separator = ',')
             {
                 return '';

--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -15,10 +15,12 @@ use Joomla\Database\Mysql\MysqlQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Mysql\MysqlDriver
  */
+#[RequiresPhpExtension('pdo_mysql')]
 class MysqlDriverTest extends AbstractDatabaseDriverTestCase
 {
     /**

--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -252,11 +252,14 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
 
             $collationText = match (true) {
                 !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0.30', '>=') => 'utf8mb3_general_ci',
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '11.5', '>=') => 'utf8mb3_uca1400_ai_ci',
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '10.6', '>=') => 'utf8mb3_general_ci',
                 default => 'utf8_general_ci',
             };
 
             $defaultText = match (true) {
                 !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=') => null,
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '11.5', '>=') => null,
                 default => '',
             };
 
@@ -348,12 +351,24 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
             'Index_comment' => '',
         ];
 
-        // MySQL 8.0 adds additional data
+        // MySQL 8.0 adds additional data and casts certain keys to integers
         if (!static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=')) {
+            $dbtestPrimaryKey['Non_unique']   = (int) $dbtestPrimaryKey['Non_unique'];
+            $dbtestPrimaryKey['Seq_in_index'] = (int) $dbtestPrimaryKey['Seq_in_index'];
+            $dbtestPrimaryKey['Cardinality']  = (int) $dbtestPrimaryKey['Cardinality'];
+
             $dbtestPrimaryKey['Visible']    = 'YES';
             if (version_compare(static::$connection->getVersion(), '8.0.13', '>=')) {
                 $dbtestPrimaryKey['Expression'] = null;
             }
+
+        // MariaDB 10.6 adds additional data and casts certain keys to integers
+        } elseif (static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '10.6', '>=')) {
+            $dbtestPrimaryKey['Non_unique']   = (int) $dbtestPrimaryKey['Non_unique'];
+            $dbtestPrimaryKey['Seq_in_index'] = (int) $dbtestPrimaryKey['Seq_in_index'];
+            $dbtestPrimaryKey['Cardinality']  = (int) $dbtestPrimaryKey['Cardinality'];
+
+            $dbtestPrimaryKey['Ignored'] = 'NO';
         }
 
         $keys = [

--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -98,14 +98,6 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
      */
     public static function dataGetTableColumns(): array
     {
-        // For unknown reasons, the connection gets lost on Travis. re-establish, if that happens
-        if (static::$connection === null) {
-            self::setUpBeforeClass();
-        }
-
-        $isMySQL8        = !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=');
-        $useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
-
         return [
             'only column types' => [
                 '#__dbtest',
@@ -125,11 +117,11 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
                 [
                     'id' => (object) [
                         'Field'      => 'id',
-                        'Type'       => $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned',
-                        'Collation'  => $isMySQL8 ? null : '',
+                        'Type'       => '<<<variable>>>',
+                        'Collation'  => null,
                         'Null'       => 'NO',
                         'Key'        => 'PRI',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => null,
                         'Extra'      => 'auto_increment',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -137,10 +129,10 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
                     'title' => (object) [
                         'Field'      => 'title',
                         'Type'       => 'varchar(50)',
-                        'Collation'  => $isMySQL8 ? 'utf8mb3_general_ci' : 'utf8_general_ci',
+                        'Collation'  => '<<<variable>>>',
                         'Null'       => 'NO',
                         'Key'        => '',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => '<<<variable>>>',
                         'Extra'      => '',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -159,10 +151,10 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
                     'description' => (object) [
                         'Field'      => 'description',
                         'Type'       => 'text',
-                        'Collation'  => $isMySQL8 ? 'utf8mb3_general_ci' : 'utf8_general_ci',
+                        'Collation'  => '<<<variable>>>',
                         'Null'       => 'NO',
                         'Key'        => '',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => '<<<variable>>>',
                         'Extra'      => '',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -243,6 +235,40 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
     /*
      * Overrides for parent class test cases
      */
+
+    /**
+     * @testdox  Information about the columns of a database table is returned
+     *
+     * @param   string   $table     The name of the database table.
+     * @param   boolean  $typeOnly  True (default) to only return field types.
+     * @param   array    $expected  Expected result.
+     */
+    #[DataProvider('dataGetTableColumns')]
+    public function testGetTableColumns(string $table, bool $typeOnly, array $expected)
+    {
+        if (!$typeOnly) {
+            $isMySQL8        = !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=');
+            $useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
+
+            $collationText = match (true) {
+                !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0.30', '>=') => 'utf8mb3_general_ci',
+                default => 'utf8_general_ci',
+            };
+
+            $defaultText = match (true) {
+                !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=') => null,
+                default => '',
+            };
+
+            $expected['id']->Type               = $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned';
+            $expected['title']->Collation       = $collationText;
+            $expected['title']->Default         = $defaultText;
+            $expected['description']->Collation = $collationText;
+            $expected['description']->Default   = $defaultText;
+        }
+
+        parent::testGetTableColumns($table, $typeOnly, $expected);
+    }
 
     /*
      * Test cases for this subclass
@@ -325,7 +351,9 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
         // MySQL 8.0 adds additional data
         if (!static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=')) {
             $dbtestPrimaryKey['Visible']    = 'YES';
-            $dbtestPrimaryKey['Expression'] = null;
+            if (version_compare(static::$connection->getVersion(), '8.0.13', '>=')) {
+                $dbtestPrimaryKey['Expression'] = null;
+            }
         }
 
         $keys = [

--- a/Tests/Mysql/MysqlDriverTest.php
+++ b/Tests/Mysql/MysqlDriverTest.php
@@ -43,7 +43,7 @@ class MysqlDriverTest extends AbstractDatabaseDriverTestCase
 
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'mysql') {
+        if (!static::$connection) {
             self::markTestSkipped('MySQL database not configured.');
         }
     }

--- a/Tests/Mysql/MysqlExporterTest.php
+++ b/Tests/Mysql/MysqlExporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Mysql\MysqlDriver;
 use Joomla\Database\Mysql\MysqlExporter;
 use Joomla\Database\Mysql\MysqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class MysqlExporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|MysqlDriver
+     * @var  Stub|MysqlDriver
      */
     private $db;
 
@@ -37,20 +37,17 @@ class MysqlExporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(MysqlDriver::class);
+        $this->db = $this->createStub(MysqlDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqlQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -78,8 +75,7 @@ class MysqlExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -99,8 +95,7 @@ class MysqlExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -224,8 +219,7 @@ XML
             ->withData($withData);
 
         if ($withData) {
-            $this->db->expects($this->once())
-                ->method('loadObjectList')
+            $this->db->method('loadObjectList')
                 ->willReturn(
                     [
                         (object) [
@@ -295,7 +289,7 @@ XML
         $exporter = new MysqlExporter();
 
         if ($db) {
-            $exporter->setDbo($this->createMock($db));
+            $exporter->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Mysql/MysqlImporterTest.php
+++ b/Tests/Mysql/MysqlImporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Mysql\MysqlDriver;
 use Joomla\Database\Mysql\MysqlImporter;
 use Joomla\Database\Mysql\MysqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class MysqlImporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|MysqlDriver
+     * @var  Stub|MysqlDriver
      */
     private $db;
 
@@ -63,20 +63,17 @@ class MysqlImporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(MysqlDriver::class);
+        $this->db = $this->createStub(MysqlDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqlQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -104,8 +101,7 @@ class MysqlImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -125,16 +121,14 @@ class MysqlImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableList')
+        $this->db->method('getTableList')
             ->willReturn(
                 [
                     'jos_dbtest',
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('insertObject')
+        $this->db->method('insertObject')
             ->willReturnCallback(
                 function ($table, &$object, $key = null) {
                     if (!isset($this->executedInsertObjects[$table])) {
@@ -147,8 +141,7 @@ class MysqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -165,8 +158,7 @@ class MysqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(
                 function ($text, $escape = true) {
                     if (is_string($text)) {
@@ -183,8 +175,7 @@ class MysqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('setQuery')
+        $this->db->method('setQuery')
             ->willReturnCallback(
                 function ($query, $offset = 0, $limit = 0) {
                     $this->executedQueries[] = $query;
@@ -383,7 +374,7 @@ class MysqlImporterTest extends TestCase
         $importer = new MysqlImporter();
 
         if ($db) {
-            $importer->setDbo($this->createMock($db));
+            $importer->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Mysql/MysqlImporterTest.php
+++ b/Tests/Mysql/MysqlImporterTest.php
@@ -190,7 +190,7 @@ class MysqlImporterTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $this->expectedInsertObjects = [];
+        $this->executedInsertObjects = [];
         $this->executedQueries       = [];
     }
 

--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -24,7 +24,7 @@ class MysqlPreparedStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'mysql') {
+        if (!static::$connection) {
             self::markTestSkipped('MySQL database not configured.');
         }
     }

--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -9,7 +9,9 @@ namespace Joomla\Database\Tests\Mysql;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
+#[RequiresPhpExtension('pdo_mysql')]
 class MysqlPreparedStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Mysql/MysqlPreparedStatementTest.php
+++ b/Tests/Mysql/MysqlPreparedStatementTest.php
@@ -9,6 +9,7 @@ namespace Joomla\Database\Tests\Mysql;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_mysql')]
@@ -68,9 +69,8 @@ class MysqlPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
@@ -88,9 +88,8 @@ class MysqlPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure running queries with named parameters appearing once didn't break.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithSingleKey()
     {
         $dummyValue = 'test';

--- a/Tests/Mysql/MysqlQueryTest.php
+++ b/Tests/Mysql/MysqlQueryTest.php
@@ -9,7 +9,7 @@ namespace Joomla\Database\Tests\Mysql;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Mysql\MysqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class MysqlQueryTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -42,7 +42,7 @@ class MysqlQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new MysqlQuery($this->db);
     }
 
@@ -69,8 +69,7 @@ class MysqlQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -97,8 +96,7 @@ class MysqlQueryTest extends TestCase
      */
     public function testGroupConcat()
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -48,7 +48,7 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
 
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'mysqli') {
+        if (!static::$connection) {
             self::markTestSkipped('MySQL database not configured.');
         }
     }

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -255,11 +255,14 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
 
             $collationText = match (true) {
                 !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0.30', '>=') => 'utf8mb3_general_ci',
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '11.5', '>=') => 'utf8mb3_uca1400_ai_ci',
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '10.6', '>=') => 'utf8mb3_general_ci',
                 default => 'utf8_general_ci',
             };
 
             $defaultText = match (true) {
                 !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=') => null,
+                static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '11.5', '>=') => null,
                 default => '',
             };
 
@@ -360,6 +363,15 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
             $dbtestPrimaryKey['Visible']    = 'YES';
             if (version_compare(static::$connection->getVersion(), '8.0.13', '>=')) {
                 $dbtestPrimaryKey['Expression'] = null;
+            }
+
+        // MariaDB 10.6 adds additional data and casts certain keys to integers
+        } elseif (static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '10.6', '>=')) {
+            $dbtestPrimaryKey['Non_unique']   = (int) $dbtestPrimaryKey['Non_unique'];
+            $dbtestPrimaryKey['Seq_in_index'] = (int) $dbtestPrimaryKey['Seq_in_index'];
+            $dbtestPrimaryKey['Cardinality']  = (int) $dbtestPrimaryKey['Cardinality'];
+
+            $dbtestPrimaryKey['Ignored'] = 'NO';
         }
 
         $keys = [

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -16,10 +16,12 @@ use Joomla\Database\Mysqli\MysqliQuery;
 use Joomla\Database\ParameterType;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Mysqli\MysqliDriver
  */
+#[RequiresPhpExtension('mysqli')]
 class MysqliDriverTest extends AbstractDatabaseDriverTestCase
 {
     /**

--- a/Tests/Mysqli/MysqliDriverTest.php
+++ b/Tests/Mysqli/MysqliDriverTest.php
@@ -117,14 +117,6 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
      */
     public static function dataGetTableColumns(): array
     {
-        // For unknown reasons, the connection gets lost on Travis. re-establish, if that happens
-        if (static::$connection === null) {
-            self::setUpBeforeClass();
-        }
-
-        $isMySQL8        = !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=');
-        $useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
-
         return [
             'only column types' => [
                 '#__dbtest',
@@ -144,11 +136,11 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
                 [
                     'id' => (object) [
                         'Field'      => 'id',
-                        'Type'       => $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned',
-                        'Collation'  => $isMySQL8 ? null : '',
+                        'Type'       => '<<<variable>>>',
+                        'Collation'  => null,
                         'Null'       => 'NO',
                         'Key'        => 'PRI',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => null,
                         'Extra'      => 'auto_increment',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -156,10 +148,10 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
                     'title' => (object) [
                         'Field'      => 'title',
                         'Type'       => 'varchar(50)',
-                        'Collation'  => $isMySQL8 ? 'utf8mb3_general_ci' : 'utf8_general_ci',
+                        'Collation'  => '<<<variable>>>',
                         'Null'       => 'NO',
                         'Key'        => '',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => '<<<variable>>>',
                         'Extra'      => '',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -178,10 +170,10 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
                     'description' => (object) [
                         'Field'      => 'description',
                         'Type'       => 'text',
-                        'Collation'  => $isMySQL8 ? 'utf8mb3_general_ci' : 'utf8_general_ci',
+                        'Collation'  => '<<<variable>>>',
                         'Null'       => 'NO',
                         'Key'        => '',
-                        'Default'    => $isMySQL8 ? null : '',
+                        'Default'    => '<<<variable>>>',
                         'Extra'      => '',
                         'Privileges' => 'select,insert,update,references',
                         'Comment'    => '',
@@ -247,6 +239,39 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
     /*
      * Overrides for parent class test cases
      */
+
+    /**
+     * @testdox  Information about the columns of a database table is returned
+     *
+     * @param   string   $table     The name of the database table.
+     * @param   boolean  $typeOnly  True (default) to only return field types.
+     * @param   array    $expected  Expected result.
+     */
+    #[DataProvider('dataGetTableColumns')]
+    public function testGetTableColumns(string $table, bool $typeOnly, array $expected)
+    {
+        if (!$typeOnly) {
+            $useDisplayWidth = static::$connection->isMariaDb() || version_compare(static::$connection->getVersion(), '8.0.17', '<');
+
+            $collationText = match (true) {
+                !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0.30', '>=') => 'utf8mb3_general_ci',
+                default => 'utf8_general_ci',
+            };
+
+            $defaultText = match (true) {
+                !static::$connection->isMariaDb() && version_compare(static::$connection->getVersion(), '8.0', '>=') => null,
+                default => '',
+            };
+
+            $expected['id']->Type               = $useDisplayWidth ? 'int(10) unsigned' : 'int unsigned';
+            $expected['title']->Collation       = $collationText;
+            $expected['title']->Default         = $defaultText;
+            $expected['description']->Collation = $collationText;
+            $expected['description']->Default   = $defaultText;
+        }
+
+        parent::testGetTableColumns($table, $typeOnly, $expected);
+    }
 
     /*
      * Test cases for this subclass
@@ -333,7 +358,8 @@ class MysqliDriverTest extends AbstractDatabaseDriverTestCase
             $dbtestPrimaryKey['Cardinality']  = (int) $dbtestPrimaryKey['Cardinality'];
 
             $dbtestPrimaryKey['Visible']    = 'YES';
-            $dbtestPrimaryKey['Expression'] = null;
+            if (version_compare(static::$connection->getVersion(), '8.0.13', '>=')) {
+                $dbtestPrimaryKey['Expression'] = null;
         }
 
         $keys = [

--- a/Tests/Mysqli/MysqliExporterTest.php
+++ b/Tests/Mysqli/MysqliExporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Mysqli\MysqliDriver;
 use Joomla\Database\Mysqli\MysqliExporter;
 use Joomla\Database\Mysqli\MysqliQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class MysqliExporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|MysqliDriver
+     * @var  Stub|MysqliDriver
      */
     private $db;
 
@@ -37,20 +37,17 @@ class MysqliExporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(MysqliDriver::class);
+        $this->db = $this->createStub(MysqliDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqliQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -78,8 +75,7 @@ class MysqliExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -99,8 +95,7 @@ class MysqliExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -224,8 +219,7 @@ XML
             ->withData($withData);
 
         if ($withData) {
-            $this->db->expects($this->once())
-                ->method('loadObjectList')
+            $this->db->method('loadObjectList')
                 ->willReturn(
                     [
                         (object) [
@@ -295,7 +289,7 @@ XML
         $exporter = new MysqliExporter();
 
         if ($db) {
-            $exporter->setDbo($this->createMock($db));
+            $exporter->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Mysqli/MysqliImporterTest.php
+++ b/Tests/Mysqli/MysqliImporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Mysqli\MysqliDriver;
 use Joomla\Database\Mysqli\MysqliImporter;
 use Joomla\Database\Mysqli\MysqliQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class MysqliImporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|MysqliDriver
+     * @var  Stub|MysqliDriver
      */
     private $db;
 
@@ -63,20 +63,17 @@ class MysqliImporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(MysqliDriver::class);
+        $this->db = $this->createStub(MysqliDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new MysqliQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -104,8 +101,7 @@ class MysqliImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -125,16 +121,14 @@ class MysqliImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableList')
+        $this->db->method('getTableList')
             ->willReturn(
                 [
                     'jos_dbtest',
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('insertObject')
+        $this->db->method('insertObject')
             ->willReturnCallback(
                 function ($table, &$object, $key = null) {
                     if (!isset($this->executedInsertObjects[$table])) {
@@ -147,8 +141,7 @@ class MysqliImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -165,8 +158,7 @@ class MysqliImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(
                 function ($text, $escape = true) {
                     if (is_string($text)) {
@@ -183,8 +175,7 @@ class MysqliImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('setQuery')
+        $this->db->method('setQuery')
             ->willReturnCallback(
                 function ($query, $offset = 0, $limit = 0) {
                     $this->executedQueries[] = $query;
@@ -383,7 +374,7 @@ class MysqliImporterTest extends TestCase
         $importer = new MysqliImporter();
 
         if ($db) {
-            $importer->setDbo($this->createMock($db));
+            $importer->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Mysqli/MysqliImporterTest.php
+++ b/Tests/Mysqli/MysqliImporterTest.php
@@ -190,7 +190,7 @@ class MysqliImporterTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $this->expectedInsertObjects = [];
+        $this->executedInsertObjects = [];
         $this->executedQueries       = [];
     }
 

--- a/Tests/Mysqli/MysqliPreparedStatementTest.php
+++ b/Tests/Mysqli/MysqliPreparedStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
+use Joomla\Test\TestHelper;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
@@ -91,17 +92,11 @@ class MysqliPreparedStatementTest extends DatabaseTestCase
             $rawQuery
         );
 
-        $refObject = new \ReflectionObject($mysqliStatementObject);
-        $refMapping = $refObject->getProperty('parameterKeyMapping');
-        /** @noinspection PhpExpressionResultUnusedInspection */
-        $refMapping->setAccessible(true);
-        $parameterKeyMapping = $refMapping->getValue($mysqliStatementObject);
-
         $this->assertEquals(
             [
                 ':search' => [0, 1],
             ],
-            $parameterKeyMapping
+            TestHelper::getValue($mysqliStatementObject, 'parameterKeyMapping')
         );
     }
 
@@ -119,18 +114,12 @@ class MysqliPreparedStatementTest extends DatabaseTestCase
             $rawQuery
         );
 
-        $refObject = new \ReflectionObject($mysqliStatementObject);
-        $refMapping = $refObject->getProperty('parameterKeyMapping');
-        /** @noinspection PhpExpressionResultUnusedInspection */
-        $refMapping->setAccessible(true);
-        $parameterKeyMapping = $refMapping->getValue($mysqliStatementObject);
-
         $this->assertEquals(
             [
                 ':search' => [0],
                 ':search2' => [1],
             ],
-            $parameterKeyMapping
+            TestHelper::getValue($mysqliStatementObject, 'parameterKeyMapping')
         );
     }
 

--- a/Tests/Mysqli/MysqliPreparedStatementTest.php
+++ b/Tests/Mysqli/MysqliPreparedStatementTest.php
@@ -10,7 +10,9 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
+#[RequiresPhpExtension('mysqli')]
 class MysqliPreparedStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Mysqli/MysqliPreparedStatementTest.php
+++ b/Tests/Mysqli/MysqliPreparedStatementTest.php
@@ -25,7 +25,7 @@ class MysqliPreparedStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'mysqli') {
+        if (!static::$connection) {
             self::markTestSkipped('MySQL database not configured.');
         }
     }

--- a/Tests/Mysqli/MysqliPreparedStatementTest.php
+++ b/Tests/Mysqli/MysqliPreparedStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('mysqli')]
@@ -135,9 +136,8 @@ class MysqliPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithDuplicateKey()
     {
         $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search';
@@ -150,9 +150,8 @@ class MysqliPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure running queries with named parameters appearing once didn't break.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithSingleKey()
     {
         $statement = 'SELECT * FROM dbtest WHERE `title` LIKE :search OR `description` LIKE :search2';

--- a/Tests/Mysqli/MysqliQueryTest.php
+++ b/Tests/Mysqli/MysqliQueryTest.php
@@ -9,7 +9,7 @@ namespace Joomla\Database\Tests\Mysqli;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Mysqli\MysqliQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class MysqliQueryTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -42,7 +42,7 @@ class MysqliQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new MysqliQuery($this->db);
     }
 
@@ -69,8 +69,7 @@ class MysqliQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -97,8 +96,7 @@ class MysqliQueryTest extends TestCase
      */
     public function testGroupConcat()
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });

--- a/Tests/Mysqli/MysqliStatementTest.php
+++ b/Tests/Mysqli/MysqliStatementTest.php
@@ -10,10 +10,12 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Mysqli\MysqliStatement
  */
+#[RequiresPhpExtension('mysqli')]
 class MysqliStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Mysqli/MysqliStatementTest.php
+++ b/Tests/Mysqli/MysqliStatementTest.php
@@ -28,7 +28,7 @@ class MysqliStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'mysqli') {
+        if (!static::$connection) {
             self::markTestSkipped('MySQL database not configured.');
         }
     }

--- a/Tests/Mysqli/MysqliStatementTest.php
+++ b/Tests/Mysqli/MysqliStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Mysqli\MysqliStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
@@ -72,9 +73,8 @@ class MysqliStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure that named values with matching named params are correctly prepared, this simulates a whereIn condition.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testStatementPreparesManyArrayValues()
     {
         $query = 'SELECT * FROM dbtest WHERE id IN (:preparedArray1,:preparedArray2,:preparedArray3,:preparedArray4,:preparedArray5,:preparedArray6,:preparedArray7,:preparedArray8,:preparedArray9,:preparedArray10)';
@@ -84,9 +84,8 @@ class MysqliStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure that named values with matching named params are correctly prepared (part 2), this simulates a general use case.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testStatementWithKeysMatching()
     {
         $query = 'SELECT * FROM dbtest WHERE `id` = :id AND `title` = :id_title';
@@ -97,9 +96,8 @@ class MysqliStatementTest extends DatabaseTestCase
     /**
      * Regression test to ensure that named values with matching named params are correctly prepared (part 3).
      * This simulates a general use case for a search function where we reuse the same prepared statement term.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testStatementWithMultipleUseOfVars()
     {
         $query = 'SELECT * FROM `dbtest` WHERE `description` LIKE :search_term AND `title` LIKE :search_term';

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -33,7 +33,7 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'pgsql') {
+        if (!static::$connection) {
             self::markTestSkipped('PostgreSQL database not configured.');
         }
     }

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -326,14 +326,7 @@ class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
      */
     public function testGetConnectionEncryption()
     {
-        $expectedResult = '';
-
-        if (\getenv('TRAVIS') === 'true' && in_array(\getenv('PGSQL_VERSION'), ['9.5', '9.6', '10.0'])) {
-            $expectedResult = 'TLSv1.2 (ECDHE-RSA-AES256-GCM-SHA384)';
-        }
-
-        $this->assertSame(
-            $expectedResult,
+        $this->assertEmpty(
             static::$connection->getConnectionEncryption(),
             'The database connection is not encrypted by default'
         );

--- a/Tests/Pgsql/PgsqlDriverTest.php
+++ b/Tests/Pgsql/PgsqlDriverTest.php
@@ -13,10 +13,12 @@ use Joomla\Database\Pgsql\PgsqlImporter;
 use Joomla\Database\Pgsql\PgsqlQuery;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Pgsql\PgsqlDriver
  */
+#[RequiresPhpExtension('pdo_pgsql')]
 class PgsqlDriverTest extends AbstractDatabaseDriverTestCase
 {
     /**

--- a/Tests/Pgsql/PgsqlExporterTest.php
+++ b/Tests/Pgsql/PgsqlExporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Pgsql\PgsqlDriver;
 use Joomla\Database\Pgsql\PgsqlExporter;
 use Joomla\Database\Pgsql\PgsqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class PgsqlExporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|PgsqlDriver
+     * @var  Stub|PgsqlDriver
      */
     private $db;
 
@@ -37,20 +37,17 @@ class PgsqlExporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(PgsqlDriver::class);
+        $this->db = $this->createStub(PgsqlDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new PgsqlQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -88,8 +85,7 @@ class PgsqlExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -102,8 +98,7 @@ class PgsqlExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableSequences')
+        $this->db->method('getTableSequences')
             ->willReturn(
                 [
                     (object) [
@@ -121,8 +116,7 @@ class PgsqlExporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -252,8 +246,7 @@ XML
             ->withData($withData);
 
         if ($withData) {
-            $this->db->expects($this->once())
-                ->method('loadObjectList')
+            $this->db->method('loadObjectList')
                 ->willReturn(
                     [
                         (object) [
@@ -323,7 +316,7 @@ XML
         $exporter = new PgsqlExporter();
 
         if ($db) {
-            $exporter->setDbo($this->createMock($db));
+            $exporter->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Pgsql/PgsqlImporterTest.php
+++ b/Tests/Pgsql/PgsqlImporterTest.php
@@ -195,7 +195,7 @@ class PgsqlImporterTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $this->expectedInsertObjects = [];
+        $this->executedInsertObjects = [];
         $this->executedQueries       = [];
     }
 

--- a/Tests/Pgsql/PgsqlImporterTest.php
+++ b/Tests/Pgsql/PgsqlImporterTest.php
@@ -11,7 +11,7 @@ use Joomla\Database\Pgsql\PgsqlDriver;
 use Joomla\Database\Pgsql\PgsqlImporter;
 use Joomla\Database\Pgsql\PgsqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ class PgsqlImporterTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|PgsqlDriver
+     * @var  Stub|PgsqlDriver
      */
     private $db;
 
@@ -63,20 +63,17 @@ class PgsqlImporterTest extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->createMock(PgsqlDriver::class);
+        $this->db = $this->createStub(PgsqlDriver::class);
 
-        $this->db->expects($this->any())
-            ->method('getPrefix')
+        $this->db->method('getPrefix')
             ->willReturn('jos_');
 
-        $this->db->expects($this->any())
-            ->method('createQuery')
+        $this->db->method('createQuery')
             ->willReturnCallback(function () {
                 return new PgsqlQuery($this->db);
             });
 
-        $this->db->expects($this->any())
-            ->method('getTableColumns')
+        $this->db->method('getTableColumns')
             ->willReturn(
                 [
                     'id' => (object) [
@@ -98,8 +95,7 @@ class PgsqlImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableKeys')
+        $this->db->method('getTableKeys')
             ->willReturn(
                 [
                     (object) [
@@ -112,16 +108,14 @@ class PgsqlImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableList')
+        $this->db->method('getTableList')
             ->willReturn(
                 [
                     'jos_dbtest',
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('getTableSequences')
+        $this->db->method('getTableSequences')
             ->willReturn(
                 [
                     (object) [
@@ -139,8 +133,7 @@ class PgsqlImporterTest extends TestCase
                 ]
             );
 
-        $this->db->expects($this->any())
-            ->method('insertObject')
+        $this->db->method('insertObject')
             ->willReturnCallback(
                 function ($table, &$object, $key = null) {
                     if (!isset($this->executedInsertObjects[$table])) {
@@ -153,8 +146,7 @@ class PgsqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quoteName')
+        $this->db->method('quoteName')
             ->willReturnCallback(
                 function ($name, $as = null) {
                     if (is_string($name)) {
@@ -171,8 +163,7 @@ class PgsqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(
                 function ($text, $escape = true) {
                     if (is_string($text)) {
@@ -189,8 +180,7 @@ class PgsqlImporterTest extends TestCase
                 }
             );
 
-        $this->db->expects($this->any())
-            ->method('setQuery')
+        $this->db->method('setQuery')
             ->willReturnCallback(
                 function ($query, $offset = 0, $limit = 0) {
                     $this->executedQueries[] = $query;
@@ -397,7 +387,7 @@ ALTER SEQUENCE "jos_dbtest_id_seq" OWNED BY "jos_dbtest.id"',
         $importer = new PgsqlImporter();
 
         if ($db) {
-            $importer->setDbo($this->createMock($db));
+            $importer->setDbo($this->createStub($db));
         }
 
         if ($from) {

--- a/Tests/Pgsql/PgsqlPreparedStatementTest.php
+++ b/Tests/Pgsql/PgsqlPreparedStatementTest.php
@@ -9,10 +9,12 @@ namespace Joomla\Database\Tests\Pgsql;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Pgsql\PgsqlStatement
  */
+#[RequiresPhpExtension('pdo_pgsql')]
 class PgsqlPreparedStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Pgsql/PgsqlPreparedStatementTest.php
+++ b/Tests/Pgsql/PgsqlPreparedStatementTest.php
@@ -9,6 +9,7 @@ namespace Joomla\Database\Tests\Pgsql;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
@@ -71,9 +72,8 @@ class PgsqlPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
@@ -91,9 +91,8 @@ class PgsqlPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure running queries with named parameters appearing once didn't break.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithSingleKey()
     {
         $dummyValue = 'test';

--- a/Tests/Pgsql/PgsqlPreparedStatementTest.php
+++ b/Tests/Pgsql/PgsqlPreparedStatementTest.php
@@ -27,7 +27,7 @@ class PgsqlPreparedStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'pgsql') {
+        if (!static::$connection) {
             self::markTestSkipped('PostgreSQL database not configured.');
         }
     }

--- a/Tests/Pgsql/PgsqlQueryTest.php
+++ b/Tests/Pgsql/PgsqlQueryTest.php
@@ -9,7 +9,7 @@ namespace Joomla\Database\Tests\Pgsql;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Pgsql\PgsqlQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class PgsqlQueryTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -42,7 +42,7 @@ class PgsqlQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new PgsqlQuery($this->db);
     }
 
@@ -99,8 +99,7 @@ class PgsqlQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -138,8 +137,7 @@ class PgsqlQueryTest extends TestCase
      */
     public function testGroupConcat()
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });

--- a/Tests/Sqlite/SqliteDriverTest.php
+++ b/Tests/Sqlite/SqliteDriverTest.php
@@ -14,10 +14,13 @@ use Joomla\Database\Sqlite\SqliteDriver;
 use Joomla\Database\Sqlite\SqliteQuery;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Sqlite\SqliteDriver
  */
+#[RequiresPhpExtension('pdo_sqlite')]
+#[RequiresPhpExtension('sqlite3')]
 class SqliteDriverTest extends AbstractDatabaseDriverTestCase
 {
     /**

--- a/Tests/Sqlite/SqlitePreparedStatementTest.php
+++ b/Tests/Sqlite/SqlitePreparedStatementTest.php
@@ -9,7 +9,10 @@ namespace Joomla\Database\Tests\Sqlite;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
+#[RequiresPhpExtension('pdo_sqlite')]
+#[RequiresPhpExtension('sqlite3')]
 class SqlitePreparedStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Sqlite/SqlitePreparedStatementTest.php
+++ b/Tests/Sqlite/SqlitePreparedStatementTest.php
@@ -9,6 +9,7 @@ namespace Joomla\Database\Tests\Sqlite;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 #[RequiresPhpExtension('pdo_sqlite')]
@@ -79,9 +80,8 @@ class SqlitePreparedStatementTest extends DatabaseTestCase
 
     /**
      * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
@@ -99,9 +99,8 @@ class SqlitePreparedStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure running queries with named parameters appearing once didn't break.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithSingleKey()
     {
         $dummyValue = 'test';

--- a/Tests/Sqlite/SqliteQueryTest.php
+++ b/Tests/Sqlite/SqliteQueryTest.php
@@ -9,7 +9,7 @@ namespace Joomla\Database\Tests\Sqlite;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Sqlite\SqliteQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class SqliteQueryTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -42,7 +42,7 @@ class SqliteQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new SqliteQuery($this->db);
     }
 
@@ -99,8 +99,7 @@ class SqliteQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -116,8 +115,7 @@ class SqliteQueryTest extends TestCase
      */
     public function testGroupConcat()
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });

--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -13,10 +13,12 @@ use Joomla\Database\Sqlsrv\SqlsrvDriver;
 use Joomla\Database\Sqlsrv\SqlsrvQuery;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Sqlsrv\SqlsrvDriver.
  */
+#[RequiresPhpExtension('sqlsrv')]
 class SqlsrvDriverTest extends AbstractDatabaseDriverTestCase
 {
     /**

--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -33,7 +33,7 @@ class SqlsrvDriverTest extends AbstractDatabaseDriverTestCase
 
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'sqlsrv') {
+        if (!static::$connection) {
             self::markTestSkipped('SQL Server database not configured.');
         }
     }

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Sqlsrv\SqlsrvStatement;
 use Joomla\Test\DatabaseTestCase;
+use Joomla\Test\TestHelper;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
@@ -85,17 +86,11 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
             $rawQuery
         );
 
-        $refObject = new \ReflectionObject($sqlsrvStatement);
-        $refMapping = $refObject->getProperty('parameterKeyMapping');
-        /** @noinspection PhpExpressionResultUnusedInspection */
-        $refMapping->setAccessible(true);
-        $parameterKeyMapping = $refMapping->getValue($sqlsrvStatement);
-
         $this->assertEquals(
             [
                 ':search' => [0, 1],
             ],
-            $parameterKeyMapping
+            TestHelper::getValue($sqlsrvStatement, 'parameterKeyMapping')
         );
     }
 
@@ -113,18 +108,12 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
             $rawQuery
         );
 
-        $refObject = new \ReflectionObject($sqlsrvStatement);
-        $refMapping = $refObject->getProperty('parameterKeyMapping');
-        /** @noinspection PhpExpressionResultUnusedInspection */
-        $refMapping->setAccessible(true);
-        $parameterKeyMapping = $refMapping->getValue($sqlsrvStatement);
-
         $this->assertEquals(
             [
                 ':search' => [0],
                 ':search2' => [1],
             ],
-            $parameterKeyMapping
+            TestHelper::getValue($sqlsrvStatement, 'parameterKeyMapping')
         );
     }
 

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Sqlsrv\SqlsrvStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
@@ -129,9 +130,8 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Make sure the mysqli driver correctly runs queries with named parameters appearing more than once.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithDuplicateKey()
     {
         $dummyValue = 'test';
@@ -149,9 +149,8 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure running queries with named parameters appearing once didn't break.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testPreparedStatementWithSingleKey()
     {
         $dummyValue = 'test';

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -10,10 +10,12 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Sqlsrv\SqlsrvStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Sqlsrv\SqlsrvStatement
  */
+#[RequiresPhpExtension('sqlsrv')]
 class SqlsrvPreparedStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvPreparedStatementTest.php
@@ -28,7 +28,7 @@ class SqlsrvPreparedStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'sqlsrv') {
+        if (!static::$connection) {
             self::markTestSkipped('SQL Server database not configured.');
         }
     }

--- a/Tests/Sqlsrv/SqlsrvQueryTest.php
+++ b/Tests/Sqlsrv/SqlsrvQueryTest.php
@@ -9,7 +9,7 @@ namespace Joomla\Database\Tests\Sqlsrv;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Sqlsrv\SqlsrvQuery;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class SqlsrvQueryTest extends TestCase
     /**
      * Mock database driver
      *
-     * @var  MockObject|DatabaseInterface
+     * @var  Stub|DatabaseInterface
      */
     private $db;
 
@@ -42,7 +42,7 @@ class SqlsrvQueryTest extends TestCase
     {
         parent::setUp();
 
-        $this->db    = $this->createMock(DatabaseInterface::class);
+        $this->db    = $this->createStub(DatabaseInterface::class);
         $this->query = new SqlsrvQuery($this->db);
     }
 
@@ -129,8 +129,7 @@ class SqlsrvQueryTest extends TestCase
     #[DataProvider('dataConcatenate')]
     public function testConcatenate(array $values, ?string $separator, string $expected)
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });
@@ -179,8 +178,7 @@ class SqlsrvQueryTest extends TestCase
      */
     public function testGroupConcat()
     {
-        $this->db->expects($this->any())
-            ->method('quote')
+        $this->db->method('quote')
             ->willReturnCallback(function ($text, $escape = true) {
                 return "'" . $text . "'";
             });

--- a/Tests/Sqlsrv/SqlsrvStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvStatementTest.php
@@ -28,7 +28,7 @@ class SqlsrvStatementTest extends DatabaseTestCase
     {
         parent::setUpBeforeClass();
 
-        if (!static::$connection || static::$connection->getName() !== 'sqlsrv') {
+        if (!static::$connection) {
             self::markTestSkipped('SQL Server database not configured.');
         }
     }

--- a/Tests/Sqlsrv/SqlsrvStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvStatementTest.php
@@ -10,10 +10,12 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Sqlsrv\SqlsrvStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Test class for Joomla\Database\Sqlsrv\SqlsrvStatement
  */
+#[RequiresPhpExtension('sqlsrv')]
 class SqlsrvStatementTest extends DatabaseTestCase
 {
     /**

--- a/Tests/Sqlsrv/SqlsrvStatementTest.php
+++ b/Tests/Sqlsrv/SqlsrvStatementTest.php
@@ -10,6 +10,7 @@ use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\Sqlsrv\SqlsrvStatement;
 use Joomla\Test\DatabaseTestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
@@ -72,9 +73,8 @@ class SqlsrvStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure that named values with matching named params are correctly prepared, this simulates a whereIn condition.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testStatementPreparesManyArrayValues()
     {
         $query = 'SELECT * FROM dbtest WHERE id IN (:preparedArray1,:preparedArray2,:preparedArray3,:preparedArray4,:preparedArray5,:preparedArray6,:preparedArray7,:preparedArray8,:preparedArray9,:preparedArray10)';
@@ -84,9 +84,8 @@ class SqlsrvStatementTest extends DatabaseTestCase
 
     /**
      * Regression test to ensure that named values with matching named params are correctly prepared (part 2), this simulates a general use case.
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testStatementWithKeysMatching()
     {
         $query = 'SELECT * FROM dbtest WHERE id = :id AND title = :id_title';
@@ -95,11 +94,10 @@ class SqlsrvStatementTest extends DatabaseTestCase
     }
 
     /**
-  * Regression test to ensure that named values with matching named params are correctly prepared (part 3).
-  * This simulates a general use case for a search function where we reuse the same prepared statement term.
-  *
-* @doesNotPerformAssertions
-  */
+     * Regression test to ensure that named values with matching named params are correctly prepared (part 3).
+     * This simulates a general use case for a search function where we reuse the same prepared statement term.
+     */
+    #[DoesNotPerformAssertions]
     public function testStatementWithMultipleUseOfVars()
     {
         $query = 'SELECT * FROM dbtest WHERE description LIKE :search_term AND title LIKE :search_term';


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

- add `RequiresPhpExtension` attribute to get better message if php extension is missing
- use Stub instead of Mock with no configured expectations or call any()
  > If you create a mock object but do not configure any expectations on it, PHPUnit will emit a notice.

  > The any() matcher, used as $this->expects($this->any()), is deprecated. It will be removed in PHPUnit 14.
- replace old php unit doc comments `@doesNotPerformAssertions` to `DoesNotPerformAssertions` attributes
- refactor dataprovider `dataGetTableColumns`
  > All data providers are executed before both the call to a before-class method such as setUpBeforeClass() and the first call to a before-test method such as setUp(). Because of this, you cannot access any properties of the actual test case object within a data provider. [...]
  >
  > The data sets provided by a data provider method should only contain (arrays of) scalar values, immutable value objects, or test stubs. Services or large object graphs should not be created in a data provider method. [...]
- fix some php deprecations in test code

### Testing Instructions

ci/cd

### Documentation Changes Required

no