### PR TITLE
[4.x] set trust_certificate for sqlsrv (unit tests)

### DIFF
--- a/Tests/Sqlsrv/SqlsrvDriverTest.php
+++ b/Tests/Sqlsrv/SqlsrvDriverTest.php
@@ -12,6 +12,7 @@ use Joomla\Database\Exception\UnsupportedAdapterException;
 use Joomla\Database\Sqlsrv\SqlsrvDriver;
 use Joomla\Database\Sqlsrv\SqlsrvQuery;
 use Joomla\Database\Tests\AbstractDatabaseDriverTestCase;
+use Joomla\Test\DatabaseManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -19,6 +20,22 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class SqlsrvDriverTest extends AbstractDatabaseDriverTestCase
 {
+    protected static function createDatabaseManager(): DatabaseManager
+    {
+        $manager = new class () extends DatabaseManager {
+            protected function initialiseParams(): void
+            {
+                parent::initialiseParams();
+
+                if (\is_array($this->params)) {
+                    $this->params['trust_certificate'] = true;
+                }
+            }
+        };
+
+        return $manager;
+    }
+
     /**
      * This method is called before the first test of this test class is run.
      *


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

no connection possible to sqlsrv server because of self signed certificate

**Question:** Should we add an environment variable as option (in `joomla/test` package)

### Testing Instructions

ci/cd 

### Documentation Changes Required
no